### PR TITLE
fix: return err if oauth provider email is unverified

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -226,13 +226,6 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 
 			if !user.IsConfirmed() {
 				if !emailData.Verified && !config.Mailer.Autoconfirm {
-					// mailer := a.Mailer(ctx)
-					// referrer := a.getReferrer(r)
-					// if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer); terr != nil {
-					// 	return internalServerError("Error sending confirmation mail").WithInternalError(terr)
-					// }
-					// email must be verified to issue a token
-					// return nil
 					return badRequestError("Please verify your email (%v) with %v", emailData.Email, providerType)
 				}
 

--- a/api/external.go
+++ b/api/external.go
@@ -226,13 +226,14 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 
 			if !user.IsConfirmed() {
 				if !emailData.Verified && !config.Mailer.Autoconfirm {
-					mailer := a.Mailer(ctx)
-					referrer := a.getReferrer(r)
-					if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer); terr != nil {
-						return internalServerError("Error sending confirmation mail").WithInternalError(terr)
-					}
+					// mailer := a.Mailer(ctx)
+					// referrer := a.getReferrer(r)
+					// if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer); terr != nil {
+					// 	return internalServerError("Error sending confirmation mail").WithInternalError(terr)
+					// }
 					// email must be verified to issue a token
-					return nil
+					// return nil
+					return badRequestError("Please verify your email (%v) with %v", emailData.Email, providerType)
 				}
 
 				if terr := models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {

--- a/api/external_github_test.go
+++ b/api/external_github_test.go
@@ -184,3 +184,15 @@ func (ts *ExternalTestSuite) TestInviteTokenExternalGitHubErrorWhenEmailDoesntMa
 
 	assertAuthorizationFailure(ts, u, "Invited email does not match emails from external provider", "invalid_request", "")
 }
+
+func (ts *ExternalTestSuite) TestSignupExternalGitHubErrorWhenVerifiedFalse() {
+	tokenCount, userCount := 0, 0
+	code := "authcode"
+	emails := `[{"email":"github@example.com", "primary": true, "verified": false}]`
+	server := GitHubTestSignupSetup(ts, &tokenCount, &userCount, code, emails)
+	defer server.Close()
+
+	u := performAuthorization(ts, "github", code, "")
+
+	assertAuthorizationFailure(ts, u, "Please verify your email (github@example.com) with github", "invalid_request", "")
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Return an error to tell the user that the oauth email being used is unverified
* User needs to verify the email associated with the oauth provider in order for the oauth flow to work
* Transaction will be rolled back an the user will not be created if they are using an unverified email 