### PR TITLE
fix: add login event to recover / magiclink verify

### DIFF
--- a/api/verify.go
+++ b/api/verify.go
@@ -200,7 +200,7 @@ func (a *API) recoverVerify(ctx context.Context, conn *storage.Connection, user 
 			return terr
 		}
 		if !user.IsConfirmed() {
-			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
+			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, nil); terr != nil {
 				return terr
 			}
 

--- a/api/verify.go
+++ b/api/verify.go
@@ -200,7 +200,7 @@ func (a *API) recoverVerify(ctx context.Context, conn *storage.Connection, user 
 			return terr
 		}
 		if !user.IsConfirmed() {
-			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, nil); terr != nil {
+			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
 				return terr
 			}
 
@@ -208,6 +208,13 @@ func (a *API) recoverVerify(ctx context.Context, conn *storage.Connection, user 
 				return terr
 			}
 			if terr = user.Confirm(tx); terr != nil {
+				return terr
+			}
+		} else {
+			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, nil); terr != nil {
+				return terr
+			}
+			if terr = triggerEventHooks(ctx, tx, LoginEvent, user, instanceID, config); terr != nil {
 				return terr
 			}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* recover verify should log a login action if the user is confirmed