### PR TITLE
[WIP] fix: remove user metadata from access token jwt

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -24,7 +24,7 @@ type GoTrueClaims struct {
 	Email        string                 `json:"email"`
 	Phone        string                 `json:"phone"`
 	AppMetaData  map[string]interface{} `json:"app_metadata"`
-	UserMetaData map[string]interface{} `json:"user_metadata"`
+	UserMetaData map[string]interface{} `json:"user_metadata,omitempty"`
 	Role         string                 `json:"role"`
 }
 
@@ -513,11 +513,10 @@ func generateAccessToken(user *models.User, expiresIn time.Duration, secret stri
 			Audience:  user.Aud,
 			ExpiresAt: time.Now().Add(expiresIn).Unix(),
 		},
-		Email:        user.GetEmail(),
-		Phone:        user.GetPhone(),
-		AppMetaData:  user.AppMetaData,
-		UserMetaData: user.UserMetaData,
-		Role:         user.Role,
+		Email:       user.GetEmail(),
+		Phone:       user.GetPhone(),
+		AppMetaData: user.AppMetaData,
+		Role:        user.Role,
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Removes the `user_metadata` field from the access token payload
* Reduces the cookie size by 1/3
* Removes potentially user sensitive information from jwt

## Considerations
* This might be a breaking change for developers who read the `user_metadata` field directly from the access token jwt