### PR TITLE
fix: add discord id to user_metadata

### DIFF
--- a/api/provider/discord.go
+++ b/api/provider/discord.go
@@ -88,8 +88,9 @@ func (g discordProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*U
 
 	return &UserProvidedData{
 		Metadata: map[string]string{
-			nameKey:      u.Name,
-			avatarURLKey: avatarURL,
+			avatarURLKey:  avatarURL,
+			nameKey:       u.Name,
+			providerIdKey: u.Id,
 		},
 		Emails: []Email{{
 			Email:    u.Email,

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	userNameKey  = "user_name"
-	avatarURLKey = "avatar_url"
-	nameKey      = "full_name"
-	aliasKey     = "slug"
+	userNameKey   = "user_name"
+	avatarURLKey  = "avatar_url"
+	nameKey       = "full_name"
+	aliasKey      = "slug"
+	providerIdKey = "provider_id"
 )
 
 type Email struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Addresses #130 

Returns `discord_id` in user_metadata as `provider_id`
