### PR TITLE
fix: set access_token & refresh_token in cookies 

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -14,8 +14,9 @@ import (
 // requireAuthentication checks incoming requests for tokens presented using the Authorization header
 func (a *API) requireAuthentication(w http.ResponseWriter, r *http.Request) (context.Context, error) {
 	token, err := a.extractBearerToken(w, r)
+	config := getConfig(r.Context())
 	if err != nil {
-		a.clearCookieToken(r.Context(), w)
+		a.clearCookieTokens(config, w)
 		return nil, err
 	}
 
@@ -64,7 +65,7 @@ func (a *API) parseJWTClaims(bearer string, r *http.Request, w http.ResponseWrit
 		return []byte(config.JWT.Secret), nil
 	})
 	if err != nil {
-		a.clearCookieToken(ctx, w)
+		a.clearCookieTokens(config, w)
 		return nil, unauthorizedError("Invalid token: %v", err)
 	}
 

--- a/api/logout.go
+++ b/api/logout.go
@@ -11,8 +11,9 @@ import (
 func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	instanceID := getInstanceID(ctx)
+	config := getConfig(ctx)
 
-	a.clearCookieToken(ctx, w)
+	a.clearCookieTokens(config, w)
 
 	u, err := getUserFromClaims(ctx, a.db)
 	if err != nil {

--- a/api/signup.go
+++ b/api/signup.go
@@ -205,7 +205,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			}
 
 			if cookie != "" && config.Cookie.Duration > 0 {
-				if terr = a.setCookieToken(config, token.Token, cookie == useSessionCookie, w); terr != nil {
+				if terr = a.setCookieTokens(config, token, cookie == useSessionCookie, w); terr != nil {
 					return internalServerError("Failed to set JWT cookie. %s", terr)
 				}
 			}

--- a/api/token.go
+++ b/api/token.go
@@ -523,8 +523,8 @@ func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, u
 // setCookieTokens sets the access_token & refresh_token in the cookies
 func (a *API) setCookieTokens(config *conf.Configuration, token *AccessTokenResponse, session bool, w http.ResponseWriter) error {
 	// don't need to catch error here since we always set the cookie name
-	_ = a.setCookieToken(config, "accesstoken", token.Token, session, w)
-	_ = a.setCookieToken(config, "refreshtoken", token.RefreshToken, session, w)
+	_ = a.setCookieToken(config, "access-token", token.Token, session, w)
+	_ = a.setCookieToken(config, "refresh-token", token.RefreshToken, session, w)
 	return nil
 }
 
@@ -532,7 +532,7 @@ func (a *API) setCookieToken(config *conf.Configuration, name string, tokenStrin
 	if name == "" {
 		return errors.New("Failed to set cookie, invalid name")
 	}
-	cookieName := config.Cookie.Key + "_" + name
+	cookieName := config.Cookie.Key + "-" + name
 	exp := time.Second * time.Duration(config.Cookie.Duration)
 	cookie := &http.Cookie{
 		Name:     cookieName,
@@ -551,14 +551,14 @@ func (a *API) setCookieToken(config *conf.Configuration, name string, tokenStrin
 }
 
 func (a *API) clearCookieTokens(config *conf.Configuration, w http.ResponseWriter) {
-	a.clearCookieToken(config, "accesstoken", w)
-	a.clearCookieToken(config, "refreshtoken", w)
+	a.clearCookieToken(config, "access-token", w)
+	a.clearCookieToken(config, "refresh-token", w)
 }
 
 func (a *API) clearCookieToken(config *conf.Configuration, name string, w http.ResponseWriter) {
 	cookieName := config.Cookie.Key
 	if name != "" {
-		cookieName += "_" + name
+		cookieName += "-" + name
 	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     cookieName,

--- a/api/token.go
+++ b/api/token.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -521,16 +522,17 @@ func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, u
 
 // setCookieTokens sets the access_token & refresh_token in the cookies
 func (a *API) setCookieTokens(config *conf.Configuration, token *AccessTokenResponse, session bool, w http.ResponseWriter) error {
-	_ = a.setCookieToken(config, "access_token", token.Token, session, w)
-	_ = a.setCookieToken(config, "refresh_token", token.RefreshToken, session, w)
+	// don't need to catch error here since we always set the cookie name
+	_ = a.setCookieToken(config, "accesstoken", token.Token, session, w)
+	_ = a.setCookieToken(config, "refreshtoken", token.RefreshToken, session, w)
 	return nil
 }
 
 func (a *API) setCookieToken(config *conf.Configuration, name string, tokenString string, session bool, w http.ResponseWriter) error {
-	cookieName := config.Cookie.Key
-	if name != "" {
-		cookieName += "_" + name
+	if name == "" {
+		return errors.New("Failed to set cookie, invalid name")
 	}
+	cookieName := config.Cookie.Key + "_" + name
 	exp := time.Second * time.Duration(config.Cookie.Duration)
 	cookie := &http.Cookie{
 		Name:     cookieName,
@@ -549,8 +551,8 @@ func (a *API) setCookieToken(config *conf.Configuration, name string, tokenStrin
 }
 
 func (a *API) clearCookieTokens(config *conf.Configuration, w http.ResponseWriter) {
-	a.clearCookieToken(config, "access_token", w)
-	a.clearCookieToken(config, "refresh_token", w)
+	a.clearCookieToken(config, "accesstoken", w)
+	a.clearCookieToken(config, "refreshtoken", w)
 }
 
 func (a *API) clearCookieToken(config *conf.Configuration, name string, w http.ResponseWriter) {

--- a/api/verify.go
+++ b/api/verify.go
@@ -125,7 +125,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 
-		if cookie != "" && config.Cookie.Duration > 0 {
+		if config.Cookie.Duration > 0 {
 			if terr = a.setCookieTokens(config, token, cookie == useSessionCookie, w); terr != nil {
 				return internalServerError("Failed to set JWT cookie. %s", terr)
 			}

--- a/api/verify.go
+++ b/api/verify.go
@@ -126,7 +126,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if cookie != "" && config.Cookie.Duration > 0 {
-			if terr = a.setCookieToken(config, token.Token, cookie == useSessionCookie, w); terr != nil {
+			if terr = a.setCookieTokens(config, token, cookie == useSessionCookie, w); terr != nil {
 				return internalServerError("Failed to set JWT cookie. %s", terr)
 			}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* to start the ball rolling for #279 
* sets access_token and refresh_token as individual cookies

## Steps to test
1. Add this to `.env` file
```
GOTRUE_COOKIE_KEY="sb"
GOTRUE_COOKIE_DURATION="100"
```
2. Update `GOTRUE_MAILER_AUTOCONFIRM=true` in the `.env` file
3. Signup a new user
```
curl -X POST "http://localhost:9999/signup" -H "Content-Type: application/json" -d '{"email": "user@example.com", "password": "secret"}'
```
4. Take note of the refresh token returned above.
5. Try to get a new access token & refresh token
```
curl -X POST 'http://localhost:9999/token?grant_type=refresh_token' \
-d '{"refresh_token": "refresh_token_in_4"}' -H "Content-type: application/json" -H "x-use-cookie: some-value" -v
```

## Expected Output
```
...
* Connected to localhost (127.0.0.1) port 9999 (#0)
> POST /token?grant_type=refresh_token HTTP/1.1
> Host: localhost:9999
> User-Agent: curl/7.77.0
> Accept: */*
> Content-type: application/json
> x-use-cookie: some-value
> Content-Length: 43
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Set-Cookie: sb_accesstoken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...; Path=/; Expires=Thu, 13 Jan 2022 02:51:16 GMT; Max-Age=10; HttpOnly; Secure
< Set-Cookie: sb_refreshtoken=R43XWbVOIvf3RpfK6A1qPg; Path=/; Expires=Thu, 13 Jan 2022 02:51:16 GMT; Max-Age=10; HttpOnly; Secure
< Vary: Origin
< Date: Thu, 13 Jan 2022 02:51:06 GMT
< Content-Length: 1353
< 
* Connection #0 to host localhost left intact
...
```
