### PR TITLE
fix: update auth functions

### DIFF
--- a/hack/init_postgres.sql
+++ b/hack/init_postgres.sql
@@ -111,3 +111,5 @@ ALTER table "auth".refresh_tokens OWNER TO supabase_auth_admin;
 ALTER table "auth".audit_log_entries OWNER TO supabase_auth_admin;
 ALTER table "auth".instances OWNER TO supabase_auth_admin;
 ALTER table "auth".schema_migrations OWNER TO supabase_auth_admin;
+ALTER FUNCTION auth.uid OWNER TO supabase_auth_admin;
+ALTER FUNCTION auth.role OWNER TO supabase_auth_admin;

--- a/migrations/20211124214934_update_auth_functions.up.sql
+++ b/migrations/20211124214934_update_auth_functions.up.sql
@@ -1,0 +1,34 @@
+-- create index on identities.user_id
+
+create or replace function auth.uid() 
+returns uuid 
+language sql stable
+as $$
+  select 
+  	coalesce(
+		current_setting('request.jwt.claim.sub', true),
+		(current_setting('request.jwt.claims', true)::jsonb ->> 'sub')
+	)::uuid
+$$;
+
+create or replace function auth.role() 
+returns text 
+language sql stable
+as $$
+  select 
+  	coalesce(
+		current_setting('request.jwt.claim.role', true),
+		(current_setting('request.jwt.claims', true)::jsonb ->> 'role')
+	)::text
+$$;
+
+create or replace function auth.email() 
+returns text 
+language sql stable
+as $$
+  select 
+  	coalesce(
+		current_setting('request.jwt.claim.email', true),
+		(current_setting('request.jwt.claims', true)::jsonb ->> 'email')
+	)::text
+$$;


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Updates the auth.uid, auth.role, auth.email functions 

## Steps to test
* Run ./hack/postgresd.sh
* `make build && ./gotrue` 
* `docker exec -it gotrue_postgresql psql -U postgres` 
* `select proname, proowner::regrole from pg_proc where pronamespace::regnamespace::text = 'auth';` 

### Query Output: 
```
 proname |      proowner
---------+---------------------
 role    | supabase_auth_admin
 uid     | supabase_auth_admin
 email   | supabase_auth_admin
```