### PR TITLE
fix: case-insensitive user emails - issue #89

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -65,7 +65,7 @@ func NewUser(instanceID uuid.UUID, email, password, aud string, userData map[str
 		InstanceID:        instanceID,
 		ID:                id,
 		Aud:               aud,
-		Email:             email,
+		Email:             strings.ToLower(email),
 		UserMetaData:      userData,
 		EncryptedPassword: pw,
 	}
@@ -265,7 +265,7 @@ func FindUserByConfirmationToken(tx *storage.Connection, token string) (*User, e
 
 // FindUserByEmailAndAudience finds a user with the matching email and audience.
 func FindUserByEmailAndAudience(tx *storage.Connection, instanceID uuid.UUID, email, aud string) (*User, error) {
-	return findUser(tx, "instance_id = ? and email = ? and aud = ?", instanceID, email, aud)
+	return findUser(tx, "instance_id = ? and LOWER(email) = ? and aud = ?", instanceID, strings.ToLower(email), aud)
 }
 
 // FindUserByID finds a user matching the provided ID.


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix, stores user emails in lowercase and performs case-insensitive query of existing email from users table.

## What is the current behavior?
Current behavior stores emails as they are provided by the user (unmodified). This this treats emails with different cases (e.g upper vs lowercase) as different emails / users.

#89

## What is the new behavior?
The new behavior saves all emails in lowercase and calls LOWER SQL function on email field when querying existing users.

## Additional context
Replaces [PR 108](https://github.com/supabase/gotrue/pull/108) correcting db dependant collation feature (Thanks @icecream78 for the catch) and follows [conventional commits guides](https://www.conventionalcommits.org) 