### PR TITLE
fix: allow user to update phone number

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -14,6 +14,7 @@ import (
 // Common error messages during signup flow
 var (
 	DuplicateEmailMsg       = "A user with this email address has already been registered"
+	DuplicatePhoneMsg       = "A user with this phone number has already been registered"
 	UserExistsError   error = errors.New("User already exists")
 )
 

--- a/api/otp.go
+++ b/api/otp.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/netlify/gotrue/api/sms_provider"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 	"github.com/sethvargo/go-password/password"
@@ -103,8 +104,11 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 		if err := models.NewAuditLogEntry(tx, instanceID, user, models.UserRecoveryRequestedAction, nil); err != nil {
 			return err
 		}
-
-		if err := a.sendPhoneConfirmation(ctx, tx, user, params.Phone); err != nil {
+		smsProvider, err := sms_provider.GetSmsProvider(*config)
+		if err != nil {
+			return err
+		}
+		if err := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider); err != nil {
 			return badRequestError("Error sending sms otp: %v", err)
 		}
 		return nil

--- a/api/phone_test.go
+++ b/api/phone_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/netlify/gotrue/conf"
+	"github.com/netlify/gotrue/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type PhoneTestSuite struct {
+	suite.Suite
+	API    *API
+	Config *conf.Configuration
+
+	instanceID uuid.UUID
+}
+
+type TestSmsProvider struct {
+	mock.Mock
+}
+
+func (t TestSmsProvider) SendSms(phone string, message string) error {
+	return nil
+}
+
+func TestPhone(t *testing.T) {
+	api, config, instanceID, err := setupAPIForTestForInstance()
+	require.NoError(t, err)
+
+	ts := &PhoneTestSuite{
+		API:        api,
+		Config:     config,
+		instanceID: instanceID,
+	}
+	defer api.db.Close()
+
+	suite.Run(t, ts)
+}
+
+func (ts *PhoneTestSuite) SetupTest() {
+	models.TruncateAll(ts.API.db)
+
+	// Create user
+	u, err := models.NewUser(ts.instanceID, "", "password", ts.Config.JWT.Aud, nil)
+	u.Phone = "123456789"
+	require.NoError(ts.T(), err, "Error creating test user model")
+	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
+}
+
+func (ts *PhoneTestSuite) TestValidateE164Format() {
+	isValid := ts.API.validateE164Format("0123456789")
+	assert.Equal(ts.T(), false, isValid)
+}
+
+func (ts *PhoneTestSuite) TestFormatPhoneNumber() {
+	actual := ts.API.formatPhoneNumber("+1 23456789 ")
+	assert.Equal(ts.T(), "123456789", actual)
+}
+
+func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
+	u, err := models.FindUserByPhoneAndAudience(ts.API.db, ts.instanceID, "123456789", ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+	ctx, err := WithInstanceConfig(context.Background(), ts.Config, ts.instanceID)
+	require.NoError(ts.T(), err)
+	cases := []struct {
+		desc     string
+		otpType  string
+		expected error
+	}{
+		{
+			"send confirmation otp",
+			phoneConfirmationOtp,
+			nil,
+		},
+		{
+			"send phone_change otp",
+			phoneChangeOtp,
+			nil,
+		},
+		{
+			"send invalid otp type ",
+			"invalid otp type",
+			internalServerError("invalid otp type"),
+		},
+	}
+
+	for _, c := range cases {
+		ts.Run(c.desc, func() {
+			err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, TestSmsProvider{})
+			require.Equal(ts.T(), c.expected, err)
+		})
+	}
+}

--- a/api/signup.go
+++ b/api/signup.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/netlify/gotrue/api/sms_provider"
 	"github.com/netlify/gotrue/metering"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
@@ -159,7 +160,11 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				}); terr != nil {
 					return terr
 				}
-				if terr = a.sendPhoneConfirmation(ctx, tx, user, params.Phone); terr != nil {
+				smsProvider, err := sms_provider.GetSmsProvider(*config)
+				if err != nil {
+					return err
+				}
+				if terr = a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider); terr != nil {
 					return badRequestError("Error sending confirmation sms: %v", terr)
 				}
 			}

--- a/go.sum
+++ b/go.sum
@@ -539,6 +539,7 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #390 
* If `GOTRUE_SMS_AUTOCONFIRM` is enabled, an otp will not be sent to the new phone number, else, an otp will be sent to the new phone number and the user has to verify it first.
* Added a new verification type called `phone_change` which when set, will verify if the token sent is valid when compared to the `phone_change_token` and `phone_change_sent_at` fields

## To-Do
* Update gotrue-js to include the `phone_change` verification type (https://github.com/supabase/gotrue-js/blob/master/src/lib/types.ts#L202) 