### PR TITLE
Feat: added logic for enabling/disabling users by admin

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -249,8 +249,8 @@ func (a *API) adminUserDelete(w http.ResponseWriter, r *http.Request) error {
 	return sendJSON(w, http.StatusOK, map[string]interface{}{})
 }
 
-// adminChangeUserActivity can enable/disable user
-func (a *API) adminChangeUserActivity(isEnabled bool) func(w http.ResponseWriter, r *http.Request) error {
+// adminSetUserStatus can enable/disable user
+func (a *API) adminSetUserStatus(isEnabled bool) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		ctx := r.Context()
 

--- a/api/api.go
+++ b/api/api.go
@@ -153,8 +153,8 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 					r.Get("/", api.adminUserGet)
 					r.Put("/", api.adminUserUpdate)
-					r.Patch("/enable", api.adminChangeUserActivity(true))
-					r.Patch("/disable", api.adminChangeUserActivity(false))
+					r.Patch("/enable", api.adminSetUserStatus(true))
+					r.Patch("/disable", api.adminSetUserStatus(false))
 					r.Delete("/", api.adminUserDelete)
 				})
 			})

--- a/api/api.go
+++ b/api/api.go
@@ -153,6 +153,8 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 					r.Get("/", api.adminUserGet)
 					r.Put("/", api.adminUserUpdate)
+					r.Patch("/enable", api.adminChangeUserActivity(true))
+					r.Patch("/disable", api.adminChangeUserActivity(false))
 					r.Delete("/", api.adminUserDelete)
 				})
 			})

--- a/api/errors.go
+++ b/api/errors.go
@@ -87,6 +87,10 @@ func tooManyRequestsError(fmtString string, args ...interface{}) *HTTPError {
 	return httpError(http.StatusTooManyRequests, fmtString, args...)
 }
 
+func blockedUserError(fmtString string, args ...interface{}) *HTTPError {
+	return httpError(http.StatusForbidden, fmtString, args...)
+}
+
 // HTTPError is an error with a message and an HTTP status code.
 type HTTPError struct {
 	Code            int    `json:"code"`

--- a/api/router.go
+++ b/api/router.go
@@ -30,6 +30,9 @@ func (r *router) Post(pattern string, fn apiHandler) {
 func (r *router) Put(pattern string, fn apiHandler) {
 	r.chi.Put(pattern, handler(fn))
 }
+func (r *router) Patch(pattern string, fn apiHandler) {
+	r.chi.Patch(pattern, handler(fn))
+}
 func (r *router) Delete(pattern string, fn apiHandler) {
 	r.chi.Delete(pattern, handler(fn))
 }

--- a/api/token.go
+++ b/api/token.go
@@ -91,6 +91,10 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		return oauthError("invalid_grant", "Invalid Password")
 	}
 
+	if user.IsBlocked() {
+		return blockedUserError("This user has been disabled by the admin")
+	}
+
 	var token *AccessTokenResponse
 	err = a.db.Transaction(func(tx *storage.Connection) error {
 		var terr error
@@ -150,6 +154,10 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 	if token.Revoked {
 		a.clearCookieToken(ctx, w)
 		return oauthError("invalid_grant", "Invalid Refresh Token").WithInternalMessage("Possible abuse attempt: %v", r)
+	}
+
+	if user.IsBlocked() {
+		return blockedUserError("This user has been disabled by the admin")
 	}
 
 	var tokenString string

--- a/migrations/20201128062553_create_add_is_disabled.down.sql
+++ b/migrations/20201128062553_create_add_is_disabled.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `{{ index .Options "Namespace" }}users` DROP `is_disabled`;

--- a/migrations/20201128062553_create_add_is_disabled.up.sql
+++ b/migrations/20201128062553_create_add_is_disabled.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `{{ index .Options "Namespace" }}users` ADD `is_disabled` tinyint(1) NULL DEFAULT NULL AFTER `invited_at`;

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -113,6 +113,7 @@ CREATE TABLE `users` (
   `is_super_admin` tinyint(1) DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
+  `is_disabled` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `users_instance_id_idx` (`instance_id`),
   KEY `users_instance_id_email_idx` (`instance_id`,`email`)

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -22,6 +22,8 @@ const (
 	UserInvitedAction           AuditAction = "user_invited"
 	UserDeletedAction           AuditAction = "user_deleted"
 	UserModifiedAction          AuditAction = "user_modified"
+	UserEnabledAction           AuditAction = "user_enabled"
+	UserDisabledAction          AuditAction = "user_disabled"
 	UserRecoveryRequestedAction AuditAction = "user_recovery_requested"
 	TokenRevokedAction          AuditAction = "token_revoked"
 	TokenRefreshedAction        AuditAction = "token_refreshed"

--- a/models/user.go
+++ b/models/user.go
@@ -28,6 +28,7 @@ type User struct {
 	EncryptedPassword string     `json:"-" db:"encrypted_password"`
 	ConfirmedAt       *time.Time `json:"confirmed_at,omitempty" db:"confirmed_at"`
 	InvitedAt         *time.Time `json:"invited_at,omitempty" db:"invited_at"`
+	IsDisabled        bool       `json:"is_disabled,omitempty" db:"is_disabled"`
 
 	ConfirmationToken  string     `json:"-" db:"confirmation_token"`
 	ConfirmationSentAt *time.Time `json:"confirmation_sent_at,omitempty" db:"confirmation_sent_at"`
@@ -135,6 +136,12 @@ func (u *User) IsConfirmed() bool {
 	return u.ConfirmedAt != nil
 }
 
+// IsBlocked checks if a user has already being
+// blocked by admin.
+func (u *User) IsBlocked() bool {
+	return u.IsDisabled
+}
+
 // SetRole sets the users Role to roleName
 func (u *User) SetRole(tx *storage.Connection, roleName string) error {
 	u.Role = strings.TrimSpace(roleName)
@@ -234,6 +241,18 @@ func (u *User) ConfirmEmailChange(tx *storage.Connection) error {
 func (u *User) Recover(tx *storage.Connection) error {
 	u.RecoveryToken = ""
 	return tx.UpdateOnly(u, "recovery_token")
+}
+
+// Disable user to get token
+func (u *User) Disable(tx *storage.Connection) error {
+	u.IsDisabled = true
+	return tx.UpdateOnly(u, "is_disabled")
+}
+
+// Enable user to get token
+func (u *User) Enable(tx *storage.Connection) error {
+	u.IsDisabled = false
+	return tx.UpdateOnly(u, "is_disabled")
 }
 
 // CountOtherUsers counts how many other users exist besides the one provided


### PR DESCRIPTION
Add feature to enable/disable users by admin according issue #41 
While start implementing the task I realized that it's more correct to separate this functionality from PUT /admin/users method.
While doing task I've changed migrations's schema.sql file and I'm not sure is this correct=) but needed migrations were added