### PR TITLE
Fix: Add user_confirmation_requested audit log action

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -120,6 +120,9 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			} else {
 				mailer := a.Mailer(ctx)
 				referrer := a.getReferrer(r)
+				if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserConfirmationRequestedAction, nil); terr != nil {
+					return terr
+				}
 				if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						now := time.Now()
@@ -141,6 +144,9 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					return internalServerError("Database error updating user").WithInternalError(terr)
 				}
 			} else {
+				if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserConfirmationRequestedAction, nil); terr != nil {
+					return terr
+				}
 				if terr = a.sendPhoneConfirmation(tx, ctx, user, params.Phone); terr != nil {
 					return badRequestError("Error sending confirmation sms: %v", terr)
 				}

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -14,16 +14,17 @@ type AuditAction string
 type auditLogType string
 
 const (
-	LoginAction                 AuditAction = "login"
-	LogoutAction                AuditAction = "logout"
-	InviteAcceptedAction        AuditAction = "invite_accepted"
-	UserSignedUpAction          AuditAction = "user_signedup"
-	UserInvitedAction           AuditAction = "user_invited"
-	UserDeletedAction           AuditAction = "user_deleted"
-	UserModifiedAction          AuditAction = "user_modified"
-	UserRecoveryRequestedAction AuditAction = "user_recovery_requested"
-	TokenRevokedAction          AuditAction = "token_revoked"
-	TokenRefreshedAction        AuditAction = "token_refreshed"
+	LoginAction                     AuditAction = "login"
+	LogoutAction                    AuditAction = "logout"
+	InviteAcceptedAction            AuditAction = "invite_accepted"
+	UserSignedUpAction              AuditAction = "user_signedup"
+	UserInvitedAction               AuditAction = "user_invited"
+	UserDeletedAction               AuditAction = "user_deleted"
+	UserModifiedAction              AuditAction = "user_modified"
+	UserRecoveryRequestedAction     AuditAction = "user_recovery_requested"
+	UserConfirmationRequestedAction AuditAction = "user_confirmation_requested"
+	TokenRevokedAction              AuditAction = "token_revoked"
+	TokenRefreshedAction            AuditAction = "token_refreshed"
 
 	account auditLogType = "account"
 	team    auditLogType = "team"
@@ -32,16 +33,17 @@ const (
 )
 
 var actionLogTypeMap = map[AuditAction]auditLogType{
-	LoginAction:                 account,
-	LogoutAction:                account,
-	InviteAcceptedAction:        account,
-	UserSignedUpAction:          team,
-	UserInvitedAction:           team,
-	UserDeletedAction:           team,
-	TokenRevokedAction:          token,
-	TokenRefreshedAction:        token,
-	UserModifiedAction:          user,
-	UserRecoveryRequestedAction: user,
+	LoginAction:                     account,
+	LogoutAction:                    account,
+	InviteAcceptedAction:            account,
+	UserSignedUpAction:              team,
+	UserInvitedAction:               team,
+	UserDeletedAction:               team,
+	TokenRevokedAction:              token,
+	TokenRefreshedAction:            token,
+	UserModifiedAction:              user,
+	UserRecoveryRequestedAction:     user,
+	UserConfirmationRequestedAction: user,
 }
 
 // AuditLogEntry is the database model for audit log entries.


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds audit log action when user requests for confirmation email / sms otp on signup.

```json
{
  "action":"user_confirmation_requested",
  "actor_id":"d01a130f-5498-4d60-971a-4236bf77b0b4",
  "actor_username":"00000000",
  "log_type":"user",
  "timestamp":"2021-07-29T07:35:11Z"
}
```