### PR TITLE
fix: block bots from consuming verification tokens

### DIFF
--- a/api/verify.go
+++ b/api/verify.go
@@ -12,6 +12,7 @@ import (
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 	"github.com/sethvargo/go-password/password"
+	"github.com/x-way/crawlerdetect"
 )
 
 var (
@@ -52,6 +53,11 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	switch r.Method {
 	// GET only supports signup type
 	case "GET":
+		// detect bots and crawlers to prevent email
+		// clients "link previewing" and expiring the token
+		if crawlerdetect.IsCrawler(r.Header.Get("User-Agent")) {
+			return unprocessableEntityError("Verify has detected a bot and will reject to prevent the token expiring")
+		}
 		params.Token = r.FormValue("token")
 		params.Password = ""
 		params.Type = r.FormValue("type")

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.6.1
+	github.com/x-way/crawlerdetect v0.2.15
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43

--- a/go.sum
+++ b/go.sum
@@ -552,6 +552,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/x-way/crawlerdetect v0.2.15 h1:tCWb1LMRtRrnH/aaxDErh5+uZObW9Rr8Qin+kjCpE98=
+github.com/x-way/crawlerdetect v0.2.15/go.mod h1:XaWyDjBjCrBR7hFnRUX+pvQvdW3oMOAkoke+Rmy3pl8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
fixes: https://github.com/supabase/gotrue/issues/368

was unsure how to scope this, decided to do it just on the GET requests to `/verify` in case people have automation on other endpoints or methods

need to find a email client that reliably does this to test that this actually works in a production environment