### PR TITLE
Fix: Retrieve Twitter and GitHub usernames via OAuth

### DIFF
--- a/api/provider/github.go
+++ b/api/provider/github.go
@@ -22,6 +22,7 @@ type githubProvider struct {
 }
 
 type githubUser struct {
+	UserName  string `json:"login"`
 	Email     string `json:"email"`
 	Name      string `json:"name"`
 	AvatarURL string `json:"avatar_url"`
@@ -75,6 +76,7 @@ func (g githubProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 
 	data := &UserProvidedData{
 		Metadata: map[string]string{
+			userNameKey:  u.UserName,
 			nameKey:      u.Name,
 			avatarURLKey: u.AvatarURL,
 		},

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	userNameKey  = "user_name"
 	avatarURLKey = "avatar_url"
 	nameKey      = "full_name"
 	aliasKey     = "slug"

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	requestURL      = "https://api.twitter.com/oauth/request_token"
-	authorizeURL    = "https://api.twitter.com/oauth/authorize"
+	authorizeURL    = "https://api.twitter.com/oauth/authenticate"
 	tokenURL        = "https://api.twitter.com/oauth/access_token"
 	endpointProfile = "https://api.twitter.com/1.1/account/verify_credentials.json"
 )

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -32,6 +32,7 @@ type TwitterProvider struct {
 }
 
 type twitterUser struct {
+	UserName  string `json:"screen_name"`
 	Name      string `json:"name"`
 	AvatarURL string `json:"profile_image_url"`
 	Email     string `json:"email"`
@@ -78,6 +79,7 @@ func (t TwitterProvider) FetchUserData(ctx context.Context, tok *oauth.AccessTok
 
 	data := &UserProvidedData{
 		Metadata: map[string]string{
+			userNameKey:  u.UserName,
 			nameKey:      u.Name,
 			avatarURLKey: u.AvatarURL,
 		},

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	requestURL      = "https://api.twitter.com/oauth/request_token"
-	authorizeURL    = "https://api.twitter.com/oauth/authenticate"
+	authenticateURL = "https://api.twitter.com/oauth/authenticate"
 	tokenURL        = "https://api.twitter.com/oauth/access_token"
 	endpointProfile = "https://api.twitter.com/1.1/account/verify_credentials.json"
 )
@@ -109,7 +109,7 @@ func newConsumer(provider *TwitterProvider) *oauth.Consumer {
 		provider.Secret,
 		oauth.ServiceProvider{
 			RequestTokenUrl:   requestURL,
-			AuthorizeTokenUrl: authorizeURL,
+			AuthorizeTokenUrl: authenticateURL,
 			AccessTokenUrl:    tokenURL,
 		})
 	return c


### PR DESCRIPTION
## What kind of change does this PR introduce?

During the OAuth login the usernames from Twitter and GitHub are retrieved and saved as meta_data of the user.

Additionally I've changed the authorization URL of Twitter from `https://api.twitter.com/oauth/authorize` to `https://api.twitter.com/oauth/authenticate` so that the user only has to authorize the application on the first login, instead of at every login.

## What is the current behavior?

Usernames from Twitter and GitHub are not retrieved.

The user has to authorize the Twitter App on every login again.

## What is the new behavior?

Usernames from Twitter and GitHub are retrieved and saved as meta_data.

The user only has to authorize the Twitter App on the first login.

## Additional context

Description for the /authenticate URL from Twitter:
https://developer.twitter.com/en/docs/authentication/api-reference/authenticate
