### PR TITLE
fix: set idle_in_transaction_session_timeout to 5min

### DIFF
--- a/migrations/20220320143831_set_idle_transaction_timeout.up.sql
+++ b/migrations/20220320143831_set_idle_transaction_timeout.up.sql
@@ -1,0 +1,3 @@
+-- set idle_in_transaction_session_timeout to 5min
+
+ALTER ROLE supabase_auth_admin SET idle_in_transaction_session_timeout TO 300000;


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Sets the `idle_in_transaction_session_timeout ` to 5mins instead of 0 (unlimited).
* Fixes issue where many long-running transactions are left in a state of `idle_in_transaction` which results in holding up too many connections
