### PR TITLE
Twitter: use HTTPS profile image URL for `AvatarURL`

### DIFF
--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -35,7 +35,7 @@ type TwitterProvider struct {
 type twitterUser struct {
 	UserName  string `json:"screen_name"`
 	Name      string `json:"name"`
-	AvatarURL string `json:"profile_image_url"`
+	AvatarURL string `json:"profile_image_url_https"`
 	Email     string `json:"email"`
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the Twitter provider to use the HTTPS profile image URL instead of the default HTTP image URL.

## What is the current behavior?

The `AvatarURL` metadata for Twitter logins has a HTTP image URL.

## What is the new behavior?

The `AvatarURL` metadata for Twitter logins now uses the HTTPS image URL.
