### PR TITLE
Feature/email referer

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -111,6 +111,22 @@ func (a *API) getReferrer(r *http.Request) string {
 	return referrer
 }
 
+// validateRedirectURL ensures any redirect URL is from a safe origin
+func (a *API) validateRedirectURL(r *http.Request, reqref string) string {
+	ctx := r.Context()
+	config := a.getConfig(ctx)
+	redirectURL := config.SiteURL
+	if reqref != "" {
+		base, berr := url.Parse(config.SiteURL)
+		refurl, rerr := url.Parse(reqref)
+		// As long as the referrer came from the site, we will redirect back there
+		if berr == nil && rerr == nil && base.Hostname() == refurl.Hostname() {
+			redirectURL = reqref
+		}
+	}
+	return redirectURL
+}
+
 var privateIPBlocks []*net.IPNet
 
 func init() {

--- a/api/verify.go
+++ b/api/verify.go
@@ -28,9 +28,10 @@ const (
 
 // VerifyParams are the parameters the Verify endpoint accepts
 type VerifyParams struct {
-	Type     string `json:"type"`
-	Token    string `json:"token"`
-	Password string `json:"password"`
+	Type       string `json:"type"`
+	Token      string `json:"token"`
+	Password   string `json:"password"`
+	RedirectTo string `json:"redirect_to"`
 }
 
 // Verify exchanges a confirmation or recovery token to a refresh token
@@ -47,6 +48,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 		params.Token = r.FormValue("token")
 		params.Password = ""
 		params.Type = r.FormValue("type")
+		params.RedirectTo = a.validateRedirectURL(r, r.FormValue("redirect_to"))
 	case "POST":
 		jsonDecoder := json.NewDecoder(r.Body)
 		if err := jsonDecoder.Decode(params); err != nil {
@@ -110,7 +112,10 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	// GET requests should return to the app site after confirmation
 	switch r.Method {
 	case "GET":
-		rurl := config.SiteURL
+		rurl := params.RedirectTo
+		if rurl == "" {
+			rurl = config.SiteURL
+		}
 		if token != nil {
 			q := url.Values{}
 			q.Set("access_token", token.Token)

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -51,12 +51,12 @@ func (m TemplateMailer) ValidateEmail(email string) error {
 func (m *TemplateMailer) InviteMail(user *models.User, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
-	refererParam := ""
+	redirectParam := ""
 	if len(referrerURL) > 0 {
-		refererParam = "&referer=" + referrerURL
+		redirectParam = "&redirect_to=" + referrerURL
 	}
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite"+refererParam)
+	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite"+redirectParam)
 	if err != nil {
 		return err
 	}
@@ -81,12 +81,12 @@ func (m *TemplateMailer) InviteMail(user *models.User, referrerURL string) error
 func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
-	refererParam := ""
+	redirectParam := ""
 	if len(referrerURL) > 0 {
-		refererParam = "&referer=" + referrerURL
+		redirectParam = "&redirect_to=" + referrerURL
 	}
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup"+refererParam)
+	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup"+redirectParam)
 	if err != nil {
 		return err
 	}
@@ -109,12 +109,12 @@ func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string)
 
 // EmailChangeMail sends an email change confirmation mail to a user
 func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) error {
-	refererParam := ""
+	redirectParam := ""
 	if len(referrerURL) > 0 {
-		refererParam = "&referer=" + referrerURL
+		redirectParam = "&redirect_to=" + referrerURL
 	}
 
-	url, err := getSiteURL(referrerURL, m.Config.SiteURL, m.Config.Mailer.URLPaths.EmailChange, "email_change_token="+user.EmailChangeToken+refererParam+"&type=email_change"+refererParam)
+	url, err := getSiteURL(referrerURL, m.Config.SiteURL, m.Config.Mailer.URLPaths.EmailChange, "email_change_token="+user.EmailChangeToken+"&type=email_change"+redirectParam)
 	if err != nil {
 		return err
 	}
@@ -140,12 +140,12 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) 
 func (m *TemplateMailer) RecoveryMail(user *models.User, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
-	refererParam := ""
+	redirectParam := ""
 	if len(referrerURL) > 0 {
-		refererParam = "&referer=" + referrerURL
+		redirectParam = "&redirect_to=" + referrerURL
 	}
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=recovery"+refererParam)
+	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=recovery"+redirectParam)
 	if err != nil {
 		return err
 	}
@@ -170,12 +170,12 @@ func (m *TemplateMailer) RecoveryMail(user *models.User, referrerURL string) err
 func (m *TemplateMailer) MagicLinkMail(user *models.User, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
-	refererParam := ""
+	redirectParam := ""
 	if len(referrerURL) > 0 {
-		refererParam = "&referer=" + referrerURL
+		redirectParam = "&redirect_to=" + referrerURL
 	}
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=magiclink"+refererParam)
+	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=magiclink"+redirectParam)
 	if err != nil {
 		return err
 	}

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -51,7 +51,12 @@ func (m TemplateMailer) ValidateEmail(email string) error {
 func (m *TemplateMailer) InviteMail(user *models.User, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite")
+	refererParam := ""
+	if len(referrerURL) > 0 {
+		refererParam = "&referer=" + referrerURL
+	}
+
+	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite"+refererParam)
 	if err != nil {
 		return err
 	}
@@ -76,7 +81,12 @@ func (m *TemplateMailer) InviteMail(user *models.User, referrerURL string) error
 func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup")
+	refererParam := ""
+	if len(referrerURL) > 0 {
+		refererParam = "&referer=" + referrerURL
+	}
+
+	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup"+refererParam)
 	if err != nil {
 		return err
 	}
@@ -99,7 +109,12 @@ func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string)
 
 // EmailChangeMail sends an email change confirmation mail to a user
 func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) error {
-	url, err := getSiteURL(referrerURL, m.Config.SiteURL, m.Config.Mailer.URLPaths.EmailChange, "email_change_token="+user.EmailChangeToken)
+	refererParam := ""
+	if len(referrerURL) > 0 {
+		refererParam = "&referer=" + referrerURL
+	}
+
+	url, err := getSiteURL(referrerURL, m.Config.SiteURL, m.Config.Mailer.URLPaths.EmailChange, "email_change_token="+user.EmailChangeToken+refererParam+"&type=email_change"+refererParam)
 	if err != nil {
 		return err
 	}
@@ -125,7 +140,12 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) 
 func (m *TemplateMailer) RecoveryMail(user *models.User, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=recovery")
+	refererParam := ""
+	if len(referrerURL) > 0 {
+		refererParam = "&referer=" + referrerURL
+	}
+
+	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=recovery"+refererParam)
 	if err != nil {
 		return err
 	}
@@ -150,7 +170,12 @@ func (m *TemplateMailer) RecoveryMail(user *models.User, referrerURL string) err
 func (m *TemplateMailer) MagicLinkMail(user *models.User, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=magiclink")
+	refererParam := ""
+	if len(referrerURL) > 0 {
+		refererParam = "&referer=" + referrerURL
+	}
+
+	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=magiclink"+refererParam)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes #62 

if a referer header is present on magic link, invite, confirmation, password reset like...

```bash
curl -d '{"email":"ant@supabase.io", "password":"11"}' -H "Content-Type: application/json" -H "Referer: https://twoot88.com/goobar" -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjEzMDk4NTQ0LCJleHAiOjE5Mjg2NzQ1NDR9.4wlgmU8oYqDJLsS8GZCepHVFHKyZIVBOsJ_yjufr-24" -X POST http://localhost:9999/magiclink
```

then the email will come as:
`http://localhost:9999/verify?token=Da7nxFZqMNzT0sJI9XgW4A&type=magiclink&redirect_to=https://twoot88.com/goobar`

when clicked this will verify the token and direct the user to the redirect_to url afterwards (as long as it shares a hostname with `SITE_URL`)