### PR TITLE
fix: update password min length config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Header on which to rate limit the `/token` endpoint.
 
 Rate limit the number of emails sent per hr on the following endpoints: `/signup`, `/invite`, `/magiclink`, `/recover`, `/otp`, & `/user`.
 
-`PASSWORD_MIN_LENGTH` - `int`
+`GOTRUE_PASSWORD_MIN_LENGTH` - `int`
 
 Minimum password length, defaults to 6.
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -11,6 +11,8 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
+const defaultMinPasswordLength int = 6
+
 // OAuthProviderConfiguration holds all config related to external account providers.
 type OAuthProviderConfiguration struct {
 	ClientID    string `json:"client_id" split_words:"true"`
@@ -176,7 +178,7 @@ type SecurityConfiguration struct {
 type Configuration struct {
 	SiteURL           string                   `json:"site_url" split_words:"true" required:"true"`
 	URIAllowList      []string                 `json:"uri_allow_list" split_words:"true"`
-	PasswordMinLength int                      `json:"password_min_length" default:"6"`
+	PasswordMinLength int                      `json:"password_min_length" split_words:"true"`
 	JWT               JWTConfiguration         `json:"jwt"`
 	SMTP              SMTPConfiguration        `json:"smtp"`
 	Mailer            MailerConfiguration      `json:"mailer"`
@@ -329,6 +331,10 @@ func (config *Configuration) ApplyDefaults() {
 
 	if config.URIAllowList == nil {
 		config.URIAllowList = []string{}
+	}
+
+	if config.PasswordMinLength < defaultMinPasswordLength {
+		config.PasswordMinLength = defaultMinPasswordLength
 	}
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Default `password_min_length` to 6 if it's less than 0
* Add `split_words:"true"` to password_min_length to support camel case struct to env var name mapping (see https://github.com/kelseyhightower/envconfig#struct-tag-support)