### PR TITLE
fix: return user for POST verify endpoints

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -224,7 +224,6 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			return err
 		}
 		metering.RecordLogin("password", user.ID, instanceID)
-		token.User = user
 		return sendJSON(w, http.StatusOK, token)
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #141 
* Decided that for DX purposes, returning the user object after verification is fine.
* Unblocks https://github.com/supabase/gotrue-js/pull/228

