### PR TITLE
`/logout`: allow removal of specific refresh token families

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,8 +878,17 @@ Returns:
 
 Logout a user (Requires authentication).
 
-This will revoke all refresh tokens for the user. Remember that the JWT tokens
+If a specific refresh token is provided, that refresh token (and all others descending from it)
+will be revoked. Otherwise, all refresh tokens for the user will be revoked. Remember that the JWT tokens
 will still be valid for stateless auth until they expires.
+
+Body (optional):
+
+```json
+{
+  "refresh_token": "a-refresh-token"
+}
+```
 
 ### **GET /authorize**
 

--- a/api/logout.go
+++ b/api/logout.go
@@ -40,8 +40,15 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 		return unauthorizedError("Invalid user").WithInternalError(err)
 	}
 
+	var traits map[string]interface{} = nil;
+	if refreshToken != "" {
+		traits = map[string]interface{}{
+			"refresh_token": refreshToken,
+		}
+	}
+
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(tx, instanceID, u, models.LogoutAction, nil); terr != nil {
+		if terr := models.NewAuditLogEntry(tx, instanceID, u, models.LogoutAction, traits); terr != nil {
 			return terr
 		}
 		return models.Logout(tx, instanceID, u.ID, refreshToken)

--- a/api/logout.go
+++ b/api/logout.go
@@ -1,17 +1,37 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 )
 
+type LogoutParams struct {
+	RefreshToken *string `json:"refresh_token"`
+}
+
+func getLogoutRefreshToken(a *API, r *http.Request) (string, error) {
+	params := LogoutParams{}
+	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+		return "", badRequestError("Could not decode logout params: %v", err)
+	}
+	if params.RefreshToken == nil {
+		return "", nil
+	}
+	return *params.RefreshToken, nil
+}
+
 // Logout is the endpoint for logging out a user and thereby revoking any refresh tokens
 func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	instanceID := getInstanceID(ctx)
 	config := getConfig(ctx)
+	refreshToken, err := getLogoutRefreshToken(a, r)
+	if err != nil {
+		return badRequestError("Could not read logout request parameters").WithInternalError(err)
+	}
 
 	a.clearCookieTokens(config, w)
 
@@ -24,7 +44,7 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(tx, instanceID, u, models.LogoutAction, nil); terr != nil {
 			return terr
 		}
-		return models.Logout(tx, instanceID, u.ID)
+		return models.Logout(tx, instanceID, u.ID, refreshToken)
 	})
 	if err != nil {
 		return internalServerError("Error logging out user").WithInternalError(err)

--- a/api/logout.go
+++ b/api/logout.go
@@ -40,7 +40,7 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 		return unauthorizedError("Invalid user").WithInternalError(err)
 	}
 
-	var traits map[string]interface{} = nil;
+	var traits map[string]interface{} = nil
 	if refreshToken != "" {
 		traits = map[string]interface{}{
 			"refresh_token": refreshToken,

--- a/api/logout.go
+++ b/api/logout.go
@@ -40,7 +40,7 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 		return unauthorizedError("Invalid user").WithInternalError(err)
 	}
 
-	var traits map[string]interface{} = nil
+	var traits map[string]interface{}
 	if refreshToken != "" {
 		traits = map[string]interface{}{
 			"refresh_token": refreshToken,

--- a/models/refresh_token_test.go
+++ b/models/refresh_token_test.go
@@ -62,15 +62,51 @@ func (ts *RefreshTokenTestSuite) TestGrantRefreshTokenSwap() {
 	require.Equal(ts.T(), u.ID, s.UserID)
 }
 
-func (ts *RefreshTokenTestSuite) TestLogout() {
+func (ts *RefreshTokenTestSuite) TestLogoutSingleRefreshTokenFamily() {
+	u := ts.createUser()
+	// Create 1st refresh token family.
+	r, err := GrantAuthenticatedUser(ts.db, u)
+	require.NoError(ts.T(), err)
+	s, err := GrantRefreshTokenSwap(ts.db, u, r)
+	require.NoError(ts.T(), err)
+
+	// Create 2nd refresh token family.
+	t, err := GrantAuthenticatedUser(ts.db, u)
+	require.NoError(ts.T(), err)
+
+	// Logout of first refresh token family.
+	require.NoError(ts.T(), Logout(ts.db, uuid.Nil, u.ID, r.Token))
+
+	// Check that first refresh token family has been deleted.
+	u, r, err = FindUserWithRefreshToken(ts.db, r.Token)
+	require.Errorf(ts.T(), err, "expected error when there are no refresh tokens to authenticate. user: %v token: %v", u, r)
+	require.True(ts.T(), IsNotFoundError(err), "expected NotFoundError")
+	u, s, err = FindUserWithRefreshToken(ts.db, s.Token)
+	require.Errorf(ts.T(), err, "expected error when there are no refresh tokens to authenticate. user: %v token: %v", u, s)
+	require.True(ts.T(), IsNotFoundError(err), "expected NotFoundError")
+
+	// Check that second refresh token family has not been deleted.
+	_, nt, err := FindUserWithRefreshToken(ts.db, t.Token)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), t.ID, nt.ID)
+}
+
+func (ts *RefreshTokenTestSuite) TestLogoutAllRefreshTokens() {
+	// Create 2 refresh tokens.
 	u := ts.createUser()
 	r, err := GrantAuthenticatedUser(ts.db, u)
 	require.NoError(ts.T(), err)
+	s, err := GrantAuthenticatedUser(ts.db, u)
+	require.NoError(ts.T(), err)
 
-	require.NoError(ts.T(), Logout(ts.db, uuid.Nil, u.ID))
+	require.NoError(ts.T(), Logout(ts.db, uuid.Nil, u.ID, ""))
+	
+	// Check that both refresh tokens have been deleted.
 	u, r, err = FindUserWithRefreshToken(ts.db, r.Token)
 	require.Errorf(ts.T(), err, "expected error when there are no refresh tokens to authenticate. user: %v token: %v", u, r)
-
+	require.True(ts.T(), IsNotFoundError(err), "expected NotFoundError")
+	u, s, err = FindUserWithRefreshToken(ts.db, s.Token)
+	require.Errorf(ts.T(), err, "expected error when there are no refresh tokens to authenticate. user: %v token: %v", u, s)
 	require.True(ts.T(), IsNotFoundError(err), "expected NotFoundError")
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

`/logout` will remove all refresh tokens, which can lead to unexpected behaviour. Eg. signing out on 1 device will lead to signing out of all devices. See #248.

## What is the new behavior?

Allow the `/logout` endpoint to accept a specific refresh token to remove. Otherwise, the default behaviour persists and all refresh tokens associated with the user are removed.

## Note

This will need to be accompanied by a PR to `gotrue-js`.