### PR TITLE
chore: bump go version to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as build
+FROM golang:1.16-alpine as build
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updates the go image from 1.13 to 1.16 in the Dockerfile. Fixes #100 

## What is the current behavior?
Current version fails to build
