### PR TITLE
feat: add basic user banning functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Returns the publicly available settings for this gotrue instance.
 
 ### **POST, PUT /admin/users/<user_id>**
 
-Creates (POST) or Updates (PUT) the user based on the `user_id` specified. The `ban_duration` field accepts the following time units: "ns", "us", "ms", "s", "m", "h". 
+Creates (POST) or Updates (PUT) the user based on the `user_id` specified. The `ban_duration` field accepts the following time units: "ns", "us", "ms", "s", "m", "h". See [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) for more details on the format used.
 
 ```js
 headers:
@@ -535,7 +535,7 @@ body:
   "phone_confirm": true,
   "user_metadata": {},
   "app_metadata": {},
-  "ban_duration": "24h"
+  "ban_duration": "24h" or "none" // to unban a user
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -515,6 +515,30 @@ Returns the publicly available settings for this gotrue instance.
 }
 ```
 
+### **POST, PUT /admin/users/<user_id>**
+
+Creates (POST) or Updates (PUT) the user based on the `user_id` specified. The `ban_duration` field accepts the following time units: "ns", "us", "ms", "s", "m", "h". 
+
+```js
+headers:
+{
+  "Authorization": "Bearer eyJhbGciOiJI...M3A90LCkxxtX9oNP9KZO" // admin role required
+}
+
+body:
+{
+  "role": "test-user",
+  "email": "email@example.com",
+  "phone": "12345678",
+  "password": "secret", // only if type = signup
+  "email_confirm": true,
+  "phone_confirm": true,
+  "user_metadata": {},
+  "app_metadata": {},
+  "ban_duration": "24h"
+}
+```
+
 ### **POST /admin/generate_link**
 
 Returns the corresponding email action link based on the type specified.

--- a/api/admin.go
+++ b/api/admin.go
@@ -163,16 +163,16 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 		if params.BanDuration != "" {
 			if params.BanDuration == RemoveBan {
-				user.BanUntil = nil
+				user.BannedUntil = nil
 			} else {
 				duration, terr := time.ParseDuration(params.BanDuration)
 				if terr != nil {
 					return badRequestError("Invalid format for ban_duration: %v", terr)
 				}
 				t := time.Now().Add(duration)
-				user.BanUntil = &t
+				user.BannedUntil = &t
 			}
-			if terr := user.UpdateBanUntil(tx); terr != nil {
+			if terr := user.UpdateBannedUntil(tx); terr != nil {
 				return terr
 			}
 		}
@@ -271,7 +271,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 			return badRequestError("Invalid format for ban_duration: %v", terr)
 		}
 		t := time.Now().Add(duration)
-		user.BanUntil = &t
+		user.BannedUntil = &t
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {

--- a/api/admin.go
+++ b/api/admin.go
@@ -28,8 +28,6 @@ type adminUserParams struct {
 	BanDuration  string                 `json:"ban_duration"`
 }
 
-const RemoveBan string = "0"
-
 func (a *API) loadUser(w http.ResponseWriter, r *http.Request) (context.Context, error) {
 	userID, err := uuid.FromString(chi.URLParam(r, "user_id"))
 	if err != nil {
@@ -162,7 +160,7 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if params.BanDuration != "" {
-			if params.BanDuration == RemoveBan {
+			if params.BanDuration == "unban" {
 				user.BannedUntil = nil
 			} else {
 				duration, terr := time.ParseDuration(params.BanDuration)

--- a/api/admin.go
+++ b/api/admin.go
@@ -160,7 +160,7 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if params.BanDuration != "" {
-			if params.BanDuration == "unban" {
+			if params.BanDuration == "none" {
 				user.BannedUntil = nil
 			} else {
 				duration, terr := time.ParseDuration(params.BanDuration)

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -416,7 +416,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdate() {
 	assert.Len(ts.T(), data.AppMetaData["roles"], 2)
 	assert.Contains(ts.T(), data.AppMetaData["roles"], "writer")
 	assert.Contains(ts.T(), data.AppMetaData["roles"], "editor")
-	assert.NotNil(ts.T(), data.BanUntil)
+	assert.NotNil(ts.T(), data.BannedUntil)
 }
 
 // TestAdminUserUpdate tests API /admin/user route (UPDATE) as system user
@@ -488,7 +488,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdatePasswordFailed() {
 	})
 }
 
-func (ts *AdminTestSuite) TestAdminUserUpdateBanUntilFailed() {
+func (ts *AdminTestSuite) TestAdminUserUpdateBannedUntilFailed() {
 	u, err := models.NewUser(ts.instanceID, "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")

--- a/api/external.go
+++ b/api/external.go
@@ -224,6 +224,10 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 				}
 			}
 
+			if user.IsBanned() {
+				return unauthorizedError("User is unauthorized")
+			}
+
 			if !user.IsConfirmed() {
 				if !emailData.Verified && !config.Mailer.Autoconfirm {
 					return badRequestError("Please verify your email (%v) with %v", emailData.Email, providerType)

--- a/api/external_github_test.go
+++ b/api/external_github_test.go
@@ -5,8 +5,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"time"
 
 	jwt "github.com/golang-jwt/jwt"
+	"github.com/netlify/gotrue/models"
+	"github.com/stretchr/testify/require"
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalGithub() {
@@ -195,4 +198,24 @@ func (ts *ExternalTestSuite) TestSignupExternalGitHubErrorWhenVerifiedFalse() {
 	u := performAuthorization(ts, "github", code, "")
 
 	assertAuthorizationFailure(ts, u, "Please verify your email (github@example.com) with github", "invalid_request", "")
+}
+
+func (ts *ExternalTestSuite) TestSignupExternalGitHubErrorWhenUserBanned() {
+	tokenCount, userCount := 0, 0
+	code := "authcode"
+	emails := `[{"email":"github@example.com", "primary": true, "verified": true}]`
+	server := GitHubTestSignupSetup(ts, &tokenCount, &userCount, code, emails)
+	defer server.Close()
+
+	u := performAuthorization(ts, "github", code, "")
+	assertAuthorizationSuccess(ts, u, tokenCount, userCount, "github@example.com", "GitHub Test", "123", "http://example.com/avatar")
+
+	user, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "github@example.com", ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+	t := time.Now().Add(24 * time.Hour)
+	user.BanUntil = &t
+	require.NoError(ts.T(), ts.API.db.UpdateOnly(user, "ban_until"))
+
+	u = performAuthorization(ts, "github", code, "")
+	assertAuthorizationFailure(ts, u, "User is unauthorized", "unauthorized_client", "")
 }

--- a/api/external_github_test.go
+++ b/api/external_github_test.go
@@ -213,8 +213,8 @@ func (ts *ExternalTestSuite) TestSignupExternalGitHubErrorWhenUserBanned() {
 	user, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "github@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	t := time.Now().Add(24 * time.Hour)
-	user.BanUntil = &t
-	require.NoError(ts.T(), ts.API.db.UpdateOnly(user, "ban_until"))
+	user.BannedUntil = &t
+	require.NoError(ts.T(), ts.API.db.UpdateOnly(user, "banned_until"))
 
 	u = performAuthorization(ts, "github", code, "")
 	assertAuthorizationFailure(ts, u, "User is unauthorized", "unauthorized_client", "")

--- a/api/token.go
+++ b/api/token.go
@@ -174,7 +174,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		return internalServerError("Database error querying schema").WithInternalError(err)
 	}
 
-	if !user.Authenticate(params.Password) {
+	if user.IsBanned() || !user.Authenticate(params.Password) {
 		return oauthError("invalid_grant", InvalidLoginMessage)
 	}
 
@@ -238,6 +238,10 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 			return oauthError("invalid_grant", "Invalid Refresh Token")
 		}
 		return internalServerError(err.Error())
+	}
+
+	if user.IsBanned() {
+		return oauthError("invalid_grant", "Invalid Refresh Token")
 	}
 
 	if !(config.External.Email.Enabled && config.External.Phone.Enabled) {
@@ -400,6 +404,9 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 			}
 			if email != "" {
 				identity.IdentityData["email"] = email
+			}
+			if user.IsBanned() {
+				return oauthError("invalid_grant", "invalid id token grant")
 			}
 			if terr = tx.UpdateOnly(identity, "identity_data", "last_sign_in_at"); terr != nil {
 				return terr

--- a/api/token_test.go
+++ b/api/token_test.go
@@ -50,6 +50,7 @@ func (ts *TokenTestSuite) SetupTest() {
 	require.NoError(ts.T(), err, "Error creating test user model")
 	t := time.Now()
 	u.EmailConfirmedAt = &t
+	u.BanUntil = nil
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 
 	ts.RefreshToken, err = models.GrantAuthenticatedUser(ts.API.db, u)
@@ -154,7 +155,8 @@ func (ts *TokenTestSuite) createBannedUser() *models.User {
 	require.NoError(ts.T(), err, "Error creating test user model")
 	t := time.Now()
 	u.EmailConfirmedAt = &t
-	u.BanUntil = time.Now().Add(24 * time.Hour)
+	t = t.Add(24 * time.Hour)
+	u.BanUntil = &t
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test banned user")
 
 	ts.RefreshToken, err = models.GrantAuthenticatedUser(ts.API.db, u)

--- a/api/token_test.go
+++ b/api/token_test.go
@@ -50,7 +50,7 @@ func (ts *TokenTestSuite) SetupTest() {
 	require.NoError(ts.T(), err, "Error creating test user model")
 	t := time.Now()
 	u.EmailConfirmedAt = &t
-	u.BanUntil = nil
+	u.BannedUntil = nil
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 
 	ts.RefreshToken, err = models.GrantAuthenticatedUser(ts.API.db, u)
@@ -156,7 +156,7 @@ func (ts *TokenTestSuite) createBannedUser() *models.User {
 	t := time.Now()
 	u.EmailConfirmedAt = &t
 	t = t.Add(24 * time.Hour)
-	u.BanUntil = &t
+	u.BannedUntil = &t
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test banned user")
 
 	ts.RefreshToken, err = models.GrantAuthenticatedUser(ts.API.db, u)

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -119,7 +119,7 @@ func (ts *VerifyTestSuite) TestExpiredConfirmationToken() {
 	w := httptest.NewRecorder()
 
 	ts.API.handler.ServeHTTP(w, req)
-	assert.Equal(ts.T(), http.StatusFound, w.Code)
+	assert.Equal(ts.T(), http.StatusSeeOther, w.Code)
 
 	url, err := w.Result().Location()
 	require.NoError(ts.T(), err)
@@ -140,7 +140,7 @@ func (ts *VerifyTestSuite) TestInvalidSmsOtp() {
 	}
 
 	expectedResponse := expected{
-		code:      http.StatusFound,
+		code:      http.StatusSeeOther,
 		fragments: "error_code=410&error_description=Otp+has+expired+or+is+invalid",
 	}
 
@@ -222,7 +222,7 @@ func (ts *VerifyTestSuite) TestExpiredRecoveryToken() {
 
 	ts.API.handler.ServeHTTP(w, req)
 
-	assert.Equal(ts.T(), http.StatusFound, w.Code, w.Body.String())
+	assert.Equal(ts.T(), http.StatusSeeOther, w.Code, w.Body.String())
 }
 
 func (ts *VerifyTestSuite) TestVerifyPermitedCustomUri() {

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -387,7 +387,7 @@ func (ts *VerifyTestSuite) TestVerifyBannedUser() {
 	u.EmailChangeSentAt = &t
 
 	t = time.Now().Add(24 * time.Hour)
-	u.BanUntil = &t
+	u.BannedUntil = &t
 	require.NoError(ts.T(), ts.API.db.Update(u))
 
 	cases := []struct {

--- a/migrations/20220114185221_update_user_idx.up.sql
+++ b/migrations/20220114185221_update_user_idx.up.sql
@@ -1,0 +1,4 @@
+-- updates users_instance_id_email_idx definition
+
+DROP INDEX IF EXISTS users_instance_id_email_idx;
+CREATE INDEX IF NOT EXISTS users_instance_id_email_idx on users using btree (instance_id, lower(email));

--- a/migrations/20220114185340_add_ban_until.up.sql
+++ b/migrations/20220114185340_add_ban_until.up.sql
@@ -1,0 +1,4 @@
+-- adds ban_until column
+
+ALTER TABLE auth.users
+ADD COLUMN IF NOT EXISTS ban_until timestamptz NULL;

--- a/migrations/20220114185340_add_ban_until.up.sql
+++ b/migrations/20220114185340_add_ban_until.up.sql
@@ -1,4 +1,0 @@
--- adds ban_until column
-
-ALTER TABLE auth.users
-ADD COLUMN IF NOT EXISTS ban_until timestamptz NULL;

--- a/migrations/20220114185340_add_banned_until.up.sql
+++ b/migrations/20220114185340_add_banned_until.up.sql
@@ -1,0 +1,4 @@
+-- adds banned_until column
+
+ALTER TABLE auth.users
+ADD COLUMN IF NOT EXISTS banned_until timestamptz NULL;

--- a/models/user.go
+++ b/models/user.go
@@ -58,9 +58,9 @@ type User struct {
 	IsSuperAdmin bool       `json:"-" db:"is_super_admin"`
 	Identities   []Identity `json:"identities" has_many:"identities"`
 
-	CreatedAt time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
-	BanUntil  time.Time `json:"ban_until,omitempty" db:"ban_until"`
+	CreatedAt time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
+	BanUntil  *time.Time `json:"ban_until,omitempty" db:"ban_until"`
 }
 
 // NewUser initializes a new user from an email, password and user data.
@@ -147,6 +147,9 @@ func (u *User) BeforeSave(tx *pop.Connection) error {
 	}
 	if u.LastSignInAt != nil && u.LastSignInAt.IsZero() {
 		u.LastSignInAt = nil
+	}
+	if u.BanUntil != nil && u.BanUntil.IsZero() {
+		u.BanUntil = nil
 	}
 	return nil
 }
@@ -460,5 +463,8 @@ func IsDuplicatedPhone(tx *storage.Connection, instanceID uuid.UUID, phone, aud 
 
 // IsBanned checks if a user is banned or not
 func (u *User) IsBanned() bool {
-	return time.Now().Before(u.BanUntil)
+	if u.BanUntil == nil {
+		return false
+	}
+	return time.Now().Before(*u.BanUntil)
 }

--- a/models/user.go
+++ b/models/user.go
@@ -60,6 +60,7 @@ type User struct {
 
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
+	BanUntil  time.Time `json:"ban_until,omitempty" db:"ban_until"`
 }
 
 // NewUser initializes a new user from an email, password and user data.
@@ -455,4 +456,9 @@ func IsDuplicatedPhone(tx *storage.Connection, instanceID uuid.UUID, phone, aud 
 		return false, err
 	}
 	return true, nil
+}
+
+// IsBanned checks if a user is banned or not
+func (u *User) IsBanned() bool {
+	return time.Now().Before(u.BanUntil)
 }

--- a/models/user.go
+++ b/models/user.go
@@ -58,9 +58,9 @@ type User struct {
 	IsSuperAdmin bool       `json:"-" db:"is_super_admin"`
 	Identities   []Identity `json:"identities" has_many:"identities"`
 
-	CreatedAt time.Time  `json:"created_at" db:"created_at"`
-	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
-	BanUntil  *time.Time `json:"ban_until,omitempty" db:"ban_until"`
+	CreatedAt   time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at" db:"updated_at"`
+	BannedUntil *time.Time `json:"banned_until,omitempty" db:"banned_until"`
 }
 
 // NewUser initializes a new user from an email, password and user data.
@@ -148,8 +148,8 @@ func (u *User) BeforeSave(tx *pop.Connection) error {
 	if u.LastSignInAt != nil && u.LastSignInAt.IsZero() {
 		u.LastSignInAt = nil
 	}
-	if u.BanUntil != nil && u.BanUntil.IsZero() {
-		u.BanUntil = nil
+	if u.BannedUntil != nil && u.BannedUntil.IsZero() {
+		u.BannedUntil = nil
 	}
 	return nil
 }
@@ -463,13 +463,13 @@ func IsDuplicatedPhone(tx *storage.Connection, instanceID uuid.UUID, phone, aud 
 
 // IsBanned checks if a user is banned or not
 func (u *User) IsBanned() bool {
-	if u.BanUntil == nil {
+	if u.BannedUntil == nil {
 		return false
 	}
-	return time.Now().Before(*u.BanUntil)
+	return time.Now().Before(*u.BannedUntil)
 }
 
-func (u *User) UpdateBanUntil(tx *storage.Connection) error {
-	return tx.UpdateOnly(u, "ban_until")
+func (u *User) UpdateBannedUntil(tx *storage.Connection) error {
+	return tx.UpdateOnly(u, "banned_until")
 
 }

--- a/models/user.go
+++ b/models/user.go
@@ -468,3 +468,8 @@ func (u *User) IsBanned() bool {
 	}
 	return time.Now().Before(*u.BanUntil)
 }
+
+func (u *User) UpdateBanUntil(tx *storage.Connection) error {
+	return tx.UpdateOnly(u, "ban_until")
+
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds a `ban_until` column in `auth.users` to restrict specific user access until a certain time.
* `GET /admin/users` should allow filtering by users
* `PUT /admin/users/<user_id>` should allow banning an existing user
  - Update `adminUserParams` struct to include a `BanDuration` field
  - Decided to use a duration rather than a timestamp or boolean since it seems like the best DX (users don't have to worry about following go's time format) and provides greater flexibility over a bool
* fixes #41
 
## Considerations
* Decided not to go with a middleware approach in view of having to make an extra query to the database to check if a user is banned or not. 
* The current implementation makes use of the existing query used to fetch the user and checks the `ban_until` column.
* Even though the current implementation requires more code repetition (more lines of `if user.IsBanned() { ... }`), the api performance won't be compromised.  

## Todo
- [x] Add `ban_until` column in `users` table
- [x] Check if user is banned in `/token` 
- [x] Check if user is banned in `/verify` 
- [x] Check if user is banned in `/callback`
- [x] PUT /admin/users/<user_id> should allow banning an existing user
- [ ] GET /admin/users should allow filtering by banned users (to be fixed in another PR)
