### PR TITLE
Fix for Issue 504 Signup Confirmation Email Link

### DIFF
--- a/models/errors.go
+++ b/models/errors.go
@@ -5,6 +5,8 @@ func IsNotFoundError(err error) bool {
 	switch err.(type) {
 	case UserNotFoundError:
 		return true
+	case ConfirmationTokenNotFoundError:
+		return true
 	case RefreshTokenNotFoundError:
 		return true
 	case InstanceNotFoundError:
@@ -18,6 +20,13 @@ type UserNotFoundError struct{}
 
 func (e UserNotFoundError) Error() string {
 	return "User not found"
+}
+
+// ConfirmationTokenNotFoundError represents when a confirmation token is not found.
+type ConfirmationTokenNotFoundError struct{}
+
+func (e ConfirmationTokenNotFoundError) Error() string {
+	return "Confirmation Token not found"
 }
 
 // RefreshTokenNotFoundError represents when a refresh token is not found.

--- a/models/user.go
+++ b/models/user.go
@@ -256,7 +256,11 @@ func findUser(tx *storage.Connection, query string, args ...interface{}) (*User,
 
 // FindUserByConfirmationToken finds users with the matching confirmation token.
 func FindUserByConfirmationToken(tx *storage.Connection, token string) (*User, error) {
-	return findUser(tx, "confirmation_token = ?", token)
+	user, err := findUser(tx, "confirmation_token = ?", token)
+	if err != nil {
+		return nil, ConfirmationTokenNotFoundError{}
+	}
+	return user, nil
 }
 
 // FindUserByEmailAndAudience finds a user with the matching email and audience.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for Issue 504 where the Signup Confirmation Token is not found.

## What is the current behavior?

When a Signup email confirmation has already been confirmed, the subsequent click on that link returns a 404 error stating user not found.

## Additional context
Golang is not my primary language (and I am still learning a lot) so I would appreciate if feedback could be provided in case this fix I introduced is incorrect or can be improved further.
