### PR TITLE
chore: adds a "dev" docker deployment on any push to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,19 +77,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           name: Release
 
-  docker:
-    name: Deploy to docker
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
       - name: Upload image to Docker Hub
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: ${{ secrets.DOCKER_REPO }}
-          tags: dev
+          tags: latest,${{ steps.releases.outputs.release }}
 
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,6 @@ jobs:
           files: 'gotrue-${{ steps.releases.outputs.release }}.tar.gz'
           release-tag: ${{ steps.releases.outputs.release }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          name: Release
 
       - name: Upload image to Docker Hub
         uses: docker/build-push-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,4 +75,21 @@ jobs:
           files: 'gotrue-${{ steps.releases.outputs.release }}.tar.gz'
           release-tag: ${{ steps.releases.outputs.release }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          name: Release
+
+  docker:
+    name: Deploy to docker
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Upload image to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ secrets.DOCKER_REPO }}
+          tags: dev
+
           


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a docker deploy. Keeps it "safe" to push upstream - Netlify would just need to input their Docker Hub details into the repository Settings > Secrets.

This always tags the image as "dev", although I could potentially add version numbers if that seems more useful