### PR TITLE
fix: verify identity email

### DIFF
--- a/api/external_github_test.go
+++ b/api/external_github_test.go
@@ -194,5 +194,10 @@ func (ts *ExternalTestSuite) TestSignupExternalGitHubErrorWhenVerifiedFalse() {
 
 	u := performAuthorization(ts, "github", code, "")
 
-	assertAuthorizationFailure(ts, u, "Please verify your email (github@example.com) with github", "invalid_request", "")
+	v, err := url.ParseQuery(u.Fragment)
+	ts.Require().NoError(err)
+	ts.Equal("unauthorized_client", v.Get("error"))
+	ts.Equal("401", v.Get("error_code"))
+	ts.Equal("Unverified email with github", v.Get("error_description"))
+	assertAuthorizationFailure(ts, u, "", "", "")
 }

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -26,6 +26,7 @@ type Mailer interface {
 // NewMailer returns a new gotrue mailer
 func NewMailer(instanceConfig *conf.Configuration) Mailer {
 	if instanceConfig.SMTP.Host == "" {
+		logrus.Infof("Noop mailer being used for %v", instanceConfig.SiteURL)
 		return &noopMailer{}
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes the following issue
   - User initially signs up with external provider on gotrue
   - User's email with external provider is unverified 
   - User verifies email with external provider OR user changes email with external provider & verifies it
   - User tries to sign-in with external provider on gotrue again 

## Expected behaviour 
* User should be confirmed since the email associated with the external provider has been verified already

>    - User verifies email with external provider OR user changes email with external provider & verifies it
* In the context of the latter, `auth.user.email` shouldn't be updated to reflect the new email associated with the identity
    - we don't update the email in `auth.user.email` because that column has a unique constraint on it
    - there is a possibility that a person has 2 user accounts in gotrue
        * User 1 (password-based), `foo@example.com`, `verified`  
        * User 2 (github sign-in), `bar@example.com`, `not verified` 
        * Person updates email in github to `foo@example.com` and verifies `foo@example.com`
        * When person signs in with github, if User 2's email is updated to `foo@example.com`, there will now be a conflict
        
* `auth.identities.identity_data->>'email'` should reflect the updated email 
   - Reason is because the `identity_data` column should always contain the latest user data from the external oauth provider
* `auth.identities.identity_data->>'email_verified'` should reflect the updated email verified status
   - Same as reason stated above