### PR TITLE
Feature/magic link response

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -79,6 +79,10 @@ func unprocessableEntityError(fmtString string, args ...interface{}) *HTTPError 
 	return httpError(http.StatusUnprocessableEntity, fmtString, args...)
 }
 
+func tooManyRequestsError(fmtString string, args ...interface{}) *HTTPError {
+	return httpError(http.StatusTooManyRequests, fmtString, args...)
+}
+
 // HTTPError is an error with a message and an HTTP status code.
 type HTTPError struct {
 	Code            int    `json:"code"`

--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -73,6 +74,9 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		return a.sendMagicLink(tx, user, mailer, config.SMTP.MaxFrequency, referrer)
 	})
 	if err != nil {
+		if errors.Is(err, MaxFriquencyLimitError) {
+			return sendJSON(w, http.StatusTooManyRequests, make(map[string]string))
+		}
 		return internalServerError("Error sending magic link").WithInternalError(err)
 	}
 

--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -49,17 +49,23 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 			r.Body = ioutil.NopCloser(strings.NewReader(newBodyContent))
 			r.ContentLength = int64(len(newBodyContent))
 
+			fakeResponse := &responseStub{}
 			if config.Mailer.Autoconfirm {
 				// signups are autoconfirmed, send magic link after signup
-				a.Signup(w, r)
+				if err := a.Signup(fakeResponse, r); err != nil {
+					return err
+				}
 				newBodyContent := `{"email":"` + params.Email + `"}`
 				r.Body = ioutil.NopCloser(strings.NewReader(newBodyContent))
 				r.ContentLength = int64(len(newBodyContent))
-				return a.MagicLink(w, r)
+				return a.MagicLink(fakeResponse, r)
 			}
 			// otherwise confirmation email already contains 'magic link'
-			return a.Signup(w, r)
+			if err := a.Signup(fakeResponse, r); err != nil {
+				return err
+			}
 
+			return sendJSON(w, http.StatusOK, make(map[string]string))
 		}
 		return internalServerError("Database error finding user").WithInternalError(err)
 	}
@@ -75,11 +81,26 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	})
 	if err != nil {
 		if errors.Is(err, MaxFriquencyLimitError) {
-			return sendJSON(w, http.StatusTooManyRequests, make(map[string]string))
+			return tooManyRequestsError("Too many requests accepted. Try again later")
 		}
 		return internalServerError("Error sending magic link").WithInternalError(err)
 	}
 
-	w.WriteHeader(http.StatusOK)
-	return nil
+	return sendJSON(w, http.StatusOK, make(map[string]string))
+}
+
+// responseStub only implement http responsewriter for ignoring
+// incoming data from methods where it passed
+type responseStub struct {
+}
+
+func (rw *responseStub) Header() http.Header {
+	return http.Header{}
+}
+
+func (rw *responseStub) Write(data []byte) (int, error) {
+	return 1, nil
+}
+
+func (rw *responseStub) WriteHeader(statusCode int) {
 }

--- a/api/mail.go
+++ b/api/mail.go
@@ -11,6 +11,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	MaxFriquencyLimitError error = errors.New("Frequency limit reached")
+)
+
 func sendConfirmation(tx *storage.Connection, u *models.User, mailer mailer.Mailer, maxFrequency time.Duration, referrerURL string) error {
 	if u.ConfirmationSentAt != nil && !u.ConfirmationSentAt.Add(maxFrequency).Before(time.Now()) {
 		return nil
@@ -59,7 +63,7 @@ func (a *API) sendMagicLink(tx *storage.Connection, u *models.User, mailer maile
 	// since Magic Link is just a recovery with a different template and behaviour
 	// around new users we will reuse the recovery db timer to prevent potential abuse
 	if u.RecoverySentAt != nil && !u.RecoverySentAt.Add(maxFrequency).Before(time.Now()) {
-		return nil
+		return MaxFriquencyLimitError
 	}
 
 	oldToken := u.RecoveryToken

--- a/models/user.go
+++ b/models/user.go
@@ -100,10 +100,6 @@ func (u *User) BeforeUpdate(tx *pop.Connection) error {
 		return errors.New("Cannot persist system user")
 	}
 
-	if u.LastSignInAt == nil || u.LastSignInAt.IsZero() {
-		return errors.New("Cannot update last_sign_in_at field with empty value")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Add response stub struct for ignoring written response from signup method according to issue #24 
In cases when error returned from signup - response will be same as direct call signup.
In case when signup successfully finish - response will be {} and 200 http status.
In case when MaxFrequency returned by sendMagicLink - return json {code: 429, msg: "Too many requests accepted. Try again later"}

P.S.
In [this](https://github.com/supabase/gotrue/pull/27/commits/bd49fba9d8cc2bf13ef7b6d255d2a06cba08824c) PR I implemented logic for updating last_sign_in field and introduced another bug that prevents creating new users.
Fix for that [here](https://github.com/supabase/gotrue/commit/56ffadc92d37d21a70808fdd9a34e46c1eb41e3b)