### PR TITLE
Added logic for returning invite token as response field

### DIFF
--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -13,7 +13,7 @@ import (
 // Mailer defines the interface a mailer must implement.
 type Mailer interface {
 	Send(user *models.User, subject, body string, data map[string]interface{}) error
-	InviteMail(user *models.User, referrerURL string) error
+	InviteMail(user *models.User, referrerURL string, notSendMail bool) (string, error)
 	ConfirmationMail(user *models.User, referrerURL string) error
 	RecoveryMail(user *models.User, referrerURL string) error
 	MagicLinkMail(user *models.User, referrerURL string) error

--- a/mailer/noop.go
+++ b/mailer/noop.go
@@ -9,8 +9,8 @@ func (m noopMailer) ValidateEmail(email string) error {
 	return nil
 }
 
-func (m *noopMailer) InviteMail(user *models.User, referrerURL string) error {
-	return nil
+func (m *noopMailer) InviteMail(user *models.User, referrerURL string, notSendMail bool) (string, error) {
+	return "", nil
 }
 
 func (m *noopMailer) ConfirmationMail(user *models.User, referrerURL string) error {


### PR DESCRIPTION
Added logic for returning invite url as part of response according to issue #65
Resulting code is little bit messy, because netlify's original code isn't suit to our logic=)