### PR TITLE
Fix: Allow refresh token grant if no email in providers field

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -122,7 +122,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 		r.With(sharedLimiter).With(api.verifyCaptcha).Post("/otp", api.Otp)
 
-		r.With(api.requireEmailProvider).With(api.limitHandler(
+		r.With(api.limitHandler(
 			// Allow requests at a rate of 30 per 5 minutes.
 			tollbooth.NewLimiter(30.0/(60*5), &limiter.ExpirableOptions{
 				DefaultExpirationTTL: time.Hour,

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -265,7 +265,7 @@ func (ts *InviteTestSuite) TestInviteExternalGitlab() {
 	ts.Equal("Gitlab Test", user.UserMetaData["full_name"])
 	ts.Equal("http://example.com/avatar", user.UserMetaData["avatar_url"])
 	ts.Equal("gitlab", user.AppMetaData["provider"])
-	ts.Equal([]interface{}{"gitlab"}, user.AppMetaData["providers"])
+	ts.Equal([]interface{}{"email", "gitlab"}, user.AppMetaData["providers"])
 }
 
 func (ts *InviteTestSuite) TestInviteExternalGitlab_MismatchedEmails() {

--- a/api/token.go
+++ b/api/token.go
@@ -153,8 +153,14 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	var user *models.User
 	var err error
 	if params.Email != "" {
+		if !config.External.Email.Enabled {
+			return badRequestError("Email logins are disabled")
+		}
 		user, err = models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
 	} else if params.Phone != "" {
+		if !config.External.Phone.Enabled {
+			return badRequestError("Phone logins are disabled")
+		}
 		params.Phone = a.formatPhoneNumber(params.Phone)
 		user, err = models.FindUserByPhoneAndAudience(a.db, instanceID, params.Phone, aud)
 	} else {
@@ -232,6 +238,21 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 			return oauthError("invalid_grant", "Invalid Refresh Token")
 		}
 		return internalServerError(err.Error())
+	}
+
+	if !(config.External.Email.Enabled && config.External.Phone.Enabled) {
+		providers, err := models.FindProvidersByUser(a.db, user)
+		if err != nil {
+			return internalServerError(err.Error())
+		}
+		for _, provider := range providers {
+			if provider == "email" && !config.External.Email.Enabled {
+				return badRequestError("Email logins are disabled")
+			}
+			if provider == "phone" && !config.External.Phone.Enabled {
+				return badRequestError("Phone logins are disabled")
+			}
+		}
 	}
 
 	if token.Revoked {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #276 
* If the `providers` field returned contains "email", we still don't allow a user to use the refresh token. This is because it is impossible to tell if the user is refreshing a token for an email login or oauth provider login. 