### PR TITLE
Fix: redirectTo allows url which should not be permitted 

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,8 @@ GoTrue exposes the following endpoints:
   ```json
   {
     "type": "signup",
-    "token": "confirmation-code-delivered-in-email"
+    "token": "confirmation-code-delivered-in-email",
+    "redirect_to": "https://supabase.io"
   }
   ```
 
@@ -512,6 +513,7 @@ GoTrue exposes the following endpoints:
   {
     "type": "signup",
     "token": "confirmation-code-delivered-in-email",
+    "redirect_to": "https://supabase.io"
   }
   ```
 

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
-	"strings"
 
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
@@ -126,7 +125,7 @@ func isRedirectURLValid(config *conf.Configuration, redirectURL string) bool {
 
 	// For case when user came from mobile app or other permitted resource - redirect back
 	for _, uri := range config.URIAllowList {
-		if strings.HasPrefix(redirectURL, uri) {
+		if redirectURL == uri {
 			return true
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
redirectTo needs to find an exact match with one of the URLs in the `URI_ALLOW_LIST` 

Addresses #107 