### PR TITLE
fix: add `UserSignedUpAction` to the audit log when the user is unconfirmed

### DIFF
--- a/api/verify.go
+++ b/api/verify.go
@@ -204,7 +204,7 @@ func (a *API) recoverVerify(ctx context.Context, conn *storage.Connection, user 
 			return terr
 		}
 		if !user.IsConfirmed() {
-			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.LoginAction, nil); terr != nil {
+			if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserSignedUpAction, nil); terr != nil {
 				return terr
 			}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Adds a `LoginAction` to the audit log when the user is unconfirmed.

## What is the new behavior?

Adds a `UserSignedUpAction` to the audit log when the user is unconfirmed.

## Additional context

This fixes a leftover bug following PRs #395 and #396.