### PR TITLE
test(/models): removed  prefix from table names in db_test

### DIFF
--- a/models/db_test.go
+++ b/models/db_test.go
@@ -13,10 +13,10 @@ func TestTableNameNamespacing(t *testing.T) {
 		expected string
 		value    interface{}
 	}{
-		{expected: "test_audit_log_entries", value: []*models.AuditLogEntry{}},
-		{expected: "test_instances", value: []*models.Instance{}},
-		{expected: "test_refresh_tokens", value: []*models.RefreshToken{}},
-		{expected: "test_users", value: []*models.User{}},
+		{expected: "audit_log_entries", value: []*models.AuditLogEntry{}},
+		{expected: "instances", value: []*models.Instance{}},
+		{expected: "refresh_tokens", value: []*models.RefreshToken{}},
+		{expected: "users", value: []*models.User{}},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## What kind of change does this PR introduce?

updates models/db_test.go with new table names in db. Test tables not present in latest migration.  

## What is the current behavior?

`go test` in `/models` fails with tables not found because of expected `test_` prefix in table name. 

