### PR TITLE
fix: no longer hardcode username for migration

### DIFF
--- a/migrations/20220320143831_set_idle_transaction_timeout.up.sql
+++ b/migrations/20220320143831_set_idle_transaction_timeout.up.sql
@@ -1,3 +1,3 @@
 -- set idle_in_transaction_session_timeout to 5min
 
-ALTER ROLE supabase_auth_admin SET idle_in_transaction_session_timeout TO 300000;
+ALTER ROLE current_user SET idle_in_transaction_session_timeout TO 300000;

--- a/migrations/20220320143831_set_idle_transaction_timeout.up.sql
+++ b/migrations/20220320143831_set_idle_transaction_timeout.up.sql
@@ -1,3 +1,3 @@
--- set idle_in_transaction_session_timeout to 5min
+-- set idle_in_transaction_session_timeout to 1min
 
-ALTER ROLE current_user SET idle_in_transaction_session_timeout TO 300000;
+ALTER ROLE current_user SET idle_in_transaction_session_timeout TO 60000;


### PR DESCRIPTION
The username is configurable via the connstring, and as such we can't
rely on it being supabase_auth_admin

