### PR TITLE
fix/trim-spaces-from-creds

### DIFF
--- a/api/provider/apple.go
+++ b/api/provider/apple.go
@@ -55,6 +55,8 @@ func NewAppleProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error
 		return nil, err
 	}
 
+	ext.SanitizeCredentials()
+
 	return &AppleProvider{
 		Config: &oauth2.Config{
 			ClientID:     ext.ClientID,

--- a/api/provider/azure.go
+++ b/api/provider/azure.go
@@ -34,6 +34,7 @@ func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
+	ext.SanitizeCredentials()
 
 	authHost := chooseHost(ext.URL, defaultAzureAuthBase)
 	apiPath := chooseHost(ext.URL, defaultAzureAPIBase)
@@ -47,7 +48,7 @@ func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 				TokenURL: authHost + "/common/oauth2/v2.0/token",
 			},
 			RedirectURL: ext.RedirectURI,
-			Scopes:      []string{
+			Scopes: []string{
 				"openid",
 				scopes,
 			},

--- a/api/provider/bitbucket.go
+++ b/api/provider/bitbucket.go
@@ -40,6 +40,7 @@ func NewBitbucketProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, e
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
+	ext.SanitizeCredentials()
 
 	authHost := chooseHost(ext.URL, defaultBitbucketAuthBase)
 	apiPath := chooseHost(ext.URL, defaultBitbucketAPIBase) + "/2.0"

--- a/api/provider/discord.go
+++ b/api/provider/discord.go
@@ -35,6 +35,7 @@ func NewDiscordProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAu
 	}
 
 	apiPath := chooseHost(ext.URL, defaultDiscordAPIBase) + "/api"
+	ext.SanitizeCredentials()
 
 	return &discordProvider{
 		Config: &oauth2.Config{

--- a/api/provider/facebook.go
+++ b/api/provider/facebook.go
@@ -40,6 +40,7 @@ func NewFacebookProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 	authHost := chooseHost(ext.URL, defaultFacebookAuthBase)
 	tokenHost := chooseHost(ext.URL, defaultFacebookTokenBase)
 	profileURL := chooseHost(ext.URL, defaultFacebookAPIBase) + "/me?fields=email,first_name,last_name,name,picture"
+	ext.SanitizeCredentials()
 
 	return &facebookProvider{
 		Config: &oauth2.Config{

--- a/api/provider/github.go
+++ b/api/provider/github.go
@@ -39,6 +39,7 @@ func NewGithubProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
+	ext.SanitizeCredentials()
 
 	authHost := chooseHost(ext.URL, defaultGitHubAuthBase)
 	apiHost := chooseHost(ext.URL, defaultGitHubApiBase)

--- a/api/provider/gitlab.go
+++ b/api/provider/gitlab.go
@@ -34,6 +34,7 @@ func NewGitlabProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
+	ext.SanitizeCredentials()
 
 	host := chooseHost(ext.URL, defaultGitLabAuthBase)
 	return &gitlabProvider{
@@ -45,7 +46,7 @@ func NewGitlabProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 				TokenURL: host + "/oauth/token",
 			},
 			RedirectURL: ext.RedirectURI,
-			Scopes:      []string{
+			Scopes: []string{
 				"read_user",
 				scopes,
 			},

--- a/api/provider/google.go
+++ b/api/provider/google.go
@@ -30,6 +30,7 @@ func NewGoogleProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
+	ext.SanitizeCredentials()
 
 	authHost := chooseHost(ext.URL, defaultGoogleAuthBase)
 	apiPath := chooseHost(ext.URL, defaultGoogleAPIBase) + "/userinfo/v2/me"

--- a/api/provider/twitch.go
+++ b/api/provider/twitch.go
@@ -46,6 +46,7 @@ func NewTwitchProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
+	ext.SanitizeCredentials()
 
 	apiHost := chooseHost(ext.URL, defaultTwitchAPIBase)
 	authHost := chooseHost(ext.URL, defaultTwitchAuthBase)

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -39,6 +39,7 @@ type twitterUser struct {
 }
 
 func NewTwitterProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+	ext.SanitizeCredentials()
 	p := &TwitterProvider{
 		ClientKey:   ext.ClientID,
 		Secret:      ext.Secret,

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -313,4 +314,9 @@ func (o *OAuthProviderConfiguration) Validate() error {
 		return errors.New("Missing redirect URI")
 	}
 	return nil
+}
+
+func (o *OAuthProviderConfiguration) SanitizeCredentials() {
+	o.ClientID = strings.TrimSpace(o.ClientID)
+	o.Secret = strings.TrimSpace(o.Secret)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #158 

## What is the new behavior?

Addresses possible human error by trimming leading and trailing spaces from OAuth credentials 