### PR TITLE
Chore: Add /migrations to deploy workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,9 @@ jobs:
           repo: gotrue
           excludes: prerelease, draft
 
-      - run: tar -czvf gotrue-${{ steps.releases.outputs.release }}-x86.tar.gz gotrue
+      - run: tar -czvf gotrue-${{ steps.releases.outputs.release }}-x86.tar.gz gotrue migrations/
       - run: mv gotrue-arm64 gotrue
-      - run: tar -czvf gotrue-${{ steps.releases.outputs.release }}-arm64.tar.gz gotrue
+      - run: tar -czvf gotrue-${{ steps.releases.outputs.release }}-arm64.tar.gz gotrue migrations/
 
       - uses: AButler/upload-release-assets@v2.0
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds `/migrations` to zip file for both arm64 and x86 
