### PR TITLE
Fixed return message to avoid information leaking

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -89,7 +89,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		var terr error
 		if user != nil {
 			if params.Provider == "email" && user.IsConfirmed() {
-				return badRequestError("A user with this email address has already been registered")
+				return badRequestError("Thanks for registering, now check your email to complete the process.")
 			}
 
 			if params.Provider == "phone" && user.IsPhoneConfirmed() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

I fixed https://github.com/supabase/gotrue/issues/119 issue. Just changed the response message.

## What is the current behavior?

Returns a response message that may cause to attack by hackers. 

## What is the new behavior?

Hides the information of person that who is signed up for the service.

## Additional context

Reference: https://security.stackexchange.com/questions/234740/on-my-websites-account-creation-form-how-to-avoid-leaking-the-information-that/234757#234757 
