### PR TITLE
Feature: Add Apple Provider 🍎

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The default group to assign all new users to.
 
 ### External Authentication Providers
 
-We support `azure`, `bitbucket`, `github`, `gitlab`, `facebook`, and `google` for external authentication.
+We support `azure`, `bitbucket`, `github`, `gitlab`, `facebook`, `twitter`, `apple` and `google` for external authentication.
 Use the names as the keys underneath `external` to configure each separately.
 
 ```properties
@@ -198,6 +198,38 @@ The URI a OAuth2 provider will redirect to with the `code` and `state` values.
 `EXTERNAL_X_URL` - `string`
 
 The base URL used for constructing the URLs to request authorization and access tokens. Used by `gitlab` only. Defaults to `https://gitlab.com`.
+
+#### Apple OAuth 
+
+To try out external authentication with Apple locally, you will need to do the following:
+1. Remap localhost to \<my_custom_dns \> in your `/etc/hosts` config.
+2. Configure gotrue to serve HTTPS traffic over localhost by replacing `ListenAndServe` in [api.go](api/api.go) with:
+   ```
+      func (a *API) ListenAndServe(hostAndPort string) {
+        log := logrus.WithField("component", "api")
+        path, err := os.Getwd()
+        if err != nil {
+          log.Println(err)
+        }
+        server := &http.Server{
+          Addr:    hostAndPort,
+          Handler: a.handler,
+        }
+        done := make(chan struct{})
+        defer close(done)
+        go func() {
+          waitForTermination(log, done)
+          ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+          defer cancel()
+          server.Shutdown(ctx)
+        }()
+        if err := server.ListenAndServeTLS("PATH_TO_CRT_FILE", "PATH_TO_KEY_FILE"); err != http.ErrServerClosed {
+          log.WithError(err).Fatal("http server listen failed")
+        }
+    }
+   ```
+3. Generate the crt and key file. See [here](https://www.freecodecamp.org/news/how-to-get-https-working-on-your-local-development-environment-in-5-minutes-7af615770eec/) for more information.
+4. Generate the `GOTRUE_EXTERNAL_APPLE_SECRET` by following this [post](https://medium.com/identity-beyond-borders/how-to-configure-sign-in-with-apple-77c61e336003)!
 
 ### E-Mail
 

--- a/api/api.go
+++ b/api/api.go
@@ -99,6 +99,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			r.Use(api.loadInstanceConfig)
 		}
 		r.Get("/", api.ExternalProviderCallback)
+		r.Post("/", api.ExternalProviderCallback)
 	})
 
 	r.Route("/", func(r *router) {

--- a/api/external.go
+++ b/api/external.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
 )
 
 type ExternalProviderClaims struct {
@@ -79,18 +80,29 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 		return internalServerError("Error creating state").WithInternalError(err)
 	}
 
-	var url string
-	if twitterProvider, ok := p.(*provider.TwitterProvider); ok {
-		url = twitterProvider.AuthCodeURL(tokenString)
-		err := gothic.StoreInSession(providerType, twitterProvider.Marshal(), r, w)
+	var authURL string
+	switch externalProvider := p.(type) {
+	case *provider.TwitterProvider:
+		authURL = externalProvider.AuthCodeURL(tokenString)
+		err := gothic.StoreInSession(providerType, externalProvider.Marshal(), r, w)
 		if err != nil {
 			return internalServerError("Error storing request token in session").WithInternalError(err)
 		}
-	} else {
-		url = p.AuthCodeURL(tokenString)
+	case *provider.AppleProvider:
+		opts := make([]oauth2.AuthCodeOption, 0, 1)
+		opts = append(opts, oauth2.SetAuthURLParam("response_mode", "form_post"))
+		authURL = externalProvider.Config.AuthCodeURL(tokenString, opts...)
+		if authURL != "" {
+			if u, err := url.Parse(authURL); err == nil {
+				u.RawQuery = strings.ReplaceAll(u.RawQuery, "+", "%20")
+				authURL = u.String()
+			}
+		}
+	default:
+		authURL = p.AuthCodeURL(tokenString)
 	}
 
-	http.Redirect(w, r, url, http.StatusFound)
+	http.Redirect(w, r, authURL, http.StatusFound)
 	return nil
 }
 
@@ -326,6 +338,8 @@ func (a *API) Provider(ctx context.Context, name string, scopes string) (provide
 	name = strings.ToLower(name)
 
 	switch name {
+	case "apple":
+		return provider.NewAppleProvider(config.External.Apple)
 	case "bitbucket":
 		return provider.NewBitbucketProvider(config.External.Bitbucket)
 	case "github":

--- a/api/provider/apple.go
+++ b/api/provider/apple.go
@@ -1,0 +1,161 @@
+package provider
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/netlify/gotrue/conf"
+	"golang.org/x/oauth2"
+)
+
+const (
+	authEndpoint  = "https://appleid.apple.com/auth/authorize"
+	tokenEndpoint = "https://appleid.apple.com/auth/token"
+
+	ScopeEmail = "email"
+	ScopeName  = "name"
+
+	appleAudOrIss                  = "https://appleid.apple.com"
+	idTokenVerificationKeyEndpoint = "https://appleid.apple.com/auth/keys"
+)
+
+type AppleProvider struct {
+	*oauth2.Config
+	APIPath    string
+	httpClient *http.Client
+}
+
+type appleName struct {
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+}
+
+type appleUser struct {
+	Name  appleName `json:"name"`
+	Email string    `json:"email"`
+}
+
+type idTokenClaims struct {
+	jwt.StandardClaims
+	AccessTokenHash string `json:"at_hash"`
+	AuthTime        int    `json:"auth_time"`
+	Email           string `json:"email"`
+	IsPrivateEmail  bool   `json:"is_private_email,string"`
+}
+
+func NewAppleProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error) {
+	if err := ext.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &AppleProvider{
+		Config: &oauth2.Config{
+			ClientID:     ext.ClientID,
+			ClientSecret: ext.Secret,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  authEndpoint,
+				TokenURL: tokenEndpoint,
+			},
+			Scopes: []string{
+				ScopeEmail,
+				ScopeName,
+			},
+			RedirectURL: ext.RedirectURI,
+		},
+		APIPath: "",
+	}, nil
+}
+
+func (p AppleProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
+	opts := []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("client_id", p.ClientID),
+		oauth2.SetAuthURLParam("secret", p.ClientSecret),
+	}
+	return p.Exchange(oauth2.NoContext, code, opts...)
+}
+
+func (p AppleProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
+	var user *UserProvidedData
+	if tok.AccessToken == "" {
+		return &UserProvidedData{}, nil
+	}
+	if idToken := tok.Extra("id_token"); idToken != nil {
+		idToken, err := jwt.ParseWithClaims(idToken.(string), &idTokenClaims{}, func(t *jwt.Token) (interface{}, error) {
+			kid := t.Header["kid"].(string)
+			claims := t.Claims.(*idTokenClaims)
+			vErr := new(jwt.ValidationError)
+			if !claims.VerifyAudience(p.ClientID, true) {
+				vErr.Inner = fmt.Errorf("incorrect audience")
+				vErr.Errors |= jwt.ValidationErrorAudience
+			}
+			if !claims.VerifyIssuer(appleAudOrIss, true) {
+				vErr.Inner = fmt.Errorf("incorrect issuer")
+				vErr.Errors |= jwt.ValidationErrorIssuer
+			}
+			if vErr.Errors > 0 {
+				return nil, vErr
+			}
+
+			// per OpenID Connect Core 1.0 §3.2.2.9, Access Token Validation
+			hash := sha256.Sum256([]byte(tok.AccessToken))
+			halfHash := hash[0:(len(hash) / 2)]
+			encodedHalfHash := base64.RawURLEncoding.EncodeToString(halfHash)
+			if encodedHalfHash != claims.AccessTokenHash {
+				vErr.Inner = fmt.Errorf(`invalid identity token`)
+				vErr.Errors |= jwt.ValidationErrorClaimsInvalid
+				return nil, vErr
+			}
+
+			// get the public key for verifying the identity token signature
+			set, err := jwk.FetchHTTP(idTokenVerificationKeyEndpoint, jwk.WithHTTPClient(http.DefaultClient))
+			if err != nil {
+				return nil, err
+			}
+			selectedKey := set.Keys[0]
+			for _, key := range set.Keys {
+				if key.KeyID() == kid {
+					selectedKey = key
+					break
+				}
+			}
+			pubKeyIface, _ := selectedKey.Materialize()
+			pubKey, ok := pubKeyIface.(*rsa.PublicKey)
+			if !ok {
+				return nil, fmt.Errorf(`expected RSA public key from %s`, idTokenVerificationKeyEndpoint)
+			}
+			return pubKey, nil
+		})
+		if err != nil {
+			return &UserProvidedData{}, err
+		}
+		user = &UserProvidedData{
+			Emails: []Email{{
+				Email:    idToken.Claims.(*idTokenClaims).Email,
+				Verified: true,
+				Primary:  true,
+			}},
+		}
+
+	}
+	return user, nil
+}
+
+func (p AppleProvider) ParseUser(data string) map[string]string {
+	userData := &appleUser{}
+	err := json.Unmarshal([]byte(data), userData)
+	if err != nil {
+		return nil
+	}
+	return map[string]string{
+		"firstName": userData.Name.FirstName,
+		"lastName":  userData.Name.LastName,
+		"email":     userData.Email,
+	}
+}

--- a/api/settings.go
+++ b/api/settings.go
@@ -3,6 +3,7 @@ package api
 import "net/http"
 
 type ProviderSettings struct {
+	Apple     bool `json:"apple"`
 	Bitbucket bool `json:"bitbucket"`
 	GitHub    bool `json:"github"`
 	GitLab    bool `json:"gitlab"`
@@ -30,6 +31,7 @@ func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
 
 	return sendJSON(w, http.StatusOK, &Settings{
 		ExternalProviders: ProviderSettings{
+			Apple:     config.External.Apple.Enabled,
 			Bitbucket: config.External.Bitbucket.Enabled,
 			GitHub:    config.External.Github.Enabled,
 			GitLab:    config.External.Gitlab.Enabled,

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -80,6 +80,7 @@ type EmailContentConfiguration struct {
 }
 
 type ProviderConfiguration struct {
+	Apple       OAuthProviderConfiguration `json:"apple"`
 	Bitbucket   OAuthProviderConfiguration `json:"bitbucket"`
 	Github      OAuthProviderConfiguration `json:"github"`
 	Gitlab      OAuthProviderConfiguration `json:"gitlab"`

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.1 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/lestrrat-go/jwx v0.9.0
 	github.com/lib/pq v1.9.0 // indirect
 	github.com/markbates/goth v1.67.1
 	github.com/microcosm-cc/bluemonday v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lestrrat-go/jwx v0.9.0 h1:Fnd0EWzTm0kFrBPzE/PEPp9nzllES5buMkksPMjEKpM=
 github.com/lestrrat-go/jwx v0.9.0/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/YNA/UnBk=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds Apple as an OAuth provider. Addresses #37 

## Additional context
1. Apple makes use of OAuth2.0
2. `GOTRUE_EXTERNAL_APPLE_SECRET` refers to the `CLIENT_SECRET` that Apple requires you to generate. See the steps [here](http://p.agnihotry.com/post/validating_sign_in_with_apple_authorization_code/) and [here](https://medium.com/identity-beyond-borders/how-to-configure-sign-in-with-apple-77c61e336003) for information I personally found useful. 
