### PR TITLE
Fix: allow phone-password login

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,9 +715,16 @@ GoTrue exposes the following endpoints:
 
   body:
   ```json
+  // Email login
   {
     "email": "name@domain.com",
-    "password": "somepassword",
+    "password": "somepassword"
+  }
+  
+  // Phone login
+  {
+    "phone": "12345678",
+    "password": "somepassword"
   }
   ```
 

--- a/api/token.go
+++ b/api/token.go
@@ -35,6 +35,7 @@ type AccessTokenResponse struct {
 // PasswordGrantParams are the parameters the ResourceOwnerPasswordGrant method accepts
 type PasswordGrantParams struct {
 	Email    string `json:"email"`
+	Phone    string `json:"phone"`
 	Password string `json:"password"`
 }
 
@@ -76,16 +77,31 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	instanceID := getInstanceID(ctx)
 	config := a.getConfig(ctx)
 
-	user, err := models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
+	if params.Email != "" && params.Phone != "" {
+		return unprocessableEntityError("Only an email address or phone number should be provided on login.")
+	}
+	var user *models.User
+	var err error
+	if params.Email != "" {
+		user, err = models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
+	} else if params.Phone != "" {
+		params.Phone = a.formatPhoneNumber(params.Phone)
+		user, err = models.FindUserByPhoneAndAudience(a.db, instanceID, params.Phone, aud)
+	} else {
+		return oauthError("invalid_grant", "Invalid login credentials")
+	}
+
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			return oauthError("invalid_grant", "Invalid email or password")
+			return oauthError("invalid_grant", "Invalid login credentials")
 		}
 		return internalServerError("Database error finding user").WithInternalError(err)
 	}
 
-	if !user.IsConfirmed() {
+	if params.Email != "" && !user.IsConfirmed() {
 		return oauthError("invalid_grant", "Email not confirmed")
+	} else if params.Phone != "" && !user.IsPhoneConfirmed() {
+		return oauthError("invalid_grant", "Phone not confirmed")
 	}
 
 	if !user.Authenticate(params.Password) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Update `/token` endpoint to allow login with phone
* If phone number is unconfirmed, return error.
* If user cannot be found by phone number, return error.
* Only allow user to login via email **or** phone but **not** email & phone

Sample curl request
```
curl -X POST 'http://localhost:9999/token?grant_type=password' \                                                                                                                                                              
-H "Content-Type: application/json" \
-d '{
  "phone": "123456789",
  "password": "super-secret-password"
}'
```
