### PR TITLE
fix: SmsOtp should still send otp the first time when sms autoconfirm…

### DIFF
--- a/api/otp.go
+++ b/api/otp.go
@@ -92,6 +92,17 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 
 			fakeResponse := &responseStub{}
 
+			if config.Sms.Autoconfirm {
+				// signups are autoconfirmed, send otp after signup
+				if err := a.Signup(fakeResponse, r); err != nil {
+					return err
+				}
+				newBodyContent := `{"phone":"` + params.Phone + `"}`
+				r.Body = ioutil.NopCloser(strings.NewReader(newBodyContent))
+				r.ContentLength = int64(len(newBodyContent))
+				return a.SmsOtp(w, r)
+			}
+
 			if err := a.Signup(fakeResponse, r); err != nil {
 				return err
 			}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #265 