### PR TITLE
Feat: added type magiclink to verify links

### DIFF
--- a/api/verify.go
+++ b/api/verify.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	signupVerification   = "signup"
-	recoveryVerification = "recovery"
-	inviteVerification   = "invite"
+	signupVerification    = "signup"
+	recoveryVerification  = "recovery"
+	inviteVerification    = "invite"
+	magicLinkVerification = "magiclink"
 )
 
 // VerifyParams are the parameters the Verify endpoint accepts
@@ -66,7 +67,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 			user, terr = a.signupVerify(ctx, tx, params)
 		case inviteVerification:
 			user, terr = a.signupVerify(ctx, tx, params)
-		case recoveryVerification:
+		case recoveryVerification, magicLinkVerification:
 			user, terr = a.recoverVerify(ctx, tx, params)
 		default:
 			return unprocessableEntityError("Verify requires a verification type")

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -150,7 +150,7 @@ func (m *TemplateMailer) RecoveryMail(user *models.User, referrerURL string) err
 func (m *TemplateMailer) MagicLinkMail(user *models.User, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=recovery")
+	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=magiclink")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Changed type of magic link from type=recover to type=magiclink according to issue #35  
I implemented that logic without changing db schema, but this change can potentually introduce buggy situation. 
When recovery called, db generate token and save it to recovery_token field and user get email with recovery link. After that someone call magiclink and new recovery_token rewrite old one and it delivered to user. After that user click to first recover link and got error. This situation can be reverted too.
@awalias Can we ignore that? or better add new fields to saving magiclink_token and sent time and fix it?