### PR TITLE
chore: fix incorrect struct tag

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -137,7 +137,7 @@ func httpError(code int, fmtString string, args ...interface{}) *HTTPError {
 
 type OTPError struct {
 	Err             string `json:"error"`
-	Description     string `json:"error_description,omitempty`
+	Description     string `json:"error_description,omitempty"`
 	InternalError   error  `json:"-"`
 	InternalMessage string `json:"-"`
 }


### PR DESCRIPTION
Missing " in struct tag causing lint to throw an error during github deploy action.
