### PR TITLE
fix: api_url config

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -19,7 +19,7 @@ type OAuthProviderConfiguration struct {
 	Secret      string `json:"secret"`
 	RedirectURI string `json:"redirect_uri" split_words:"true"`
 	URL         string `json:"url"`
-	ApiURL      string `json:"api_url"`
+	ApiURL      string `json:"api_url" split_words:"true"`
 	Enabled     bool   `json:"enabled"`
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Allows for setting the api url config of a provider like `GOTRUE_EXTERNAL_AZURE_API_URL` instead of `GOTRUE_EXTERNAL_AZURE_APIURL`

