### PR TITLE
Do not restrict email and phone logins if the respective providers' s…

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -153,14 +153,8 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	var user *models.User
 	var err error
 	if params.Email != "" {
-		if !config.External.Email.Enabled {
-			return badRequestError("Email logins are disabled")
-		}
 		user, err = models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
 	} else if params.Phone != "" {
-		if !config.External.Phone.Enabled {
-			return badRequestError("Phone logins are disabled")
-		}
 		params.Phone = a.formatPhoneNumber(params.Phone)
 		user, err = models.FindUserByPhoneAndAudience(a.db, instanceID, params.Phone, aud)
 	} else {


### PR DESCRIPTION
…ignups are disabled

Hi, this is related to supabase/supabase#4746. I think this might be the fix so I've decided to open a PR for discussion. I do not have a clear enough picture of the role of this condition other than what it was currently causing as per the linked issue.

I _think_ it should be okay to remove these conditions as I do not suppose preventing logins while the email and phone provider's signups are disabled is an intentional feature? If I am mistaken, please excuse the assumption. Should that be the case, could someone please explain the logic behind the decision? I am sure there might be a valid security reason I am overlooking. And if that's the case, is there an alternative for getting email signins to work while keeping signups disabled?

Thank you

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
