### PR TITLE
#149 urlencode the redirect_to parameter in the confirmations urls.

### DIFF
--- a/mailer/template.go
+++ b/mailer/template.go
@@ -2,6 +2,7 @@ package mailer
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/badoux/checkmail"
 	"github.com/netlify/gotrue/conf"
@@ -55,7 +56,7 @@ func (m *TemplateMailer) InviteMail(user *models.User, referrerURL string) error
 
 	redirectParam := ""
 	if len(referrerURL) > 0 {
-		redirectParam = "&redirect_to=" + referrerURL
+		redirectParam = "&redirect_to=" + url.QueryEscape(referrerURL)
 	}
 
 	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite"+redirectParam)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #149 

## What is the current behavior?

1. With SITE_URL = http://localhost:5000/#/
2. Send an invite email.
3. Click on the link in the invite email : http://localhost:8000/ext/auth/verify?token=LxSrVKfTNFRFJK4qhF0wHA&type=invite&redirect_to=http://localhost:5000/#/
4. -> The link is opened by the browser which strips the url on '#/', so Gotrue receives a wrong redirect_to url : http://localhost:5000/ instead of http://localhost:5000/#/ . Then the user is not redirected at the expected location.

## What is the new behavior?

The redirect_to url is url encoded. Then when a browser opens such a link, the value of redirect_to is treated as a HTTP request parameter and is not stripped anymore.

