### PR TITLE
Fix: Add rate limiting on email endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Use this to disable phone signups (users can still use external oauth providers 
 
 Header on which to rate limit the `/token` endpoint.
 
+`GOTRUE_RATE_LIMIT_EMAIL_SENT` - `string`
+
+Rate limit the number of emails sent per hr on the following endpoints: `/signup`, `/invite`, `/magiclink`, `/recover`, `/otp`, & `/user`. 
+
 `PASSWORD_MIN_LENGTH` - `int`
 
 Minimum password length, defaults to 6.

--- a/api/api.go
+++ b/api/api.go
@@ -114,12 +114,12 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 		r.Get("/authorize", api.ExternalProviderRedirect)
 
-		r.With(api.requireAdminCredentials).Post("/invite", api.Invite)
+		r.With(api.limitEmailSentHandler()).With(api.requireAdminCredentials).Post("/invite", api.Invite)
+		r.With(api.limitEmailSentHandler()).With(api.verifyCaptcha).Post("/signup", api.Signup)
+		r.With(api.limitEmailSentHandler()).With(api.verifyCaptcha).With(api.requireEmailProvider).Post("/recover", api.Recover)
+		r.With(api.limitEmailSentHandler()).With(api.verifyCaptcha).Post("/magiclink", api.MagicLink)
 
-		r.With(api.verifyCaptcha).Post("/signup", api.Signup)
-		r.With(api.verifyCaptcha).With(api.requireEmailProvider).Post("/recover", api.Recover)
-		r.With(api.verifyCaptcha).Post("/magiclink", api.MagicLink)
-		r.With(api.verifyCaptcha).Post("/otp", api.Otp)
+		r.With(api.limitEmailSentHandler()).With(api.verifyCaptcha).Post("/otp", api.Otp)
 
 		r.With(api.requireEmailProvider).With(api.limitHandler(
 			// Allow requests at a rate of 30 per 5 minutes.
@@ -143,7 +143,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		r.Route("/user", func(r *router) {
 			r.Use(api.requireAuthentication)
 			r.Get("/", api.UserGet)
-			r.Put("/", api.UserUpdate)
+			r.With(api.limitEmailSentHandler()).Put("/", api.UserUpdate)
 		})
 
 		r.Route("/admin", func(r *router) {

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/netlify/gotrue/security"
-	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/netlify/gotrue/security"
+	"github.com/sirupsen/logrus"
 
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"
@@ -148,6 +150,44 @@ func (a *API) limitHandler(lmt *limiter.Limiter) middlewareHandler {
 			err := tollbooth.LimitByKeys(lmt, []string{key})
 			if err != nil {
 				return c, httpError(http.StatusTooManyRequests, "Rate limit exceeded")
+			}
+		}
+		return c, nil
+	}
+}
+
+func (a *API) limitEmailSentHandler() middlewareHandler {
+	// limit per hour
+	freq := a.config.RateLimitEmailSent / (60 * 60)
+	lmt := tollbooth.NewLimiter(freq, &limiter.ExpirableOptions{
+		DefaultExpirationTTL: time.Hour,
+	}).SetBurst(int(a.config.RateLimitEmailSent)).SetMethods([]string{"PUT", "POST"})
+	return func(w http.ResponseWriter, req *http.Request) (context.Context, error) {
+		c := req.Context()
+		config := a.getConfig(c)
+		if config.External.Email.Enabled && !config.Mailer.Autoconfirm {
+			if req.Method == "PUT" || req.Method == "POST" {
+				res := make(map[string]interface{})
+				bodyBytes, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return c, internalServerError("Error invalid request body").WithInternalError(err)
+				}
+				req.Body.Close()
+				req.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+
+				jsonDecoder := json.NewDecoder(bytes.NewBuffer(bodyBytes))
+				if err := jsonDecoder.Decode(&res); err != nil {
+					return c, badRequestError("Error invalid request body").WithInternalError(err)
+				}
+
+				if _, ok := res["email"]; !ok {
+					// email not in POST body
+					return c, nil
+				}
+
+				if err := tollbooth.LimitByRequest(lmt, w, req); err != nil {
+					return c, httpError(http.StatusTooManyRequests, "Rate limit exceeded")
+				}
 			}
 		}
 		return c, nil

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -59,14 +59,15 @@ type GlobalConfiguration struct {
 		RequestIDHeader string `envconfig:"REQUEST_ID_HEADER"`
 		ExternalURL     string `json:"external_url" envconfig:"API_EXTERNAL_URL"`
 	}
-	DB                DBConfiguration
-	External          ProviderConfiguration
-	Logging           LoggingConfig `envconfig:"LOG"`
-	OperatorToken     string        `split_words:"true" required:"false"`
-	MultiInstanceMode bool
-	Tracing           TracingConfig
-	SMTP              SMTPConfiguration
-	RateLimitHeader   string `split_words:"true"`
+	DB                 DBConfiguration
+	External           ProviderConfiguration
+	Logging            LoggingConfig `envconfig:"LOG"`
+	OperatorToken      string        `split_words:"true" required:"false"`
+	MultiInstanceMode  bool
+	Tracing            TracingConfig
+	SMTP               SMTPConfiguration
+	RateLimitHeader    string  `split_words:"true"`
+	RateLimitEmailSent float64 `split_words:"true" default:"30"`
 }
 
 // EmailContentConfiguration holds the configuration for emails, both subjects and template URLs.


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Add rate-limit on all endpoints that send out emails via `GOTRUE_RATE_LIMIT_EMAIL_SENT` env var. Default is set to 30. 

## Implementation Details
* Want to enforce rate-limit on only `PUT` or `POST` requests with `email` field in request body. 

## Limitations
* Can't seem to find a way to enforce a rate-limit over multiple endpoints collectively using tollbooth. 