### PR TITLE
fixed case when Autoconfirm flag setted and magic link response ignored

### DIFF
--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -58,7 +58,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 				newBodyContent := `{"email":"` + params.Email + `"}`
 				r.Body = ioutil.NopCloser(strings.NewReader(newBodyContent))
 				r.ContentLength = int64(len(newBodyContent))
-				return a.MagicLink(fakeResponse, r)
+				return a.MagicLink(w, r)
 			}
 			// otherwise confirmation email already contains 'magic link'
 			if err := a.Signup(fakeResponse, r); err != nil {


### PR DESCRIPTION
[PR](https://github.com/supabase/gotrue/pull/33) was released too fast.
In situations when Autoconfirm flag setted to true then output of magic link call just ignored. 
This is bug fix