### PR TITLE
fix: ensure confirmation & phone change sent at is saved

### DIFF
--- a/api/phone.go
+++ b/api/phone.go
@@ -78,7 +78,11 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 	}
 
 	now := time.Now()
-	sentAt = &now
+	if otpType == phoneConfirmationOtp {
+		user.ConfirmationSentAt = &now
+	} else if otpType == phoneChangeOtp {
+		user.PhoneChangeSentAt = &now
+	}
 
 	return errors.Wrap(tx.UpdateOnly(user, tokenDbField, sentAtDbField), "Database error updating user for confirmation")
 }

--- a/api/sms_provider/messagebird.go
+++ b/api/sms_provider/messagebird.go
@@ -55,7 +55,7 @@ func NewMessagebirdProvider(config conf.MessagebirdProviderConfiguration) (SmsPr
 }
 
 // Send an SMS containing the OTP with Messagebird's API
-func (t MessagebirdProvider) SendSms(phone string, message string) error {
+func (t *MessagebirdProvider) SendSms(phone string, message string) error {
 	body := url.Values{
 		"originator": {t.Config.Originator},
 		"body":       {message},

--- a/api/sms_provider/textlocal.go
+++ b/api/sms_provider/textlocal.go
@@ -44,7 +44,7 @@ func NewTextlocalProvider(config conf.TextlocalProviderConfiguration) (SmsProvid
 }
 
 // Send an SMS containing the OTP with Textlocal's API
-func (t TextlocalProvider) SendSms(phone string, message string) error {
+func (t *TextlocalProvider) SendSms(phone string, message string) error {
 	body := url.Values{
 		"sender":  {t.Config.Sender},
 		"apikey":  {t.Config.ApiKey},
@@ -70,7 +70,7 @@ func (t TextlocalProvider) SendSms(phone string, message string) error {
 	if derr != nil {
 		return derr
 	}
-	
+
 	if len(resp.Errors) == 0 {
 		return errors.New("Textlocal error: Internal Error")
 	}

--- a/api/sms_provider/twilio.go
+++ b/api/sms_provider/twilio.go
@@ -54,7 +54,7 @@ func NewTwilioProvider(config conf.TwilioProviderConfiguration) (SmsProvider, er
 }
 
 // Send an SMS containing the OTP with Twilio's API
-func (t TwilioProvider) SendSms(phone string, message string) error {
+func (t *TwilioProvider) SendSms(phone string, message string) error {
 	body := url.Values{
 		"To":      {"+" + phone}, // twilio api requires "+" extension to be included
 		"Channel": {"sms"},

--- a/api/sms_provider/vonage.go
+++ b/api/sms_provider/vonage.go
@@ -43,7 +43,7 @@ func NewVonageProvider(config conf.VonageProviderConfiguration) (SmsProvider, er
 }
 
 // Send an SMS containing the OTP with Vonage's API
-func (t VonageProvider) SendSms(phone string, message string) error {
+func (t *VonageProvider) SendSms(phone string, message string) error {
 	body := url.Values{
 		"from":       {t.Config.From},
 		"to":         {phone},


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes issue introduced in #421 where `confirmation_sent_at` and `phone_change_sent` where not updated if they were originally nil pointers
* Refactor struct receiver for other sms pointers from using a value to a pointer (faster to pass by pointer than value)