### PR TITLE
fix: Set version number at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build deps image lint migrate test vet
 CHECK_FILES?=$$(go list ./... | grep -v /vendor/)
-FLAGS?=-ldflags "-X github.com/supabase/gotrue/cmd.Version=`git rev-parse HEAD`"
+FLAGS?=-ldflags "-X github.com/netlify/gotrue/cmd.Version=`git describe --tags`"
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Version number is not displayed when running `gotrue version`.

## What is the new behavior?

This adds the version number at compile time.

This also switches to `git describe --tags` to get the version, which
displays either the Git tag for the current commit if it has been
tagged, or the last Git tag along with the number of commits on top of
the tag and the commit hash.

## Additional context

Fixes #272.