### PR TITLE
fix: redirect user on expired or invalid confirmaton token and otp 

### DIFF
--- a/api/verify.go
+++ b/api/verify.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	// used below to specify need to return answer to user via specific redirect
-	redirectWithQueryError = errors.New("need return answer with query params")
+	// indicates that a user should be redirected due to an error
+	redirectWithQueryError = errors.New("redirect user")
 )
 
 const (
@@ -170,7 +170,7 @@ func (a *API) signupVerify(ctx context.Context, conn *storage.Connection, params
 
 	nextDay := user.ConfirmationSentAt.Add(24 * time.Hour)
 	if user.ConfirmationSentAt != nil && time.Now().After(nextDay) {
-		return nil, expiredTokenError("Confirmation token expired")
+		return nil, expiredTokenError("Confirmation token expired").WithInternalError(redirectWithQueryError)
 	}
 
 	err = conn.Transaction(func(tx *storage.Connection) error {
@@ -265,7 +265,7 @@ func (a *API) smsVerify(ctx context.Context, conn *storage.Connection, params *V
 
 	// check if token has expired or is invalid
 	if isOtpValid := now.Before(expiresAt) && params.Token == user.ConfirmationToken; !isOtpValid {
-		return nil, expiredTokenError("Otp has expired or is invalid")
+		return nil, expiredTokenError("Otp has expired or is invalid").WithInternalError(redirectWithQueryError)
 	}
 
 	err = conn.Transaction(func(tx *storage.Connection) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Developer reported that an expired invite link does not redirect the user to the redirect_url specified 
* User would not get redirect to the client page set up to handle invalid / expired tokens or otps
