### PR TITLE
fix: redirects on email change

### DIFF
--- a/api/mail.go
+++ b/api/mail.go
@@ -232,13 +232,21 @@ func (a *API) sendMagicLink(tx *storage.Connection, u *models.User, mailer maile
 func (a *API) sendEmailChange(tx *storage.Connection, u *models.User, mailer mailer.Mailer, email string, referrerURL string) error {
 	u.EmailChangeTokenCurrent, u.EmailChangeTokenNew = crypto.SecureToken(), crypto.SecureToken()
 	u.EmailChange = email
+	u.EmailChangeConfirmStatus = noneConfirmed
 	now := time.Now()
 	if err := mailer.EmailChangeMail(u, referrerURL); err != nil {
 		return err
 	}
 
 	u.EmailChangeSentAt = &now
-	return errors.Wrap(tx.UpdateOnly(u, "email_change_token_current", "email_change_token_new", "email_change", "email_change_sent_at"), "Database error updating user for email change")
+	return errors.Wrap(tx.UpdateOnly(
+		u,
+		"email_change_token_current",
+		"email_change_token_new",
+		"email_change",
+		"email_change_sent_at",
+		"email_change_confirm_status",
+	), "Database error updating user for email change")
 }
 
 func (a *API) validateEmail(ctx context.Context, email string) error {

--- a/models/user.go
+++ b/models/user.go
@@ -279,12 +279,12 @@ func (u *User) UpdateLastSignInAt(tx *storage.Connection) error {
 }
 
 // ConfirmEmailChange confirm the change of email for a user
-func (u *User) ConfirmEmailChange(tx *storage.Connection) error {
+func (u *User) ConfirmEmailChange(tx *storage.Connection, status int) error {
 	u.Email = storage.NullString(u.EmailChange)
 	u.EmailChange = ""
 	u.EmailChangeTokenCurrent = ""
 	u.EmailChangeTokenNew = ""
-	u.EmailChangeConfirmStatus = 0
+	u.EmailChangeConfirmStatus = status
 	return tx.UpdateOnly(
 		u,
 		"email",


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Email change endpoint should redirect properly if only 1 email is confirmed. See #200 
* Email change confirmation status should reset when user requests to change email again (regardless of the current status)