### PR TITLE
resolve #94, #159, #292 and #299

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -351,7 +351,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 	} else if params.ClientID != "" && params.Issuer != "" {
 		verifier, err = params.getVerifierFromClientIDandIssuer(ctx)
 	} else {
-		return err
+		return badRequestError("%v", err)
 	}
 	if err != nil {
 		return err

--- a/api/token.go
+++ b/api/token.go
@@ -359,7 +359,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	idToken, err := verifier.Verify(ctx, params.IdToken)
 	if err != nil {
-		return badRequestError("%v", err)
+		return err
 	}
 
 	claims := make(map[string]interface{})

--- a/api/token.go
+++ b/api/token.go
@@ -354,7 +354,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 		return badRequestError("%v", err)
 	}
 	if err != nil {
-		return err
+		return badRequestError("%v", err)
 	}
 
 	idToken, err := verifier.Verify(ctx, params.IdToken)

--- a/api/token.go
+++ b/api/token.go
@@ -354,12 +354,12 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 		return badRequestError("%v", err)
 	}
 	if err != nil {
-		return badRequestError("%v", err)
+		return err
 	}
 
 	idToken, err := verifier.Verify(ctx, params.IdToken)
 	if err != nil {
-		return err
+		return badRequestError("%v", err)
 	}
 
 	claims := make(map[string]interface{})

--- a/api/token.go
+++ b/api/token.go
@@ -346,11 +346,12 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	var verifier *oidc.IDTokenVerifier
 	var err error
-	if params.ClientID == "" || params.Issuer == "" {
+	if params.Provider != "" {
 		verifier, err = params.getVerifier(ctx)
-	}
-	if params.Provider == "" {
+	} else if params.ClientID != "" && params.Issuer != "" {
 		verifier, err = params.getVerifierFromClientIDandIssuer(ctx)
+	} else {
+		return err
 	}
 	if err != nil {
 		return err

--- a/api/token.go
+++ b/api/token.go
@@ -345,6 +345,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 	}
 
 	var verifier *oidc.IDTokenVerifier
+	var err error
 	if params.ClientID == "" || params.Issuer == "" {
 		verifier, err = params.getVerifier(ctx)
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

resolve this issue

#94 Self hosted Gitlab login provider support by exposing GOTRUE_EXTERNAL_GITLAB_URL as setting in UI
#159 Support arbitrary OpenID Connect providers for external authentication
#292 Allow org-specific endpoint to be specified for Azure OAuth provider
#299 Generic OpenID Connect auth provider

## What is the current behavior?

#94 Self hosted Gitlab login provider support by exposing GOTRUE_EXTERNAL_GITLAB_URL as setting in UI
#159 Support arbitrary OpenID Connect providers for external authentication
#292 Allow org-specific endpoint to be specified for Azure OAuth provider
#299 Generic OpenID Connect auth provider

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

https://github.com/supabase/supabase/pull/5181
