### PR TITLE
fix: add default message for sending sms otp

### DIFF
--- a/api/phone.go
+++ b/api/phone.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -47,7 +48,9 @@ func (a *API) sendPhoneConfirmation(tx *storage.Connection, ctx context.Context,
 		return err
 	}
 
-	if serr := smsProvider.SendSms(phone, user.ConfirmationToken); serr != nil {
+	message := fmt.Sprintf("Your OTP for %s is %v", config.SiteURL, user.ConfirmationToken)
+
+	if serr := smsProvider.SendSms(phone, message); serr != nil {
 		user.ConfirmationToken = oldToken
 		return serr
 	}

--- a/api/sms_provider/sms_provider.go
+++ b/api/sms_provider/sms_provider.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SmsProvider interface {
-	SendSms(phone, otp string) error
+	SendSms(phone, message string) error
 }
 
 func GetSmsProvider(config conf.Configuration) (SmsProvider, error) {

--- a/api/sms_provider/twilio.go
+++ b/api/sms_provider/twilio.go
@@ -54,12 +54,12 @@ func NewTwilioProvider(config conf.TwilioProviderConfiguration) (SmsProvider, er
 }
 
 // Send an SMS containing the OTP with Twilio's API
-func (t TwilioProvider) SendSms(phone string, otp string) error {
+func (t TwilioProvider) SendSms(phone string, message string) error {
 	body := url.Values{
 		"To":      {"+" + phone}, // twilio api requires "+" extension to be included
 		"Channel": {"sms"},
 		"From":    {t.Config.MessageServiceSid},
-		"Body":    {otp},
+		"Body":    {message},
 	}
 
 	client := &http.Client{}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Current sms otp message just sends the otp. This PR adds a default message in the format:
`Your OTP for {{ SITE_URL }} is {{ OTP }}`
