### PR TITLE
fix: allow max db pool size to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Chooses what dialect of database you want. Must be `mysql`.
 
 Connection string for the database.
 
+`GOTRUE_DB_MAX_POOL_SIZE` - `int`
+
+Sets the maximum number of open connections to the database. Defaults to 0 which is equivalent to an "unlimited" number of connections.
+
 `DB_NAMESPACE` - `string`
 
 Adds a prefix to all table names.

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -38,8 +38,11 @@ type SamlProviderConfiguration struct {
 
 // DBConfiguration holds all the database related configuration.
 type DBConfiguration struct {
-	Driver         string `json:"driver" required:"true"`
-	URL            string `json:"url" envconfig:"DATABASE_URL" required:"true"`
+	Driver string `json:"driver" required:"true"`
+	URL    string `json:"url" envconfig:"DATABASE_URL" required:"true"`
+
+	// MaxPoolSize defaults to 0 (unlimited).
+	MaxPoolSize    int    `json:"max_pool_size" split_words:"true"`
 	MigrationsPath string `json:"migrations_path" split_words:"true" default:"./migrations"`
 }
 

--- a/storage/dial.go
+++ b/storage/dial.go
@@ -31,6 +31,7 @@ func Dial(config *conf.GlobalConfiguration) (*Connection, error) {
 	db, err := pop.NewConnection(&pop.ConnectionDetails{
 		Dialect: config.DB.Driver,
 		URL:     config.DB.URL,
+		Pool:    config.DB.MaxPoolSize,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "opening database connection")


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Currently, pop always defaults to an unlimited number of connections for the db pool, this PR allows one to set the desired pool size via `GOTRUE_DB_MAX_POOL_SIZE` 