### PR TITLE
Fix: email change dx

### DIFF
--- a/api/mail.go
+++ b/api/mail.go
@@ -233,7 +233,7 @@ func (a *API) sendMagicLink(tx *storage.Connection, u *models.User, mailer maile
 func (a *API) sendSecureEmailChange(tx *storage.Connection, u *models.User, mailer mailer.Mailer, email string, referrerURL string) error {
 	u.EmailChangeTokenCurrent, u.EmailChangeTokenNew = crypto.SecureToken(), crypto.SecureToken()
 	u.EmailChange = email
-	u.EmailChangeConfirmStatus = noneConfirmed
+	u.EmailChangeConfirmStatus = zeroConfirmation
 	now := time.Now()
 	if err := mailer.EmailChangeMail(u, referrerURL); err != nil {
 		return err
@@ -254,7 +254,7 @@ func (a *API) sendSecureEmailChange(tx *storage.Connection, u *models.User, mail
 func (a *API) sendEmailChange(tx *storage.Connection, u *models.User, mailer mailer.Mailer, email string, referrerURL string) error {
 	u.EmailChangeTokenNew = crypto.SecureToken()
 	u.EmailChange = email
-	u.EmailChangeConfirmStatus = noneConfirmed
+	u.EmailChangeConfirmStatus = zeroConfirmation
 	now := time.Now()
 	if err := mailer.EmailChangeMail(u, referrerURL); err != nil {
 		return err

--- a/api/mail.go
+++ b/api/mail.go
@@ -229,7 +229,8 @@ func (a *API) sendMagicLink(tx *storage.Connection, u *models.User, mailer maile
 	return errors.Wrap(tx.UpdateOnly(u, "recovery_token", "recovery_sent_at"), "Database error updating user for recovery")
 }
 
-func (a *API) sendEmailChange(tx *storage.Connection, u *models.User, mailer mailer.Mailer, email string, referrerURL string) error {
+// sendSecureEmailChange sends out an email change token each to the old and new emails.
+func (a *API) sendSecureEmailChange(tx *storage.Connection, u *models.User, mailer mailer.Mailer, email string, referrerURL string) error {
 	u.EmailChangeTokenCurrent, u.EmailChangeTokenNew = crypto.SecureToken(), crypto.SecureToken()
 	u.EmailChange = email
 	u.EmailChangeConfirmStatus = noneConfirmed
@@ -242,6 +243,26 @@ func (a *API) sendEmailChange(tx *storage.Connection, u *models.User, mailer mai
 	return errors.Wrap(tx.UpdateOnly(
 		u,
 		"email_change_token_current",
+		"email_change_token_new",
+		"email_change",
+		"email_change_sent_at",
+		"email_change_confirm_status",
+	), "Database error updating user for email change")
+}
+
+// sendEmailChange sends out an email change token to the new email.
+func (a *API) sendEmailChange(tx *storage.Connection, u *models.User, mailer mailer.Mailer, email string, referrerURL string) error {
+	u.EmailChangeTokenNew = crypto.SecureToken()
+	u.EmailChange = email
+	u.EmailChangeConfirmStatus = noneConfirmed
+	now := time.Now()
+	if err := mailer.EmailChangeMail(u, referrerURL); err != nil {
+		return err
+	}
+
+	u.EmailChangeSentAt = &now
+	return errors.Wrap(tx.UpdateOnly(
+		u,
 		"email_change_token_new",
 		"email_change",
 		"email_change_sent_at",

--- a/api/user.go
+++ b/api/user.go
@@ -120,8 +120,14 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 			mailer := a.Mailer(ctx)
 			referrer := a.getReferrer(r)
-			if terr = a.sendEmailChange(tx, user, mailer, params.Email, referrer); terr != nil {
-				return internalServerError("Error sending change email").WithInternalError(terr)
+			if config.Mailer.SecureEmailChangeEnabled {
+				if terr = a.sendSecureEmailChange(tx, user, mailer, params.Email, referrer); terr != nil {
+					return internalServerError("Error sending change email").WithInternalError(terr)
+				}
+			} else {
+				if terr = a.sendEmailChange(tx, user, mailer, params.Email, referrer); terr != nil {
+					return internalServerError("Error sending change email").WithInternalError(terr)
+				}
 			}
 		}
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -107,10 +107,11 @@ type SMTPConfiguration struct {
 }
 
 type MailerConfiguration struct {
-	Autoconfirm bool                      `json:"autoconfirm"`
-	Subjects    EmailContentConfiguration `json:"subjects"`
-	Templates   EmailContentConfiguration `json:"templates"`
-	URLPaths    EmailContentConfiguration `json:"url_paths"`
+	Autoconfirm              bool                      `json:"autoconfirm"`
+	Subjects                 EmailContentConfiguration `json:"subjects"`
+	Templates                EmailContentConfiguration `json:"templates"`
+	URLPaths                 EmailContentConfiguration `json:"url_paths"`
+	SecureEmailChangeEnabled bool                      `json:"secure_email_change_enabled" split_words:"true" default:"true"`
 }
 
 type PhoneProviderConfiguration struct {

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -23,9 +23,9 @@ const defaultInviteMail = `<h2>You have been invited</h2>
 <p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>
 <p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>`
 
-const defaultConfirmationMail = `<h2>Confirm your signup</h2>
+const defaultConfirmationMail = `<h2>Confirm your email</h2>
 
-<p>Follow this link to confirm your user:</p>
+<p>Follow this link to confirm your email:</p>
 <p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>`
 
 const defaultRecoveryMail = `<h2>Reset password</h2>
@@ -102,7 +102,7 @@ func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string)
 
 	return m.Mailer.Mail(
 		user.GetEmail(),
-		string(withDefault(m.Config.Mailer.Subjects.Confirmation, "Confirm Your Signup")),
+		string(withDefault(m.Config.Mailer.Subjects.Confirmation, "Confirm Your Email")),
 		m.Config.Mailer.Templates.Confirmation,
 		defaultConfirmationMail,
 		data,

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -111,6 +111,30 @@ func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string)
 
 // EmailChangeMail sends an email change confirmation mail to a user
 func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) error {
+	type Email struct {
+		Address  string
+		Token    string
+		Subject  string
+		Template string
+	}
+	emails := []Email{
+		{
+			Address:  user.EmailChange,
+			Token:    user.EmailChangeTokenNew,
+			Subject:  string(withDefault(m.Config.Mailer.Subjects.EmailChange, "Confirm Email Change")),
+			Template: m.Config.Mailer.Templates.Confirmation,
+		},
+	}
+
+	if m.Config.Mailer.SecureEmailChangeEnabled {
+		emails = append(emails, Email{
+			Address:  user.GetEmail(),
+			Token:    user.EmailChangeTokenCurrent,
+			Subject:  string(withDefault(m.Config.Mailer.Subjects.Confirmation, "Confirm Email Address")),
+			Template: m.Config.Mailer.Templates.EmailChange,
+		})
+	}
+
 	globalConfig, err := conf.LoadGlobal(configFile)
 	if err != nil {
 		return err
@@ -120,42 +144,37 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) 
 	if len(referrerURL) > 0 {
 		redirectParam = "&redirect_to=" + referrerURL
 	}
-
 	errors := make(chan error)
-	tokens := map[string]string{
-		user.GetEmail():  user.EmailChangeTokenCurrent,
-		user.EmailChange: user.EmailChangeTokenNew,
-	}
-	for email, token := range tokens {
+	for _, email := range emails {
 		url, err := getSiteURL(
 			referrerURL,
 			globalConfig.API.ExternalURL,
 			m.Config.Mailer.URLPaths.EmailChange,
-			"token="+token+"&type=email_change"+redirectParam,
+			"token="+email.Token+"&type=email_change"+redirectParam,
 		)
 		if err != nil {
 			return err
 		}
-		go func(e, t string) {
+		go func(address, token, template string) {
 			data := map[string]interface{}{
 				"SiteURL":         m.Config.SiteURL,
 				"ConfirmationURL": url,
 				"Email":           user.GetEmail(),
 				"NewEmail":        user.EmailChange,
-				"Token":           t,
+				"Token":           token,
 				"Data":            user.UserMetaData,
 			}
 			errors <- m.Mailer.Mail(
-				e,
+				address,
 				string(withDefault(m.Config.Mailer.Subjects.EmailChange, "Confirm Email Change")),
-				m.Config.Mailer.Templates.EmailChange,
+				template,
 				defaultEmailChangeMail,
 				data,
 			)
-		}(email, token)
+		}(email.Address, email.Token, email.Template)
 	}
 
-	for i := 0; i < len(tokens); i++ {
+	for i := 0; i < len(emails); i++ {
 		e := <-errors
 		if e != nil {
 			return e


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Allow custom email change templates. Send email change template to old email and confirmation email template to new email
- Change API responses to have a better response. It shouldn’t say email has changed when only one link has been clicked. Better message for confirming 1 email (it shouldn't be an error message)
- Option to disable double confirmation.