### PR TITLE
fix: re-use existing connection's transaction in `emailChangeVerify`

### DIFF
--- a/api/verify.go
+++ b/api/verify.go
@@ -288,7 +288,7 @@ func (a *API) emailChangeVerify(ctx context.Context, conn *storage.Connection, p
 	config := a.getConfig(ctx)
 
 	if config.Mailer.SecureEmailChangeEnabled && user.EmailChangeConfirmStatus == zeroConfirmation && user.GetEmail() != "" {
-		err := a.db.Transaction(func(tx *storage.Connection) error {
+		err := conn.Transaction(func(tx *storage.Connection) error {
 			user.EmailChangeConfirmStatus = singleConfirmation
 			if params.Token == user.EmailChangeTokenCurrent {
 				user.EmailChangeTokenCurrent = ""
@@ -307,7 +307,7 @@ func (a *API) emailChangeVerify(ctx context.Context, conn *storage.Connection, p
 	}
 
 	// one email is confirmed at this point
-	err := a.db.Transaction(func(tx *storage.Connection) error {
+	err := conn.Transaction(func(tx *storage.Connection) error {
 		var terr error
 
 		if terr = models.NewAuditLogEntry(tx, instanceID, user, models.UserModifiedAction, nil); terr != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The `emailChangeVerify` function created new transactions when performing updates, although an existing connection already exists.

## What is the new behavior?

The existing connection passed into `emailChangeVerify` is re-used. This aligns the connection handling behaviour with the rest of the functions in `api/verify.go`.


## Additional context

This looks like it might have been a leftover bug during refactoring in PR #379.