### PR TITLE
BUG FIX: Only require nonce in id_token when also passed in body

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	jwt "github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/metering"
 	"github.com/netlify/gotrue/models"
@@ -384,10 +384,12 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 		return oauthError("invalid request", "Passed nonce and nonce in id_token should either both exist or not.")
 	}
 
-	// verify nonce to mitigate replay attacks
-	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(params.Nonce)))
-	if hash != hashedNonce.(string) {
-		return oauthError("invalid nonce", "").WithInternalMessage("Possible abuse attempt: %v", r)
+	if ok && params.Nonce != "" {
+		// verify nonce to mitigate replay attacks
+		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(params.Nonce)))
+		if hash != hashedNonce.(string) {
+			return oauthError("invalid nonce", "").WithInternalMessage("Possible abuse attempt: %v", r)
+		}
 	}
 
 	sub, ok := claims["sub"].(string)


### PR DESCRIPTION
## Context
Receiving a nonce is optional in the open id spec. Google has 2 apis, the older one does not return a nonce while the newer one does.
There's a risk of replay attack if there's no nonce, but that's why my PR makes passing the nonce optional ONLY if it's missing from the returned jwt

## What kind of change does this PR introduce?

Fix(?) When using native auth on some platforms like Flutter's sign in with google, the idtoken that is returned does not contain a nonce.

## What is the current behavior?

The current behavior requires a nonce inside the id_token as well as a nonce passed.

## What is the new behavior?

If there is a nonce in the id_token, then a nonce is required in the body and vice versa.


Fixes and adds support for
https://github.com/supabase/gotrue/issues/412
https://github.com/supabase-community/gotrue-dart/issues/27
https://github.com/supabase-community/supabase-flutter/issues/5