### PR TITLE
fix: add env var to set custom message for sms

### DIFF
--- a/api/phone.go
+++ b/api/phone.go
@@ -15,6 +15,7 @@ import (
 )
 
 const e164Format = `^[1-9]\d{1,14}$`
+const defaultSmsMessage = "Your code is %v"
 
 // validateE165Format checks if phone number follows the E.164 format
 func (a *API) validateE164Format(phone string) bool {
@@ -48,7 +49,12 @@ func (a *API) sendPhoneConfirmation(tx *storage.Connection, ctx context.Context,
 		return err
 	}
 
-	message := fmt.Sprintf("Your code for %s is %v", config.SiteURL, user.ConfirmationToken)
+	var message string
+	if config.Sms.Template == "" {
+		message = fmt.Sprintf(defaultSmsMessage, user.ConfirmationToken)
+	} else {
+		message = strings.Replace(config.Sms.Template, "{{ .Code }}", user.ConfirmationToken, -1)
+	}
 
 	if serr := smsProvider.SendSms(phone, message); serr != nil {
 		user.ConfirmationToken = oldToken

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -122,6 +122,7 @@ type SmsProviderConfiguration struct {
 	OtpExp       uint                        `json:"otp_exp" split_words:"true"`
 	OtpLength    int                         `json:"otp_length" split_words:"true"`
 	Provider     string                      `json:"provider"`
+	Template     string                      `json:"template"`
 	Twilio       TwilioProviderConfiguration `json:"twilio"`
 }
 
@@ -259,6 +260,10 @@ func (config *Configuration) ApplyDefaults() {
 	if config.Sms.OtpLength == 0 || config.Sms.OtpLength < 6 || config.Sms.OtpLength > 10 {
 		// 6-digit otp by default
 		config.Sms.OtpLength = 6
+	}
+
+	if len(config.Sms.Template) == 0 {
+		config.Sms.Template = ""
 	}
 
 	if config.Cookie.Key == "" {


### PR DESCRIPTION
## What kind of change does this PR introduce?
The default message sent will always be "Your code is `{{ .Code }}`". 

![IMG_97CB66FADB44-1](https://user-images.githubusercontent.com/28647601/129159136-df86aa83-0b86-4c21-bd5f-4841d9f01e77.jpeg)
