### PR TITLE
Fix for Signup Confirmation Email Link Issue

### DIFF
--- a/api/verify.go
+++ b/api/verify.go
@@ -140,7 +140,7 @@ func (a *API) signupVerify(ctx context.Context, conn *storage.Connection, params
 	user, err := models.FindUserByConfirmationToken(conn, params.Token)
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			return nil, notFoundError(err.Error())
+			return nil, notFoundError(err.Error()).WithInternalError(redirectWithQueryError)
 		}
 		return nil, internalServerError("Database error finding user").WithInternalError(err)
 	}

--- a/models/errors.go
+++ b/models/errors.go
@@ -5,6 +5,8 @@ func IsNotFoundError(err error) bool {
 	switch err.(type) {
 	case UserNotFoundError:
 		return true
+	case ConfirmationTokenNotFoundError:
+		return true
 	case RefreshTokenNotFoundError:
 		return true
 	case InstanceNotFoundError:
@@ -18,6 +20,13 @@ type UserNotFoundError struct{}
 
 func (e UserNotFoundError) Error() string {
 	return "User not found"
+}
+
+// ConfirmationTokenNotFoundError represents when a confirmation token is not found.
+type ConfirmationTokenNotFoundError struct{}
+
+func (e ConfirmationTokenNotFoundError) Error() string {
+	return "Confirmation Token not found"
 }
 
 // RefreshTokenNotFoundError represents when a refresh token is not found.

--- a/models/user.go
+++ b/models/user.go
@@ -256,7 +256,11 @@ func findUser(tx *storage.Connection, query string, args ...interface{}) (*User,
 
 // FindUserByConfirmationToken finds users with the matching confirmation token.
 func FindUserByConfirmationToken(tx *storage.Connection, token string) (*User, error) {
-	return findUser(tx, "confirmation_token = ?", token)
+	user, err := findUser(tx, "confirmation_token = ?", token)
+	if err != nil {
+		return nil, ConfirmationTokenNotFoundError{}
+	}
+	return user, nil
 }
 
 // FindUserByEmailAndAudience finds a user with the matching email and audience.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for [Signup Confirmation Email link](https://github.com/supabase/supabase/issues/504) on second and subsequent clicks.

## What is the current behavior?

Subsequent clicks on confirmation link sent when user signs up results in error `User not found`.

## What is the new behavior?

Descriptive error informing user that Confirmation Token was not found. 

## Additional context

User will also be redirected back to the application with the error context in the return url.