### PR TITLE
Fix: Add sender name to SMTP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ If the mail server requires authentication, the password to use.
 
 Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email. The value is the number of seconds. Defaults to 900 (15 minutes).
 
+`SMTP_SENDER_NAME` - `string`
+
+Sets the name of the sender. Defaults to the `SMTP_ADMIN_EMAIL` if not used.
+
 `MAILER_AUTOCONFIRM` - `bool`
 
 If you do not require email confirmation, you may set this to `true`. Defaults to `false`.

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -101,6 +101,7 @@ type SMTPConfiguration struct {
 	User         string        `json:"user"`
 	Pass         string        `json:"pass,omitempty"`
 	AdminEmail   string        `json:"admin_email" split_words:"true"`
+	SenderName   string        `json:"sender_name" split_words:"true"`
 }
 
 type MailerConfiguration struct {

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/mailme"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/gomail.v2"
 )
 
 // Mailer defines the interface a mailer must implement.
@@ -27,6 +28,12 @@ func NewMailer(instanceConfig *conf.Configuration) Mailer {
 		return &noopMailer{}
 	}
 
+	mail := gomail.NewMessage()
+	from := instanceConfig.SMTP.AdminEmail
+	if instanceConfig.SMTP.SenderName != "" {
+		from = mail.FormatAddress(instanceConfig.SMTP.AdminEmail, instanceConfig.SMTP.SenderName)
+	}
+
 	return &TemplateMailer{
 		SiteURL: instanceConfig.SiteURL,
 		Config:  instanceConfig,
@@ -35,7 +42,7 @@ func NewMailer(instanceConfig *conf.Configuration) Mailer {
 			Port:    instanceConfig.SMTP.Port,
 			User:    instanceConfig.SMTP.User,
 			Pass:    instanceConfig.SMTP.Pass,
-			From:    instanceConfig.SMTP.AdminEmail,
+			From:    from,
 			BaseURL: instanceConfig.SiteURL,
 			Logger:  logrus.New(),
 		},

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -29,10 +29,7 @@ func NewMailer(instanceConfig *conf.Configuration) Mailer {
 	}
 
 	mail := gomail.NewMessage()
-	from := instanceConfig.SMTP.AdminEmail
-	if instanceConfig.SMTP.SenderName != "" {
-		from = mail.FormatAddress(instanceConfig.SMTP.AdminEmail, instanceConfig.SMTP.SenderName)
-	}
+	from := mail.FormatAddress(instanceConfig.SMTP.AdminEmail, instanceConfig.SMTP.SenderName)
 
 	return &TemplateMailer{
 		SiteURL: instanceConfig.SiteURL,


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes #120 

## What is the current behavior?
AdminUser cannot add a custom sender name which results in the emails being blocked by some providers.

## What is the new behavior?
Exposes an env var `SMTP_SENDER_NAME` which allows the user to set a custom sender name. Defaults to the `SMTP_ADMIN_EMAIL` if empty.

*Not ideal, I'm gonna make a PR to the netlify repo that we use and change it [here](https://github.com/netlify/mailme/blob/9b1d3a9cef8bb81cebaebff53ac464c3d15f1a45/mailme.go#L69) but in the meantime, this will work on our end.
