### PR TITLE
fix: nest hcaptcha token under a more generic field

### DIFF
--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -45,9 +45,9 @@ func TestHCaptcha(t *testing.T) {
 func (ts *MiddlewareTestSuite) TestVerifyCaptchaValid() {
 	var buffer bytes.Buffer
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
-		"email":          "test@example.com",
-		"password":       "secret",
-		"__gotrue_meta_security": map[string]interface{}{
+		"email":    "test@example.com",
+		"password": "secret",
+		"gotrue_meta_security": map[string]interface{}{
 			"hcaptcha_token": HCaptchaResponse,
 		},
 	}))
@@ -72,9 +72,9 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaValid() {
 
 	// re-initialize buffer
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
-		"email":          "test@example.com",
-		"password":       "secret",
-		"__gotrue_meta_security": map[string]interface{}{
+		"email":    "test@example.com",
+		"password": "secret",
+		"gotrue_meta_security": map[string]interface{}{
 			"hcaptcha_token": HCaptchaResponse,
 		},
 	}))
@@ -126,9 +126,9 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaInvalid() {
 			ts.Config.Security.Captcha = *c.captchaConf
 			var buffer bytes.Buffer
 			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
-				"email":          "test@example.com",
-				"password":       "secret",
-				"__gotrue_meta_security": map[string]interface{}{
+				"email":    "test@example.com",
+				"password": "secret",
+				"gotrue_meta_security": map[string]interface{}{
 					"hcaptcha_token": HCaptchaResponse,
 				},
 			}))

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -47,7 +47,9 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaValid() {
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
 		"email":          "test@example.com",
 		"password":       "secret",
-		"hcaptcha_token": HCaptchaResponse,
+		"__gotrue_meta_security": map[string]interface{}{
+			"hcaptcha_token": HCaptchaResponse,
+		},
 	}))
 
 	ts.Config.Security.Captcha.Enabled = true
@@ -72,7 +74,9 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaValid() {
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
 		"email":          "test@example.com",
 		"password":       "secret",
-		"hcaptcha_token": HCaptchaResponse,
+		"__gotrue_meta_security": map[string]interface{}{
+			"hcaptcha_token": HCaptchaResponse,
+		},
 	}))
 
 	// check if body is the same
@@ -124,7 +128,9 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaInvalid() {
 			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
 				"email":          "test@example.com",
 				"password":       "secret",
-				"hcaptcha_token": HCaptchaResponse,
+				"__gotrue_meta_security": map[string]interface{}{
+					"hcaptcha_token": HCaptchaResponse,
+				},
 			}))
 			req := httptest.NewRequest(http.MethodPost, "http://localhost", &buffer)
 			req.Header.Set("Content-Type", "application/json")
@@ -136,8 +142,8 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaInvalid() {
 			w := httptest.NewRecorder()
 
 			_, err = ts.API.verifyCaptcha(w, req)
-			require.Equal(ts.T(), err.(*HTTPError).Code, c.expectedCode)
-			require.Equal(ts.T(), err.(*HTTPError).Message, c.expectedMsg)
+			require.Equal(ts.T(), c.expectedCode, err.(*HTTPError).Code)
+			require.Equal(ts.T(), c.expectedMsg, err.(*HTTPError).Message)
 		})
 	}
 }

--- a/security/hcaptcha.go
+++ b/security/hcaptcha.go
@@ -4,18 +4,19 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type GotrueRequest struct {
-	Security GotrueSecurity `json:"__gotrue_meta_security"`
+	Security GotrueSecurity `json:"gotrue_meta_security"`
 }
 
 type GotrueSecurity struct {
@@ -29,11 +30,13 @@ type VerificationResponse struct {
 }
 
 type VerificationResult int
+
 const (
 	UserRequestFailed VerificationResult = iota
 	VerificationProcessFailure
 	SuccessfullyVerified
 )
+
 var Client *http.Client
 
 func init() {

--- a/security/hcaptcha.go
+++ b/security/hcaptcha.go
@@ -14,7 +14,11 @@ import (
 	"time"
 )
 
-type CaptchaResponse struct {
+type GotrueRequest struct {
+	Security GotrueSecurity `json:"__gotrue_meta_security"`
+}
+
+type GotrueSecurity struct {
 	Token string `json:"hcaptcha_token"`
 }
 
@@ -38,7 +42,7 @@ func init() {
 }
 
 func VerifyRequest(r *http.Request, secretKey string) (VerificationResult, error) {
-	res := CaptchaResponse{}
+	res := GotrueRequest{}
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return UserRequestFailed, err
@@ -49,11 +53,11 @@ func VerifyRequest(r *http.Request, secretKey string) (VerificationResult, error
 
 	jsonDecoder := json.NewDecoder(bytes.NewBuffer(bodyBytes))
 	err = jsonDecoder.Decode(&res)
-	if err != nil || strings.TrimSpace(res.Token) == "" {
+	if err != nil || strings.TrimSpace(res.Security.Token) == "" {
 		return UserRequestFailed, errors.Wrap(err, "couldn't decode captcha info")
 	}
 	clientIP := strings.Split(r.RemoteAddr, ":")[0]
-	return verifyCaptchaCode(res.Token, secretKey, clientIP)
+	return verifyCaptchaCode(res.Security.Token, secretKey, clientIP)
 }
 
 func verifyCaptchaCode(token string, secretKey string, clientIP string) (VerificationResult, error) {


### PR DESCRIPTION
The hcaptcha token included in API requests gets pushed down a level
under the '__gotrue_meta_security' field to allow for greater
extensibility, while also communicating that the included data is for
Gotrue's consumption (vs a third-party provider, or user db).

Although this constitutes a breaking change in the API, the HCaptcha functionality is as-of-yet unsupported by our client libs, and was initially merged under an 'alpha' moniker, marking it liable to such changes.

https://github.com/supabase/gotrue-js/pull/128#issuecomment-917523658