### PR TITLE
fix: empty password update should return explicit error

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -17,7 +17,7 @@ type adminUserParams struct {
 	Role         string                 `json:"role"`
 	Email        string                 `json:"email"`
 	Phone        string                 `json:"phone"`
-	Password     string                 `json:"password"`
+	Password     *string                `json:"password"`
 	EmailConfirm bool                   `json:"email_confirm"`
 	PhoneConfirm bool                   `json:"phone_confirm"`
 	UserMetaData map[string]interface{} `json:"user_metadata"`
@@ -121,12 +121,12 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		if params.Password != "" {
-			if len(params.Password) < config.PasswordMinLength {
+		if params.Password != nil {
+			if len(*params.Password) < config.PasswordMinLength {
 				return fmt.Errorf("Password should be at least %d characters", config.PasswordMinLength)
 			}
 
-			if terr := user.UpdatePassword(tx, params.Password); terr != nil {
+			if terr := user.UpdatePassword(tx, *params.Password); terr != nil {
 				return terr
 			}
 		}
@@ -216,7 +216,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	user, err := models.NewUser(instanceID, params.Email, params.Password, aud, params.UserMetaData)
+	user, err := models.NewUser(instanceID, params.Email, *params.Password, aud, params.UserMetaData)
 	if err != nil {
 		return internalServerError("Error creating user").WithInternalError(err)
 	}

--- a/api/admin.go
+++ b/api/admin.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi"
@@ -123,7 +123,7 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 		if params.Password != nil {
 			if len(*params.Password) < config.PasswordMinLength {
-				return fmt.Errorf("Password should be at least %d characters", config.PasswordMinLength)
+				return invalidPasswordLengthError(config)
 			}
 
 			if terr := user.UpdatePassword(tx, *params.Password); terr != nil {
@@ -166,6 +166,9 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 	})
 
 	if err != nil {
+		if errors.Is(err, invalidPasswordLengthError(config)) {
+			return err
+		}
 		return internalServerError("Error updating user").WithInternalError(err)
 	}
 

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -412,7 +412,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdatePasswordFailed() {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
 
 		ts.API.handler.ServeHTTP(w, req)
-		require.Equal(ts.T(), http.StatusInternalServerError, w.Code)
+		require.Equal(ts.T(), http.StatusUnprocessableEntity, w.Code)
 	})
 }
 

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -400,6 +400,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdatePasswordFailed() {
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
 	var updateEndpoint = fmt.Sprintf("/admin/users/%s", u.ID)
+	ts.Config.PasswordMinLength = 6
 	ts.Run("Password doesn't meet minimum length", func() {
 		var buffer bytes.Buffer
 		require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{

--- a/api/errors.go
+++ b/api/errors.go
@@ -60,6 +60,10 @@ func (e *OAuthError) Cause() error {
 	return e
 }
 
+func invalidPasswordLengthError(config *conf.Configuration) *HTTPError {
+	return unprocessableEntityError(fmt.Sprintf("Password should be at least %d characters", config.PasswordMinLength))
+}
+
 func invalidSignupError(config *conf.Configuration) *HTTPError {
 	var msg string
 	if config.External.Email.Enabled && config.External.Phone.Enabled {
@@ -129,6 +133,10 @@ func (e *HTTPError) Error() string {
 		return e.InternalMessage
 	}
 	return fmt.Sprintf("%d: %s", e.Code, e.Message)
+}
+
+func (e *HTTPError) Is(target error) bool {
+	return e.Error() == target.Error()
 }
 
 // Cause returns the root cause error

--- a/api/user.go
+++ b/api/user.go
@@ -13,7 +13,7 @@ import (
 // UserUpdateParams parameters for updating a user
 type UserUpdateParams struct {
 	Email    string                 `json:"email"`
-	Password string                 `json:"password"`
+	Password *string                `json:"password"`
 	Data     map[string]interface{} `json:"data"`
 	AppData  map[string]interface{} `json:"app_metadata,omitempty"`
 	Phone    string                 `json:"phone"`
@@ -80,12 +80,12 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
 		var terr error
-		if params.Password != "" {
-			if len(params.Password) < config.PasswordMinLength {
+		if params.Password != nil {
+			if len(*params.Password) < config.PasswordMinLength {
 				return unprocessableEntityError(fmt.Sprintf("Password should be at least %d characters", config.PasswordMinLength))
 			}
 
-			if terr = user.UpdatePassword(tx, params.Password); terr != nil {
+			if terr = user.UpdatePassword(tx, *params.Password); terr != nil {
 				return internalServerError("Error during password storage").WithInternalError(terr)
 			}
 		}

--- a/api/user.go
+++ b/api/user.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/gofrs/uuid"
@@ -82,7 +81,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		var terr error
 		if params.Password != nil {
 			if len(*params.Password) < config.PasswordMinLength {
-				return unprocessableEntityError(fmt.Sprintf("Password should be at least %d characters", config.PasswordMinLength))
+				return invalidPasswordLengthError(config)
 			}
 
 			if terr = user.UpdatePassword(tx, *params.Password); terr != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `PUT /admin/users/<user_id>` with a password of length 0 should return an explicit error 
* `PUT /user` with a password of length 0 should return an explicit error 
* Standardise invalid password update error response for both `PUT /user` & `PUT /admin/users/<user_id>` to return a 422 unprocessable entity
* Resolves #294 