### PR TITLE
Fix: allow signups always

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -177,10 +177,6 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.getConfig(ctx)
 
-	if config.DisableSignup {
-		return forbiddenError("Signups not allowed for this instance")
-	}
-
 	instanceID := getInstanceID(ctx)
 	adminUser := getAdminUser(ctx)
 	params, err := a.getAdminParams(r)
@@ -198,9 +194,6 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Email != "" {
-		if !config.External.Email.Enabled {
-			return badRequestError("Email signups are disabled")
-		}
 		if err := a.validateEmail(ctx, params.Email); err != nil {
 			return err
 		}
@@ -212,9 +205,6 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Phone != "" {
-		if !config.External.Phone.Enabled {
-			return badRequestError("Phone signups are disabled")
-		}
 		params.Phone = a.formatPhoneNumber(params.Phone)
 		if isValid := a.validateE164Format(params.Phone); !isValid {
 			return unprocessableEntityError("Invalid phone format")

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -431,7 +431,7 @@ func (ts *AdminTestSuite) TestAdminUserCreateWithDisabledLogin() {
 				"email":    "test1@example.com",
 				"password": "test1",
 			},
-			http.StatusBadRequest,
+			http.StatusOK,
 		},
 		{
 			"Phone Signups Disabled",
@@ -447,7 +447,7 @@ func (ts *AdminTestSuite) TestAdminUserCreateWithDisabledLogin() {
 				"phone":    "123456789",
 				"password": "test1",
 			},
-			http.StatusBadRequest,
+			http.StatusOK,
 		},
 		{
 			"All Signups Disabled",
@@ -456,10 +456,10 @@ func (ts *AdminTestSuite) TestAdminUserCreateWithDisabledLogin() {
 				DisableSignup: true,
 			},
 			map[string]interface{}{
-				"email":    "test1@example.com",
-				"password": "test1",
+				"email":    "test2@example.com",
+				"password": "test2",
 			},
-			http.StatusForbidden,
+			http.StatusOK,
 		},
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Allow admin to create users regardless of whether `DISABLE_SIGNUP=true`, `GOTRUE_EXTERNAL_EMAIL_ENABLED=false` or `GOTRUE_EXTERNAL_PHONE_ENABLED=false`