### PR TITLE
Bugfix/redirect url construct

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -53,10 +53,7 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 		}
 	}
 
-	redirectURL := a.validateRedirectURL(r, r.URL.Query().Get("redirect_to"))
-	if redirectURL == "" {
-		redirectURL = a.getReferrer(r)
-	}
+	redirectURL := a.getRedirectURLOrReferrer(r, r.URL.Query().Get("redirect_to"))
 	log := getLogEntry(r)
 	log.WithField("provider", providerType).Info("Redirecting to external provider")
 

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -98,14 +98,14 @@ func (a *API) requestAud(ctx context.Context, r *http.Request) string {
 }
 
 // tries extract redirect url from header or from query params
-func getRedirectTo(r *http.Request, fieldName string) (reqref string) {
-	reqref = r.Header.Get(fieldName)
+func getRedirectTo(r *http.Request) (reqref string) {
+	reqref = r.Header.Get("redirect_to")
 	if reqref != "" {
 		return
 	}
 
 	if err := r.ParseForm(); err == nil {
-		reqref = r.Form.Get(fieldName)
+		reqref = r.Form.Get("redirect_to")
 	}
 
 	return
@@ -139,7 +139,7 @@ func (a *API) getReferrer(r *http.Request) string {
 	config := a.getConfig(ctx)
 
 	// try get redirect url from query or post data first
-	reqref := getRedirectTo(r, config.RedirectParamName)
+	reqref := getRedirectTo(r)
 	if isRedirectURLValid(config, reqref) {
 		return reqref
 	}

--- a/api/verify.go
+++ b/api/verify.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/netlify/gotrue/models"
@@ -123,7 +124,12 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 			q.Set("expires_in", strconv.Itoa(token.ExpiresIn))
 			q.Set("refresh_token", token.RefreshToken)
 			q.Set("type", params.Type)
-			rurl += "#" + q.Encode()
+
+			if strings.HasSuffix(rurl, "#") || strings.HasSuffix(rurl, "?") || strings.HasSuffix(rurl, "/") {
+				rurl += q.Encode()
+			} else {
+				rurl += "#" + q.Encode()
+			}
 		}
 		http.Redirect(w, r, rurl, http.StatusSeeOther)
 	case "POST":

--- a/api/verify.go
+++ b/api/verify.go
@@ -49,7 +49,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 		params.Token = r.FormValue("token")
 		params.Password = ""
 		params.Type = r.FormValue("type")
-		params.RedirectTo = a.validateRedirectURL(r, r.FormValue("redirect_to"))
+		params.RedirectTo = a.getRedirectURLOrReferrer(r, r.FormValue("redirect_to"))
 	case "POST":
 		jsonDecoder := json.NewDecoder(r.Body)
 		if err := jsonDecoder.Decode(params); err != nil {
@@ -114,9 +114,6 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	switch r.Method {
 	case "GET":
 		rurl := params.RedirectTo
-		if rurl == "" {
-			rurl = config.SiteURL
-		}
 		if token != nil {
 			q := url.Values{}
 			q.Set("access_token", token.Token)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -111,7 +111,6 @@ type MailerConfiguration struct {
 type Configuration struct {
 	SiteURL           string                `json:"site_url" split_words:"true" required:"true"`
 	URIAllowList      []string              `json:"uri_allow_list" split_words:"true"`
-	RedirectParamName string                `json:"redirect_param_name" default:"redirect_to"`
 	PasswordMinLength int                   `json:"password_min_length" default:"6"`
 	JWT               JWTConfiguration      `json:"jwt"`
 	SMTP              SMTPConfiguration     `json:"smtp"`

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -109,8 +109,9 @@ type MailerConfiguration struct {
 
 // Configuration holds all the per-instance configuration.
 type Configuration struct {
-	SiteURL       string                `json:"site_url" split_words:"true" required:"true"`
-	URIAllowList  []string              `json:"uri_allow_list" split_words:"true"`
+	SiteURL           string                `json:"site_url" split_words:"true" required:"true"`
+	URIAllowList      []string              `json:"uri_allow_list" split_words:"true"`
+	RedirectParamName string                `json:"redirect_param_name" default:"redirect_to"`
 	PasswordMinLength int                   `json:"password_min_length" default:"6"`
 	JWT               JWTConfiguration      `json:"jwt"`
 	SMTP              SMTPConfiguration     `json:"smtp"`


### PR DESCRIPTION
According to issue #90  I've implemented logic about prioritization of redirect parameter into workflow of redirect urls construction.
Now, when function getRefferer() calls - firstly checked redirect_to header/parameter, if it's empty - check referrer header, if it's empty too - return config_site value. I suppose that logic fits customers wishes.
Additionally add new configuration parameter REDIRECT_PARAM_NAME for constomization alias of redirect url into input parameters list (default is redirect_to). 