### PR TITLE
fix: send otp in email link

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ Sets the name of the sender. Defaults to the `SMTP_ADMIN_EMAIL` if not used.
 
 If you do not require email confirmation, you may set this to `true`. Defaults to `false`.
 
+`MAILER_OTP_EXP` - `number`
+
+Controls the duration an email link or otp is valid for.
+
 `MAILER_URLPATHS_INVITE` - `string`
 
 URL path to use in the user invite email. Defaults to `/`.

--- a/api/verify.go
+++ b/api/verify.go
@@ -328,6 +328,7 @@ func (v *VerifyParams) VerifyUser(ctx context.Context, conn *storage.Connection,
 	var user *models.User
 	var err error
 	if v.Email != "" {
+		// email_change should use old email for otp verification
 		user, err = models.FindUserByEmailAndAudience(conn, instanceID, v.Email, aud)
 	} else if v.Phone != "" {
 		user, err = models.FindUserByPhoneAndAudience(conn, instanceID, v.Phone, aud)
@@ -363,6 +364,7 @@ func (v *VerifyParams) VerifyUser(ctx context.Context, conn *storage.Connection,
 		expiresAt := user.EmailChangeSentAt.Add(24 * time.Hour)
 		isValid = isOtpValid(v.Token, user.EmailChangeTokenCurrent, expiresAt) || isOtpValid(v.Token, user.EmailChangeTokenNew, expiresAt)
 		if !isValid {
+			// reset email confirmation status
 			user.EmailChangeConfirmStatus = zeroConfirmation
 			err = conn.UpdateOnly(user, "email_change_confirm_status")
 		}

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -123,7 +123,7 @@ func (ts *VerifyTestSuite) TestExpiredConfirmationToken() {
 
 	url, err := w.Result().Location()
 	require.NoError(ts.T(), err)
-	assert.Equal(ts.T(), "error_code=410&error_description=Confirmation+token+expired", url.Fragment)
+	assert.Equal(ts.T(), "error_code=410&error_description=Token+has+expired+or+is+invalid", url.Fragment)
 }
 
 func (ts *VerifyTestSuite) TestInvalidSmsOtp() {
@@ -141,7 +141,7 @@ func (ts *VerifyTestSuite) TestInvalidSmsOtp() {
 
 	expectedResponse := expected{
 		code:      http.StatusSeeOther,
-		fragments: "error_code=410&error_description=Otp+has+expired+or+is+invalid",
+		fragments: "error_code=410&error_description=Token+has+expired+or+is+invalid",
 	}
 
 	cases := []struct {

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -50,7 +50,7 @@ func (ts *VerifyTestSuite) SetupTest() {
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 }
 
-func (ts *VerifyTestSuite) TestVerify_PasswordRecovery() {
+func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.RecoverySentAt = &time.Time{}
@@ -96,7 +96,7 @@ func (ts *VerifyTestSuite) TestVerify_PasswordRecovery() {
 	assert.True(ts.T(), u.IsConfirmed())
 }
 
-func (ts *VerifyTestSuite) TestVerify_SecureEmailChange() {
+func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.EmailChangeSentAt = &time.Time{}
@@ -195,7 +195,7 @@ func (ts *VerifyTestSuite) TestExpiredConfirmationToken() {
 	assert.Equal(ts.T(), "error_code=410&error_description=Token+has+expired+or+is+invalid", url.Fragment)
 }
 
-func (ts *VerifyTestSuite) TestInvalidSmsOtp() {
+func (ts *VerifyTestSuite) TestInvalidOtp() {
 	u, err := models.FindUserByPhoneAndAudience(ts.API.db, ts.instanceID, "12345678", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.ConfirmationToken = "123456"
@@ -220,7 +220,7 @@ func (ts *VerifyTestSuite) TestInvalidSmsOtp() {
 		expected
 	}{
 		{
-			desc:     "Expired OTP",
+			desc:     "Expired Sms OTP",
 			sentTime: time.Now().Add(-48 * time.Hour),
 			body: map[string]interface{}{
 				"type":  smsVerification,
@@ -230,12 +230,22 @@ func (ts *VerifyTestSuite) TestInvalidSmsOtp() {
 			expected: expectedResponse,
 		},
 		{
-			desc:     "Incorrect OTP",
+			desc:     "Invalid Sms OTP",
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":  smsVerification,
-				"token": "incorrect_otp",
+				"token": "invalid_otp",
 				"phone": u.GetPhone(),
+			},
+			expected: expectedResponse,
+		},
+		{
+			desc:     "Invalid Email OTP",
+			sentTime: time.Now(),
+			body: map[string]interface{}{
+				"type":  signupVerification,
+				"token": "invalid_otp",
+				"email": u.GetEmail(),
 			},
 			expected: expectedResponse,
 		},

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -118,6 +118,7 @@ type MailerConfiguration struct {
 	Templates                EmailContentConfiguration `json:"templates"`
 	URLPaths                 EmailContentConfiguration `json:"url_paths"`
 	SecureEmailChangeEnabled bool                      `json:"secure_email_change_enabled" split_words:"true" default:"true"`
+	OtpExp                   uint                      `json:"otp_exp" split_words:"true"`
 }
 
 type PhoneProviderConfiguration struct {
@@ -275,14 +276,21 @@ func (config *Configuration) ApplyDefaults() {
 	if config.Mailer.URLPaths.Invite == "" {
 		config.Mailer.URLPaths.Invite = "/"
 	}
+
 	if config.Mailer.URLPaths.Confirmation == "" {
 		config.Mailer.URLPaths.Confirmation = "/"
 	}
+
 	if config.Mailer.URLPaths.Recovery == "" {
 		config.Mailer.URLPaths.Recovery = "/"
 	}
+
 	if config.Mailer.URLPaths.EmailChange == "" {
 		config.Mailer.URLPaths.EmailChange = "/"
+	}
+
+	if config.Mailer.OtpExp == 0 {
+		config.Mailer.OtpExp = 86400 // 1 day
 	}
 
 	if config.SMTP.MaxFrequency == 0 {

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -21,27 +21,33 @@ var configFile = ""
 const defaultInviteMail = `<h2>You have been invited</h2>
 
 <p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>
-<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>`
+<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>
+<p>Alternatively, enter the code: {{ .Token }}</p>`
 
 const defaultConfirmationMail = `<h2>Confirm your email</h2>
 
 <p>Follow this link to confirm your email:</p>
-<p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>`
+<p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>
+<p>Alternatively, enter the code: {{ .Token }}</p>
+`
 
 const defaultRecoveryMail = `<h2>Reset password</h2>
 
 <p>Follow this link to reset the password for your user:</p>
-<p><a href="{{ .ConfirmationURL }}">Reset password</a></p>`
+<p><a href="{{ .ConfirmationURL }}">Reset password</a></p>
+<p>Alternatively, enter the code: {{ .Token }}</p>`
 
 const defaultMagicLinkMail = `<h2>Magic Link</h2>
 
 <p>Follow this link to login:</p>
-<p><a href="{{ .ConfirmationURL }}">Log In</a></p>`
+<p><a href="{{ .ConfirmationURL }}">Log In</a></p>
+<p>Alternatively, enter the code: {{ .Token }}</p>`
 
 const defaultEmailChangeMail = `<h2>Confirm email address change</h2>
 
 <p>Follow this link to confirm the update of your email address from {{ .Email }} to {{ .NewEmail }}:</p>
-<p><a href="{{ .ConfirmationURL }}">Change email address</a></p>`
+<p><a href="{{ .ConfirmationURL }}">Change email address</a></p>
+<p>Alternatively, enter the code: {{ .Token }}</p>`
 
 // ValidateEmail returns nil if the email is valid,
 // otherwise an error indicating the reason it is invalid


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #139, #264, #368 
* Sends the OTP (which can either be a confirmation / invite / recovery / email change token) in the email together with the url link
* Developers can choose to omit `{{ .ConfirmationURL }}` from their email templates to prevent cases where email clients preview the URL thus resulting in the token being consumed. (addresses #368)

## API Additions / Changes
1. `POST /verify` now accepts an `email` field which would be used together with the token to verify the user. 
```json
{
  "type": "signup",
  "email": "foo@example.com",
  "token": "random token",
  "redirect_to": "my_redirect_to_url"
}
```

2. If `type=email_change` and `MAILER_SECURE_EMAIL_CHANGE_ENABLED=true`, the old email will be used for verifying both OTPs sent to the old and new email address.

## Implementation Details
1. I refactored the common parts in `signupVerify`, `recoverVerify`, `emailChangeVerify` and `smsVerify` into a new function called `verifyUserAndToken` 
2. `verifyUserAndToken` does the following:
    * Checks if the verification is an url or otp verification
    * If it's an otp verification, check if its an sms or email otp.
3. Checks if the user is banned
4. Checks if the otp is valid

## To-Dos:
- [x] Allow url link / otp expiration to be configurable rather than restricted to 24hrs 
- [ ] Send a human-readable hash / slug instead of an otp (will be added as an enhancement in a separate PR)

