### PR TITLE
fix: add Slack Team ID custom claim

### DIFF
--- a/api/provider/slack.go
+++ b/api/provider/slack.go
@@ -22,6 +22,7 @@ type slackUser struct {
 	Email     string `json:"email"`
 	Name      string `json:"name"`
 	AvatarURL string `json:"picture"`
+	TeamID    string `json:"https://slack.com/team_id"`
 }
 
 // NewSlackProvider creates a Slack account provider.
@@ -80,6 +81,9 @@ func (g slackProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 			Picture:       u.AvatarURL,
 			Email:         u.Email,
 			EmailVerified: true, // Slack dosen't provide data on if email is verified.
+			CustomClaims: map[string]interface{}{
+				"https://slack.com/team_id": u.TeamID,
+			},
 
 			// To be deprecated
 			AvatarURL:  u.AvatarURL,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This change adds Slack's `https://slack.com/team_id` as a custom claim.

## What is the current behavior?

Right now, it is difficult to use Supabase for apps that use Slack workspace membership as an authorization mechanism.

## What is the new behavior?

With this change, a user's Slack team ID is included in the `identity_data` column.

## Additional context

Slack API response [documentation](https://api.slack.com/authentication/sign-in-with-slack#response)
