### PR TITLE
[WIP] fix: remove email dependency for oauth providers

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -173,12 +173,14 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 							return forbiddenError("Signups not allowed for this instance")
 						}
 
-						// prefer primary email for new signups
-						emailData = userData.Emails[0]
-						for _, e := range userData.Emails {
-							if e.Primary {
-								emailData = e
-								break
+						if len(userData.Emails) != 0 {
+							emailData = userData.Emails[0]
+							for _, e := range userData.Emails {
+								if e.Primary {
+									// prefer primary email for new signups
+									emailData = e
+									break
+								}
 							}
 						}
 
@@ -508,6 +510,10 @@ func (a *API) getUserByVerifiedEmail(tx *storage.Connection, config *conf.Config
 	var user *models.User
 	var emailData provider.Email
 	var err error
+
+	if len(emails) == 0 {
+		return nil, emailData, models.UserNotFoundError{}
+	}
 
 	for _, e := range emails {
 		if e.Verified || config.Mailer.Autoconfirm {

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -90,8 +89,9 @@ func (t TwitterProvider) FetchUserData(ctx context.Context, tok *oauth.AccessTok
 	}
 	err = json.NewDecoder(bytes.NewReader(bits)).Decode(&u)
 
-	if u.Email == "" {
-		return nil, errors.New("Unable to find email with Twitter provider")
+	var emails []Email
+	if u.Email != "" {
+		emails = append(emails, Email{Email: u.Email, Verified: true, Primary: true})
 	}
 
 	data := &UserProvidedData{
@@ -110,11 +110,7 @@ func (t TwitterProvider) FetchUserData(ctx context.Context, tok *oauth.AccessTok
 			AvatarURL:   u.AvatarURL,
 			ProviderId:  u.ID,
 		},
-		Emails: []Email{{
-			Email:    u.Email,
-			Verified: true,
-			Primary:  true,
-		}},
+		Emails: emails,
 	}
 
 	return data, nil


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #214 
* TLDR: Some oauth providers (e.g. twitter) do not require their users to provide an email address when they sign up. Gotrue currently restricts oauth logins to user accounts with at least a verified email address associated to it. 

## To-be-addressed
* Should gotrue auto-confirm users with no email addresses associated to their oauth account?
* Should gotrue have a setting in the config for the above? 

## Details
We are changing the orange flow to allow new users to be created without having to provide a verified email. 

![image](https://user-images.githubusercontent.com/28647601/157269000-90d35185-917a-4212-8033-70c25b81b311.png)

