### PR TITLE
Fix: update repeated user signups

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -165,6 +165,9 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			return tooManyRequestsError("For security purposes, you can only request this once every minute")
 		}
 		if errors.Is(err, UserExistsError) {
+			if config.Mailer.Autoconfirm || config.Sms.Autoconfirm {
+				return badRequestError("User already registered")
+			}
 			sanitizedUser, err := sanitizeUser(user, params)
 			if err != nil {
 				return err

--- a/api/signup.go
+++ b/api/signup.go
@@ -92,11 +92,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	err = a.db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		if user != nil {
-			if params.Provider == "email" && user.IsConfirmed() {
-				return UserExistsError
-			}
-
-			if params.Provider == "phone" && user.IsPhoneConfirmed() {
+			if (params.Provider == "email" && user.IsConfirmed()) || (params.Provider == "phone" && user.IsPhoneConfirmed()) {
 				return UserExistsError
 			}
 
@@ -165,6 +161,15 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			return tooManyRequestsError("For security purposes, you can only request this once every minute")
 		}
 		if errors.Is(err, UserExistsError) {
+			err = a.db.Transaction(func(tx *storage.Connection) error {
+				if terr := models.NewAuditLogEntry(tx, instanceID, user, models.UserRepeatedSignUpAction, nil); terr != nil {
+					return terr
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
 			if config.Mailer.Autoconfirm || config.Sms.Autoconfirm {
 				return badRequestError("User already registered")
 			}

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -23,6 +23,7 @@ const (
 	UserModifiedAction              AuditAction = "user_modified"
 	UserRecoveryRequestedAction     AuditAction = "user_recovery_requested"
 	UserConfirmationRequestedAction AuditAction = "user_confirmation_requested"
+	UserRepeatedSignUpAction        AuditAction = "user_repeated_signup"
 	TokenRevokedAction              AuditAction = "token_revoked"
 	TokenRefreshedAction            AuditAction = "token_refreshed"
 
@@ -44,6 +45,7 @@ var actionLogTypeMap = map[AuditAction]auditLogType{
 	UserModifiedAction:              user,
 	UserRecoveryRequestedAction:     user,
 	UserConfirmationRequestedAction: user,
+	UserRepeatedSignUpAction:        user,
 }
 
 // AuditLogEntry is the database model for audit log entries.


### PR DESCRIPTION
## What kind of change does this PR introduce?
* If autoconfirm is enabled:
```
{
  "code":400,
  "msg":"User already registered"
}
```

* Insert `user_repeated_signup` action into audit log trail  (if there is a repeated signup)