### PR TITLE
Feat: Generate email action links

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,19 +443,15 @@ GoTrue exposes the following endpoints:
     "Authorization": "Bearer eyJhbGciOiJI...M3A90LCkxxtX9oNP9KZO" // admin role required
   }
 
-  query params:
-  {
-    "type": "signup" or "magiclink" or "recovery" or "invite",
-    "redirect_to": "https://supabase.io"
-  }
-
   body: 
   {
+    "type": "signup" or "magiclink" or "recovery" or "invite",
     "email": "email@example.com",
     "password": "secret", // only if type = signup
     "data": {
       ...
     }, // only if type = signup
+    "redirect_to": "https://supabase.io" // Redirect URL to send the user to after an email action. Defaults to SITE_URL. 
 
   }
   ```

--- a/README.md
+++ b/README.md
@@ -434,6 +434,39 @@ GoTrue exposes the following endpoints:
   }
   ```
 
+### **POST /admin/generate_link**
+  Returns the corresponding email action link based on the type specified.
+
+  ```json
+  headers: 
+  {
+    "Authorization": "Bearer eyJhbGciOiJI...M3A90LCkxxtX9oNP9KZO" // admin role required
+  }
+
+  query params:
+  {
+    "type": "signup" or "magiclink" or "recovery" or "invite",
+    "redirect_to": "https://supabase.io"
+  }
+
+  body: 
+  {
+    "email": "email@example.com",
+    "password": "secret", // only if type = signup
+    "data": {
+      ...
+    }, // only if type = signup
+
+  }
+  ```
+  Returns
+  ```json
+  {
+    "action_link": "http://localhost:9999/verify?token=TOKEN&type=TYPE&redirect_to=REDIRECT_URL",
+    ...
+  }
+  ```
+
 ### **POST /signup**
 
   Register a new user with an email and password.

--- a/api/admin.go
+++ b/api/admin.go
@@ -179,7 +179,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	if exists, err := models.IsDuplicatedEmail(a.db, instanceID, params.Email, aud); err != nil {
 		return internalServerError("Database error checking email").WithInternalError(err)
 	} else if exists {
-		return unprocessableEntityError("Email address already registered by another user")
+		return unprocessableEntityError(DuplicateEmailMsg)
 	}
 
 	user, err := models.NewUser(instanceID, params.Email, params.Password, aud, params.UserMetaData)

--- a/api/api.go
+++ b/api/api.go
@@ -158,6 +158,8 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 					r.Delete("/", api.adminUserDelete)
 				})
 			})
+
+			r.Post("/generate_link", api.GenerateLink)
 		})
 
 		r.Route("/saml", func(r *router) {

--- a/api/errors.go
+++ b/api/errors.go
@@ -8,6 +8,11 @@ import (
 	"runtime/debug"
 )
 
+// Common error messages during signup flow
+var (
+	DuplicateEmailMsg = "A user with this email address has already been registered"
+)
+
 var oauthErrorMap = map[int]string{
 	http.StatusBadRequest:          "invalid_request",
 	http.StatusUnauthorized:        "unauthorized_client",

--- a/api/invite.go
+++ b/api/invite.go
@@ -37,7 +37,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 		return internalServerError("Database error finding user").WithInternalError(err)
 	}
 	if user != nil {
-		return unprocessableEntityError("Email address already registered by another user")
+		return unprocessableEntityError(DuplicateEmailMsg)
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {

--- a/api/invite.go
+++ b/api/invite.go
@@ -36,20 +36,23 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	if err != nil && !models.IsNotFoundError(err) {
 		return internalServerError("Database error finding user").WithInternalError(err)
 	}
-	if user != nil {
-		return unprocessableEntityError(DuplicateEmailMsg)
-	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		signupParams := SignupParams{
-			Email:    params.Email,
-			Data:     params.Data,
-			Aud:      aud,
-			Provider: "email",
-		}
-		user, err = a.signupNewUser(ctx, tx, &signupParams)
-		if err != nil {
-			return err
+		if user != nil {
+			if user.IsConfirmed() {
+				return unprocessableEntityError(DuplicateEmailMsg)
+			}
+		} else {
+			signupParams := SignupParams{
+				Email:    params.Email,
+				Data:     params.Data,
+				Aud:      aud,
+				Provider: "email",
+			}
+			user, err = a.signupNewUser(ctx, tx, &signupParams)
+			if err != nil {
+				return err
+			}
 		}
 
 		if terr := models.NewAuditLogEntry(tx, instanceID, adminUser, models.UserInvitedAction, map[string]interface{}{

--- a/api/mail.go
+++ b/api/mail.go
@@ -21,10 +21,11 @@ var (
 )
 
 type GenerateLinkParams struct {
-	Type     string                 `json:"type"`
-	Email    string                 `json:"email"`
-	Password string                 `json:"password"`
-	Data     map[string]interface{} `json:"data"`
+	Type       string                 `json:"type"`
+	Email      string                 `json:"email"`
+	Password   string                 `json:"password"`
+	Data       map[string]interface{} `json:"data"`
+	RedirectTo string                 `json:"redirect_to"`
 }
 
 func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
@@ -40,7 +41,6 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 	if err := jsonDecoder.Decode(params); err != nil {
 		return badRequestError("Could not read body: %v", err)
 	}
-	params.Type = r.FormValue("type")
 
 	if err := a.validateEmail(ctx, params.Email); err != nil {
 		return err
@@ -65,7 +65,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var url string
-	referrer := a.getRedirectURLOrReferrer(r, r.URL.Query().Get("redirect_to"))
+	referrer := a.getRedirectURLOrReferrer(r, params.RedirectTo)
 	now := time.Now()
 	err = a.db.Transaction(func(tx *storage.Connection) error {
 		var terr error

--- a/api/mail.go
+++ b/api/mail.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/netlify/gotrue/crypto"
@@ -9,11 +12,156 @@ import (
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/sethvargo/go-password/password"
 )
 
 var (
 	MaxFrequencyLimitError error = errors.New("Frequency limit reached")
+	configFile                   = ""
 )
+
+type GenerateLinkParams struct {
+	Type     string                 `json:"type"`
+	Email    string                 `json:"email"`
+	Password string                 `json:"password"`
+	Data     map[string]interface{} `json:"data"`
+}
+
+func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	config := a.getConfig(ctx)
+	mailer := a.Mailer(ctx)
+	instanceID := getInstanceID(ctx)
+	adminUser := getAdminUser(ctx)
+
+	params := &GenerateLinkParams{}
+	jsonDecoder := json.NewDecoder(r.Body)
+
+	if err := jsonDecoder.Decode(params); err != nil {
+		return badRequestError("Could not read body: %v", err)
+	}
+	params.Type = r.FormValue("type")
+
+	if err := a.validateEmail(ctx, params.Email); err != nil {
+		return err
+	}
+
+	aud := a.requestAud(ctx, r)
+	user, err := models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
+	if err != nil {
+		if models.IsNotFoundError(err) {
+			if params.Type == "magiclink" {
+				params.Type = "signup"
+				params.Password, err = password.Generate(64, 10, 0, false, true)
+				if err != nil {
+					return internalServerError("error creating user").WithInternalError(err)
+				}
+			} else if params.Type == "recovery" {
+				return notFoundError(err.Error())
+			}
+		} else {
+			return internalServerError("Database error finding user").WithInternalError(err)
+		}
+	}
+
+	var url string
+	referrer := a.getRedirectURLOrReferrer(r, r.URL.Query().Get("redirect_to"))
+	now := time.Now()
+	err = a.db.Transaction(func(tx *storage.Connection) error {
+		var terr error
+		switch params.Type {
+		case "magiclink", "recovery":
+			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserRecoveryRequestedAction, nil); terr != nil {
+				return terr
+			}
+			user.RecoveryToken = crypto.SecureToken()
+			user.RecoverySentAt = &now
+			terr = errors.Wrap(tx.UpdateOnly(user, "recovery_token", "recovery_sent_at"), "Database error updating user for recovery")
+		case "invite":
+			if user != nil {
+				return unprocessableEntityError("Email address already registered by another user")
+			}
+			signupParams := &SignupParams{
+				Email:    params.Email,
+				Data:     params.Data,
+				Provider: "email",
+				Aud:      aud,
+			}
+			user, terr = a.signupNewUser(ctx, tx, signupParams)
+			if terr != nil {
+				return terr
+			}
+			if terr = models.NewAuditLogEntry(tx, instanceID, adminUser, models.UserInvitedAction, map[string]interface{}{
+				"user_id":    user.ID,
+				"user_email": user.Email,
+			}); terr != nil {
+				return terr
+			}
+			user.ConfirmationToken = crypto.SecureToken()
+			user.ConfirmationSentAt = &now
+			user.InvitedAt = &now
+			terr = errors.Wrap(tx.UpdateOnly(user, "confirmation_token", "confirmation_sent_at", "invited_at"), "Database error updating user for invite")
+		case "signup":
+			if user != nil {
+				if user.IsConfirmed() {
+					return badRequestError("A user with this email address has already been registered")
+				}
+				if err := user.UpdateUserMetaData(tx, params.Data); err != nil {
+					return internalServerError("Database error updating user").WithInternalError(err)
+				}
+			} else {
+				if params.Password == "" {
+					return unprocessableEntityError("Signup requires a valid password")
+				}
+				if len(params.Password) < config.PasswordMinLength {
+					return unprocessableEntityError(fmt.Sprintf("Password should be at least %d characters", config.PasswordMinLength))
+				}
+				signupParams := &SignupParams{
+					Email:    params.Email,
+					Password: params.Password,
+					Data:     params.Data,
+					Provider: "email",
+					Aud:      aud,
+				}
+				user, terr = a.signupNewUser(ctx, tx, signupParams)
+				if terr != nil {
+					return terr
+				}
+			}
+			user.ConfirmationToken = crypto.SecureToken()
+			user.ConfirmationSentAt = &now
+			terr = errors.Wrap(tx.UpdateOnly(user, "confirmation_token", "confirmation_sent_at"), "Database error updating user for confirmation")
+		default:
+			return badRequestError("Invalid email action link type requested: %v", params.Type)
+		}
+
+		if terr != nil {
+			return terr
+		}
+
+		url, terr = mailer.GetEmailActionLink(user, params.Type, referrer)
+		if terr != nil {
+			return terr
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	resp := make(map[string]interface{})
+	u, err := json.Marshal(user)
+	if err != nil {
+		return internalServerError("User serialization error").WithInternalError(err)
+	}
+	if err = json.Unmarshal(u, &resp); err != nil {
+		return internalServerError("User serialization error").WithInternalError(err)
+	}
+	resp["action_link"] = url
+
+	return sendJSON(w, http.StatusOK, resp)
+}
 
 func sendConfirmation(tx *storage.Connection, u *models.User, mailer mailer.Mailer, maxFrequency time.Duration, referrerURL string) error {
 	if u.ConfirmationSentAt != nil && !u.ConfirmationSentAt.Add(maxFrequency).Before(time.Now()) {

--- a/api/mail.go
+++ b/api/mail.go
@@ -79,7 +79,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 			terr = errors.Wrap(tx.UpdateOnly(user, "recovery_token", "recovery_sent_at"), "Database error updating user for recovery")
 		case "invite":
 			if user != nil {
-				return unprocessableEntityError("Email address already registered by another user")
+				return unprocessableEntityError(DuplicateEmailMsg)
 			}
 			signupParams := &SignupParams{
 				Email:    params.Email,
@@ -104,7 +104,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 		case "signup":
 			if user != nil {
 				if user.IsConfirmed() {
-					return badRequestError("A user with this email address has already been registered")
+					return unprocessableEntityError(DuplicateEmailMsg)
 				}
 				if err := user.UpdateUserMetaData(tx, params.Data); err != nil {
 					return internalServerError("Database error updating user").WithInternalError(err)

--- a/api/signup.go
+++ b/api/signup.go
@@ -61,7 +61,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		var terr error
 		if user != nil {
 			if user.IsConfirmed() {
-				return badRequestError("A user with this email address has already been registered")
+				return unprocessableEntityError(DuplicateEmailMsg)
 			}
 
 			if err := user.UpdateUserMetaData(tx, params.Data); err != nil {

--- a/api/user.go
+++ b/api/user.go
@@ -125,7 +125,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			if exists, terr = models.IsDuplicatedEmail(tx, instanceID, params.Email, user.Aud); terr != nil {
 				return internalServerError("Database error checking email").WithInternalError(terr)
 			} else if exists {
-				return unprocessableEntityError("Email address already registered by another user")
+				return unprocessableEntityError(DuplicateEmailMsg)
 			}
 
 			mailer := a.Mailer(ctx)

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -20,6 +20,7 @@ type Mailer interface {
 	MagicLinkMail(user *models.User, referrerURL string) error
 	EmailChangeMail(user *models.User, referrerURL string) error
 	ValidateEmail(email string) error
+	GetEmailActionLink(user *models.User, actionType, referrerURL string) (string, error)
 }
 
 // NewMailer returns a new gotrue mailer

--- a/mailer/noop.go
+++ b/mailer/noop.go
@@ -32,3 +32,7 @@ func (m *noopMailer) EmailChangeMail(user *models.User, referrerURL string) erro
 func (m noopMailer) Send(user *models.User, subject, body string, data map[string]interface{}) error {
 	return nil
 }
+
+func (m noopMailer) GetEmailActionLink(user *models.User, actionType, referrerURL string) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Allows an admin user to generate email action links (`signup`, `magiclink`, `recovery`, `invite`).


## What is the current behavior?
Admin user cannot make use of their own custom email service (e.g. Sendgrid) or email templates to serve their customers. 
#109 

## What is the new behavior?
Adds a new admin endpoint: `POST /admin/generate_link?type=TYPE&redirect_to=REDIRECT_URL` 
Allows an admin user to generate the corresponding email action link to send in their custom email templates.

## Additional context
Requires admin credentials because the email action links contain the verification token used to sign a user in.

Sign up a new user via magiclink
Request: 
```
POST /admin/generate_link?type=magiclink&redirect_to=REDIRECT_URL
```

Response:
```
{
    "action_link": "http://localhost:9999/verify?token=TOKEN&type=signup&redirect_to=REDIRECT_URL",
    "app_metadata": {
        "provider": "email"
    },
    "aud": "authenticated",
    "confirmation_sent_at": "2021-07-07T18:40:29.314439+08:00",
    "created_at": "2021-07-07T18:40:31.144371+08:00",
    "email": "newuser@mail.com",
    "id": "user_id",
    "role": "authenticated",
    "updated_at": "2021-07-07T18:40:32.356308+08:00",
    "user_metadata": null
}
```

