### PR TITLE
fix: magiclink & recover verification should send login instead of signup action

### DIFF
--- a/api/verify.go
+++ b/api/verify.go
@@ -200,7 +200,7 @@ func (a *API) recoverVerify(ctx context.Context, conn *storage.Connection, user 
 			return terr
 		}
 		if !user.IsConfirmed() {
-			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
+			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, nil); terr != nil {
 				return terr
 			}
 


### PR DESCRIPTION
* Currently, the verification for a magiclink / recover sends a sign up action to the audit_log_entries table.
* We should be sending a login action instead.


