### PR TITLE
feature: store entries for audit log rejection

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -175,7 +175,7 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		if terr := models.NewAuditLogEntry(tx, instanceID, adminUser, models.UserModifiedAction, map[string]interface{}{
+		if terr := models.NewAuditLogEntry(a.db, tx, instanceID, adminUser, models.UserModifiedAction, map[string]interface{}{
 			"user_id":    user.ID,
 			"user_email": user.Email,
 			"user_phone": user.Phone,
@@ -273,7 +273,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(tx, instanceID, adminUser, models.UserSignedUpAction, map[string]interface{}{
+		if terr := models.NewAuditLogEntry(a.db, tx, instanceID, adminUser, models.UserSignedUpAction, map[string]interface{}{
 			"user_id":    user.ID,
 			"user_email": user.Email,
 			"user_phone": user.Phone,
@@ -326,7 +326,7 @@ func (a *API) adminUserDelete(w http.ResponseWriter, r *http.Request) error {
 	adminUser := getAdminUser(ctx)
 
 	err := a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(tx, instanceID, adminUser, models.UserDeletedAction, map[string]interface{}{
+		if terr := models.NewAuditLogEntry(a.db, tx, instanceID, adminUser, models.UserDeletedAction, map[string]interface{}{
 			"user_id":    user.ID,
 			"user_email": user.Email,
 			"user_phone": user.Phone,

--- a/api/external.go
+++ b/api/external.go
@@ -243,7 +243,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 					return nil
 				}
 
-				if terr := models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, map[string]interface{}{
+				if terr := models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserSignedUpAction, map[string]interface{}{
 					"provider": providerType,
 				}); terr != nil {
 					return terr
@@ -257,7 +257,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 					return internalServerError("Error updating user").WithInternalError(terr)
 				}
 			} else {
-				if terr := models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, map[string]interface{}{
+				if terr := models.NewAuditLogEntry(a.db, tx, instanceID, user, models.LoginAction, map[string]interface{}{
 					"provider": providerType,
 				}); terr != nil {
 					return terr
@@ -345,7 +345,7 @@ func (a *API) processInvite(ctx context.Context, tx *storage.Connection, userDat
 		return nil, internalServerError("Database error updating user").WithInternalError(err)
 	}
 
-	if err := models.NewAuditLogEntry(tx, instanceID, user, models.InviteAcceptedAction, map[string]interface{}{
+	if err := models.NewAuditLogEntry(a.db, tx, instanceID, user, models.InviteAcceptedAction, map[string]interface{}{
 		"provider": providerType,
 	}); err != nil {
 		return nil, err

--- a/api/invite.go
+++ b/api/invite.go
@@ -55,7 +55,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		if terr := models.NewAuditLogEntry(tx, instanceID, adminUser, models.UserInvitedAction, map[string]interface{}{
+		if terr := models.NewAuditLogEntry(a.db, tx, instanceID, adminUser, models.UserInvitedAction, map[string]interface{}{
 			"user_id":    user.ID,
 			"user_email": user.Email,
 		}); terr != nil {

--- a/api/logout.go
+++ b/api/logout.go
@@ -21,7 +21,7 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(tx, instanceID, u, models.LogoutAction, nil); terr != nil {
+		if terr := models.NewAuditLogEntry(a.db, tx, instanceID, u, models.LogoutAction, nil); terr != nil {
 			return terr
 		}
 		return models.Logout(tx, instanceID, u.ID)

--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -76,7 +76,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(tx, instanceID, user, models.UserRecoveryRequestedAction, nil); terr != nil {
+		if terr := models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserRecoveryRequestedAction, nil); terr != nil {
 			return terr
 		}
 

--- a/api/mail.go
+++ b/api/mail.go
@@ -71,7 +71,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 		var terr error
 		switch params.Type {
 		case "magiclink", "recovery":
-			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserRecoveryRequestedAction, nil); terr != nil {
+			if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserRecoveryRequestedAction, nil); terr != nil {
 				return terr
 			}
 			user.RecoveryToken = crypto.SecureToken()
@@ -94,7 +94,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 			}
-			if terr = models.NewAuditLogEntry(tx, instanceID, adminUser, models.UserInvitedAction, map[string]interface{}{
+			if terr = models.NewAuditLogEntry(a.db, tx, instanceID, adminUser, models.UserInvitedAction, map[string]interface{}{
 				"user_id":    user.ID,
 				"user_email": user.Email,
 			}); terr != nil {

--- a/api/otp.go
+++ b/api/otp.go
@@ -100,7 +100,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err := a.db.Transaction(func(tx *storage.Connection) error {
-		if err := models.NewAuditLogEntry(tx, instanceID, user, models.UserRecoveryRequestedAction, nil); err != nil {
+		if err := models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserRecoveryRequestedAction, nil); err != nil {
 			return err
 		}
 

--- a/api/recover.go
+++ b/api/recover.go
@@ -41,7 +41,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(tx, instanceID, user, models.UserRecoveryRequestedAction, nil); terr != nil {
+		if terr := models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserRecoveryRequestedAction, nil); terr != nil {
 			return terr
 		}
 

--- a/api/signup.go
+++ b/api/signup.go
@@ -112,7 +112,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 
 		if params.Provider == "email" && !user.IsConfirmed() {
 			if config.Mailer.Autoconfirm {
-				if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, map[string]interface{}{
+				if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserSignedUpAction, map[string]interface{}{
 					"provider": params.Provider,
 				}); terr != nil {
 					return terr
@@ -126,7 +126,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			} else {
 				mailer := a.Mailer(ctx)
 				referrer := a.getReferrer(r)
-				if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserConfirmationRequestedAction, map[string]interface{}{
+				if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserConfirmationRequestedAction, map[string]interface{}{
 					"provider": params.Provider,
 				}); terr != nil {
 					return terr
@@ -142,7 +142,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			}
 		} else if params.Provider == "phone" && !user.IsPhoneConfirmed() {
 			if config.Sms.Autoconfirm {
-				if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, map[string]interface{}{
+				if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserSignedUpAction, map[string]interface{}{
 					"provider": params.Provider,
 				}); terr != nil {
 					return terr
@@ -154,7 +154,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					return internalServerError("Database error updating user").WithInternalError(terr)
 				}
 			} else {
-				if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserConfirmationRequestedAction, map[string]interface{}{
+				if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserConfirmationRequestedAction, map[string]interface{}{
 					"provider": params.Provider,
 				}); terr != nil {
 					return terr
@@ -174,7 +174,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		}
 		if errors.Is(err, UserExistsError) {
 			err = a.db.Transaction(func(tx *storage.Connection) error {
-				if terr := models.NewAuditLogEntry(tx, instanceID, user, models.UserRepeatedSignUpAction, map[string]interface{}{
+				if terr := models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserRepeatedSignUpAction, map[string]interface{}{
 					"provider": params.Provider,
 				}); terr != nil {
 					return terr
@@ -201,7 +201,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		var token *AccessTokenResponse
 		err = a.db.Transaction(func(tx *storage.Connection) error {
 			var terr error
-			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, map[string]interface{}{
+			if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.LoginAction, map[string]interface{}{
 				"provider": params.Provider,
 			}); terr != nil {
 				return terr

--- a/api/user.go
+++ b/api/user.go
@@ -130,7 +130,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserModifiedAction, nil); terr != nil {
+		if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserModifiedAction, nil); terr != nil {
 			return internalServerError("Error recording audit log entry").WithInternalError(terr)
 		}
 

--- a/api/verify.go
+++ b/api/verify.go
@@ -175,7 +175,7 @@ func (a *API) signupVerify(ctx context.Context, conn *storage.Connection, user *
 			}
 		}
 
-		if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
+		if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
 			return terr
 		}
 
@@ -204,7 +204,7 @@ func (a *API) recoverVerify(ctx context.Context, conn *storage.Connection, user 
 			return terr
 		}
 		if !user.IsConfirmed() {
-			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, nil); terr != nil {
+			if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.LoginAction, nil); terr != nil {
 				return terr
 			}
 
@@ -215,7 +215,7 @@ func (a *API) recoverVerify(ctx context.Context, conn *storage.Connection, user 
 				return terr
 			}
 		} else {
-			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, nil); terr != nil {
+			if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.LoginAction, nil); terr != nil {
 				return terr
 			}
 			if terr = triggerEventHooks(ctx, tx, LoginEvent, user, instanceID, config); terr != nil {
@@ -237,7 +237,7 @@ func (a *API) smsVerify(ctx context.Context, conn *storage.Connection, user *mod
 
 	err := conn.Transaction(func(tx *storage.Connection) error {
 		var terr error
-		if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
+		if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
 			return terr
 		}
 
@@ -303,7 +303,7 @@ func (a *API) emailChangeVerify(ctx context.Context, conn *storage.Connection, p
 	err := a.db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 
-		if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserModifiedAction, nil); terr != nil {
+		if terr = models.NewAuditLogEntry(a.db, tx, instanceID, user, models.UserModifiedAction, nil); terr != nil {
 			return terr
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.1.1
 	github.com/imdario/mergo v0.0.0-20160216103600-3e95a51e0639
+	github.com/jackc/pgconn v1.8.0 // indirect
+	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451 // indirect
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
 	github.com/jmoiron/sqlx v1.3.1 // indirect
 	github.com/joho/godotenv v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,8 @@ github.com/jackc/pgconn v1.5.1-0.20200601181101-fa742c524853/go.mod h1:QeD3lBfpT
 github.com/jackc/pgconn v1.6.0/go.mod h1:yeseQo4xhQbgyJs2c87RAXOH2i624N0Fh1KSPJya7qo=
 github.com/jackc/pgconn v1.8.0 h1:FmjZ0rOyXTr1wfWs45i4a9vjnjWUAGpMuQLD9OSs+lw=
 github.com/jackc/pgconn v1.8.0/go.mod h1:1C2Pb36bGIP9QHGBYCjnyhqu7Rv3sGshaQUvmfGIB/o=
+github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451 h1:WAvSpGf7MsFuzAtK4Vk7R4EVe+liW4x83r4oWu0WHKw=
+github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye4717ITLaNwV9mWbJx0dLCpcRzdA=

--- a/models/audit_log_entry_test.go
+++ b/models/audit_log_entry_test.go
@@ -1,0 +1,121 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/netlify/gotrue/conf"
+	"github.com/netlify/gotrue/storage"
+	"github.com/netlify/gotrue/storage/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type AuditLogEntryTestSuite struct {
+	suite.Suite
+	db *storage.Connection
+}
+
+func (ts *AuditLogEntryTestSuite) SetupTest() {
+	TruncateAll(ts.db)
+}
+
+func TestAuditLogEntry(t *testing.T) {
+	globalConfig, err := conf.LoadGlobal(modelsTestConfig)
+	require.NoError(t, err)
+
+	conn, err := test.SetupDBConnection(globalConfig)
+	require.NoError(t, err)
+
+	ts := &AuditLogEntryTestSuite{
+		db: conn,
+	}
+	defer ts.db.Close()
+
+	suite.Run(t, ts)
+}
+
+func (ts *AuditLogEntryTestSuite) TestInsertAuditLogEntry() {
+	u := ts.createUserWithEmail("test@example.com")
+
+	err := NewAuditLogEntry(ts.db, ts.db, uuid.Nil, u, UserSignedUpAction, nil)
+	require.NoError(ts.T(), err)
+
+	logs, err := FindAuditLogEntries(ts.db, uuid.Nil, make([]string, 0), "", nil)
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), logs, 1)
+
+	entry := logs[0]
+	assert.Equal(ts.T(), uuid.Nil, entry.InstanceID)
+	assert.Equal(ts.T(), "test@example.com", entry.Payload["actor_username"])
+	assert.Equal(ts.T(), u.ID.String(), entry.Payload["actor_id"])
+	assert.Equal(ts.T(), string(UserSignedUpAction), entry.Payload["action"])
+}
+
+func (ts *AuditLogEntryTestSuite) TestInsertAuditLogEntryWithRejection() {
+	u := ts.createUserWithEmail("test@example.com")
+
+	// Add trigger which rejects audit log entries except `AuditLogEntryRejectedAction`.
+	err := ts.db.RawQuery(`
+		drop trigger if exists reject_audit_log_entries on auth.audit_log_entries;
+		drop function if exists auth.reject_audit_log_entries;
+		create function auth.reject_audit_log_entries() returns trigger as $$
+			begin
+				if (new.payload->>'action') != 'audit_log_entry_rejected' then
+					raise exception 'Rejected audit log entry insertion';
+				end if;
+				return NEW;
+			end;
+		$$ language plpgsql stable;
+
+		create trigger reject_audit_log_entries
+			after insert on auth.audit_log_entries
+			for each row execute function auth.reject_audit_log_entries();
+	`).Exec()
+	require.NoError(ts.T(), err)
+
+	// Inserting a new audit log entry should cause an error.
+	err = NewAuditLogEntry(ts.db, ts.db, uuid.Nil, u, UserSignedUpAction, nil)
+	require.Error(ts.T(), err)
+
+	// Audit log should contain entry indicating rejection.
+	logs, err := FindAuditLogEntries(ts.db, uuid.Nil, make([]string, 0), "", nil)
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), logs, 1)
+	entry := logs[0]
+	assert.Equal(ts.T(), uuid.Nil, entry.InstanceID)
+	assert.Equal(ts.T(), "test@example.com", entry.Payload["actor_username"])
+	assert.Equal(ts.T(), u.ID.String(), entry.Payload["actor_id"])
+	assert.Equal(ts.T(), string(AuditLogEntryRejectedAction), entry.Payload["action"])
+
+	// Audit log rejection entry should contain original entry information.
+	var originalEntry AuditLogEntry
+	bytes, err := json.Marshal(entry.Payload["original_entry"])
+	require.NoError(ts.T(), err)
+	err = json.Unmarshal(bytes, &originalEntry)
+	require.NoError(ts.T(), err)
+
+	assert.Equal(ts.T(), uuid.Nil, originalEntry.InstanceID)
+	assert.Equal(ts.T(), "test@example.com", originalEntry.Payload["actor_username"])
+	assert.Equal(ts.T(), u.ID.String(), originalEntry.Payload["actor_id"])
+	assert.Equal(ts.T(), string(UserSignedUpAction), originalEntry.Payload["action"])
+
+	// Clear the custom trigger and function.
+	err = ts.db.RawQuery(`
+		drop trigger reject_audit_log_entries on auth.audit_log_entries;
+		drop function auth.reject_audit_log_entries;
+	`).Exec()
+	require.NoError(ts.T(), err)
+}
+
+func (ts *AuditLogEntryTestSuite) createUserWithEmail(email string) *User {
+	user, err := NewUser(uuid.Nil, email, "secret", "test", nil)
+	require.NoError(ts.T(), err)
+
+	err = ts.db.Create(user)
+	require.NoError(ts.T(), err)
+
+	return user
+}

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -37,11 +37,11 @@ func GrantAuthenticatedUser(tx *storage.Connection, user *User) (*RefreshToken, 
 }
 
 // GrantRefreshTokenSwap swaps a refresh token for a new one, revoking the provided token.
-func GrantRefreshTokenSwap(tx *storage.Connection, user *User, token *RefreshToken) (*RefreshToken, error) {
+func GrantRefreshTokenSwap(db, tx *storage.Connection, user *User, token *RefreshToken) (*RefreshToken, error) {
 	var newToken *RefreshToken
 	err := tx.Transaction(func(rtx *storage.Connection) error {
 		var terr error
-		if terr = NewAuditLogEntry(tx, user.InstanceID, user, TokenRevokedAction, nil); terr != nil {
+		if terr = NewAuditLogEntry(db, tx, user.InstanceID, user, TokenRevokedAction, nil); terr != nil {
 			return errors.Wrap(terr, "error creating audit log entry")
 		}
 

--- a/models/refresh_token_test.go
+++ b/models/refresh_token_test.go
@@ -3,10 +3,10 @@ package models
 import (
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
-	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -49,7 +49,7 @@ func (ts *RefreshTokenTestSuite) TestGrantRefreshTokenSwap() {
 	r, err := GrantAuthenticatedUser(ts.db, u)
 	require.NoError(ts.T(), err)
 
-	s, err := GrantRefreshTokenSwap(ts.db, u, r)
+	s, err := GrantRefreshTokenSwap(ts.db, ts.db, u, r)
 	require.NoError(ts.T(), err)
 
 	_, nr, err := FindUserWithRefreshToken(ts.db, r.Token)

--- a/utilities/postgres.go
+++ b/utilities/postgres.go
@@ -1,0 +1,67 @@
+package utilities
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
+)
+
+// PostgresError is a custom error struct for marshalling Postgres errors to JSON.
+type PostgresError struct {
+	Code           string `json:"code"`
+	HttpStatusCode int    `json:"-"`
+	Message        string `json:"message"`
+	Hint           string `json:"hint,omitempty"`
+	Detail         string `json:"detail,omitempty"`
+}
+
+// NewPostgresError returns a new PostgresError if the error was from a publicly
+// accessible Postgres error.
+func NewPostgresError(err error) *PostgresError {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && isPubliclyAccessiblePostgresError(pgErr.Code) {
+		return &PostgresError{
+			Code:           pgErr.Code,
+			HttpStatusCode: getHttpStatusCodeFromPostgresErrorCode(pgErr.Code),
+			Message:        pgErr.Message,
+			Detail:         pgErr.Detail,
+			Hint:           pgErr.Hint,
+		}
+	}
+
+	return nil
+}
+
+// isPubliclyAccessiblePostgresError checks if the Postgres error should be
+// made accessible.
+func isPubliclyAccessiblePostgresError(code string) bool {
+	if len(code) != 5 {
+		return false
+	}
+
+	if code == pgerrcode.RaiseException {
+		return true
+	}
+
+	return getHttpStatusCodeFromPostgresErrorCode(code) != 0
+}
+
+// getHttpStatusCodeFromPostgresErrorCode maps a Postgres error code to a HTTP
+// status code.
+func getHttpStatusCodeFromPostgresErrorCode(code string) int {
+	if code == pgerrcode.RaiseException {
+		return 500
+	}
+
+	// Use custom HTTP status code if Postgres error was triggered with `PTXXX`
+	// code. This is consistent with PostgREST's behaviour as well.
+	if code[0:2] == "PT" {
+		if httpStatusCode, err := strconv.ParseInt(code[2:], 10, 0); err == nil {
+			return int(httpStatusCode)
+		}
+	}
+
+	return 0
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

Users can add custom triggers on `auth.audit_log_entries`, and raise exceptions to prevent successful completion of the action. However, no record will exist of the original entry.

## What is the new behavior?

Given that adding triggers to `auth.audit_log_entries` is currently the de-facto method for performing more advanced features such as sign-in rejection (as per https://github.com/supabase/gotrue/issues/246), storing the information about rejected audit log entries will ensure that all data is persisted for auditing purposes. This is done by creating a new transaction and storing the original entry and error information, given that an exception raised during insertion would cause the original transaction to rollback.

As per #404, only specific error types will be stored as rejected audit log entries since the audit log entry insertion could fail for any number of reasons apart from explicit user rejections.