### PR TITLE
fix: update user email should not fail when current email doesn't exist

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -119,14 +119,8 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 			mailer := a.Mailer(ctx)
 			referrer := a.getReferrer(r)
-			if config.Mailer.SecureEmailChangeEnabled {
-				if terr = a.sendSecureEmailChange(tx, user, mailer, params.Email, referrer); terr != nil {
-					return internalServerError("Error sending change email").WithInternalError(terr)
-				}
-			} else {
-				if terr = a.sendEmailChange(tx, user, mailer, params.Email, referrer); terr != nil {
-					return internalServerError("Error sending change email").WithInternalError(terr)
-				}
+			if terr = a.sendEmailChange(tx, config, user, mailer, params.Email, referrer); terr != nil {
+				return internalServerError("Error sending change email").WithInternalError(terr)
 			}
 		}
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -47,6 +47,20 @@ func (ts *UserTestSuite) SetupTest() {
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 }
 
+func (ts *UserTestSuite) TestUserGet() {
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err, "Error finding user")
+	token, err := generateAccessToken(u, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	require.NoError(ts.T(), err, "Error generating access token")
+
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/user", nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+}
+
 func (ts *UserTestSuite) TestUserUpdateEmail() {
 	cases := []struct {
 		desc                       string

--- a/api/verify.go
+++ b/api/verify.go
@@ -280,7 +280,7 @@ func (a *API) emailChangeVerify(ctx context.Context, conn *storage.Connection, p
 	instanceID := getInstanceID(ctx)
 	config := a.getConfig(ctx)
 
-	if config.Mailer.SecureEmailChangeEnabled && user.EmailChangeConfirmStatus == zeroConfirmation {
+	if config.Mailer.SecureEmailChangeEnabled && user.EmailChangeConfirmStatus == zeroConfirmation && user.GetEmail() != "" {
 		err := a.db.Transaction(func(tx *storage.Connection) error {
 			user.EmailChangeConfirmStatus = singleConfirmation
 			if params.Token == user.EmailChangeTokenCurrent {

--- a/mailer/noop.go
+++ b/mailer/noop.go
@@ -1,8 +1,13 @@
 package mailer
 
-import "github.com/netlify/gotrue/models"
+import (
+	"errors"
+
+	"github.com/netlify/gotrue/models"
+)
 
 type noopMailer struct {
+	Mailer MailClient
 }
 
 func (m noopMailer) ValidateEmail(email string) error {
@@ -35,4 +40,13 @@ func (m noopMailer) Send(user *models.User, subject, body string, data map[strin
 
 func (m noopMailer) GetEmailActionLink(user *models.User, actionType, referrerURL string) (string, error) {
 	return "", nil
+}
+
+type noopMailClient struct{}
+
+func (m *noopMailClient) Mail(to, subjectTemplate, templateURL, defaultTemplate string, templateData map[string]interface{}) error {
+	if to == "" {
+		return errors.New("to field cannot be empty")
+	}
+	return nil
 }

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -6,14 +6,17 @@ import (
 	"github.com/badoux/checkmail"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/netlify/mailme"
 )
+
+type MailClient interface {
+	Mail(string, string, string, string, map[string]interface{}) error
+}
 
 // TemplateMailer will send mail and use templates from the site for easy mail styling
 type TemplateMailer struct {
 	SiteURL string
 	Config  *conf.Configuration
-	Mailer  *mailme.Mailer
+	Mailer  MailClient
 }
 
 var configFile = ""

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -132,9 +132,10 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) 
 		},
 	}
 
-	if m.Config.Mailer.SecureEmailChangeEnabled {
+	currentEmail := user.GetEmail()
+	if m.Config.Mailer.SecureEmailChangeEnabled && currentEmail != "" {
 		emails = append(emails, Email{
-			Address:  user.GetEmail(),
+			Address:  currentEmail,
 			Token:    user.EmailChangeTokenCurrent,
 			Subject:  string(withDefault(m.Config.Mailer.Subjects.Confirmation, "Confirm Email Address")),
 			Template: m.Config.Mailer.Templates.EmailChange,


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes issue where updating a user's email fails if the existing email is empty (when `SECURE_EMAIL_CHANGE_ENABLED=true`)
* This issue happens because `SECURE_EMAIL_CHANGE_ENABLED` attempts to send an email confirmation link to both the current and new email, since the current email doesn't exist, the mail client fails to send the link.
* Refactored the `TemplateMailer` to use an interface for the `Mailer`. This makes mocking the `mailme.Mailer.Mail` method easier rather than just mocking the `EmailChangeMail` method.
* Added tests for updating a user 