### PR TITLE
fix: reauthenticate bugs

### DIFF
--- a/api/phone_test.go
+++ b/api/phone_test.go
@@ -1,8 +1,15 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
@@ -114,6 +121,88 @@ func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
 				require.NotEmpty(ts.T(), u.ReauthenticationSentAt)
 			default:
 			}
+		})
+	}
+}
+
+func (ts *PhoneTestSuite) TestMissingTwilioProviderConfig() {
+	u, err := models.FindUserByPhoneAndAudience(ts.API.db, ts.instanceID, "123456789", ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+	now := time.Now()
+	u.PhoneConfirmedAt = &now
+	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
+
+	token, err := generateAccessToken(u, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	require.NoError(ts.T(), err)
+
+	cases := []struct {
+		desc     string
+		endpoint string
+		method   string
+		header   string
+		body     map[string]string
+		expected map[string]interface{}
+	}{
+		{
+			"Signup",
+			"/signup",
+			http.MethodPost,
+			"",
+			map[string]string{
+				"phone":    "1234567890",
+				"password": "testpassword",
+			},
+			map[string]interface{}{
+				"code":    http.StatusBadRequest,
+				"message": "Error sending confirmation sms:",
+			},
+		},
+		{
+			"Sms OTP",
+			"/otp",
+			http.MethodPost,
+			"",
+			map[string]string{
+				"phone": "123456789",
+			},
+			map[string]interface{}{
+				"code":    http.StatusBadRequest,
+				"message": "Error sending sms:",
+			},
+		},
+		{
+			"Reauthenticate",
+			"/reauthenticate",
+			http.MethodGet,
+			"",
+			nil,
+			map[string]interface{}{
+				"code":    http.StatusBadRequest,
+				"message": "Error sending sms:",
+			},
+		},
+	}
+
+	ts.Config.External.Phone.Enabled = true
+	for _, c := range cases {
+		ts.Run(c.desc, func() {
+			ts.Config.Sms.Provider = "twilio"
+			ts.Config.Sms.Twilio.AccountSid = ""
+			ts.Config.Sms.Twilio.MessageServiceSid = ""
+
+			var buffer bytes.Buffer
+			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(c.body))
+
+			req := httptest.NewRequest(c.method, "http://localhost"+c.endpoint, &buffer)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+			w := httptest.NewRecorder()
+			ts.API.handler.ServeHTTP(w, req)
+			require.Equal(ts.T(), c.expected["code"], w.Code)
+
+			body := w.Body.String()
+			require.True(ts.T(), strings.Contains(body, c.expected["message"].(string)))
 		})
 	}
 }

--- a/api/phone_test.go
+++ b/api/phone_test.go
@@ -171,6 +171,19 @@ func (ts *PhoneTestSuite) TestMissingTwilioProviderConfig() {
 			},
 		},
 		{
+			"Phone change",
+			"/user",
+			http.MethodPut,
+			token,
+			map[string]string{
+				"phone": "111111111",
+			},
+			map[string]interface{}{
+				"code":    http.StatusBadRequest,
+				"message": "Error sending sms:",
+			},
+		},
+		{
 			"Reauthenticate",
 			"/reauthenticate",
 			http.MethodGet,

--- a/api/reauthenticate.go
+++ b/api/reauthenticate.go
@@ -12,6 +12,8 @@ import (
 	"github.com/netlify/gotrue/storage"
 )
 
+const InvalidNonceMessage = "Nonce has expired or is invalid"
+
 // Reauthenticate sends a reauthentication otp to either the user's email or phone
 func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
@@ -59,7 +61,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return badRequestError("Error sending sms: %v", terr)
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, phone, recoveryVerification, smsProvider)
+			return a.sendPhoneConfirmation(ctx, tx, user, phone, phoneReauthenticationOtp, smsProvider)
 		}
 		return nil
 	})
@@ -76,7 +78,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 // verifyReauthentication checks if the nonce provided is valid
 func (a *API) verifyReauthentication(nonce string, tx *storage.Connection, config *conf.Configuration, user *models.User) error {
 	if user.ReauthenticationToken == "" || user.ReauthenticationSentAt == nil {
-		return unauthorizedError("Requires reauthentication")
+		return badRequestError(InvalidNonceMessage)
 	}
 	var isValid bool
 	if user.GetEmail() != "" {
@@ -89,7 +91,7 @@ func (a *API) verifyReauthentication(nonce string, tx *storage.Connection, confi
 		return unprocessableEntityError("Reauthentication requires an email or a phone number")
 	}
 	if !isValid {
-		return badRequestError("Nonce has expired or is invalid")
+		return badRequestError(InvalidNonceMessage)
 	}
 	if err := user.ConfirmReauthentication(tx); err != nil {
 		return internalServerError("Error during reauthentication").WithInternalError(err)

--- a/api/reauthenticate.go
+++ b/api/reauthenticate.go
@@ -69,7 +69,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 		if errors.Is(err, MaxFrequencyLimitError) {
 			return tooManyRequestsError("For security purposes, you can only request this once every 60 seconds")
 		}
-		return internalServerError("Reauthentication failed.").WithInternalError(err)
+		return err
 	}
 
 	return sendJSON(w, http.StatusOK, make(map[string]string))

--- a/api/recover.go
+++ b/api/recover.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/netlify/gotrue/api/sms_provider"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 )
@@ -13,7 +12,6 @@ import (
 // RecoverParams holds the parameters for a password recovery request
 type RecoverParams struct {
 	Email string `json:"email"`
-	Phone string `json:"phone"`
 }
 
 // Recover sends a recovery email
@@ -28,25 +26,17 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read verification params: %v", err)
 	}
 
-	if params.Email == "" && params.Phone == "" {
-		return unprocessableEntityError("Password recovery requires an email or a phone number")
+	if params.Email == "" {
+		return unprocessableEntityError("Password recovery requires an email")
 	}
 
 	var user *models.User
 	aud := a.requestAud(ctx, r)
 	recoverErrorMessage := "If a user exists, you will receive an email with instructions on how to reset your password."
-	if params.Email != "" {
-		if err := a.validateEmail(ctx, params.Email); err != nil {
-			return err
-		}
-		user, err = models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
-	} else if params.Phone != "" {
-		params.Phone, err = a.validatePhone(params.Phone)
-		if err != nil {
-			return err
-		}
-		user, err = models.FindUserByPhoneAndAudience(a.db, instanceID, params.Phone, aud)
+	if err := a.validateEmail(ctx, params.Email); err != nil {
+		return err
 	}
+	user, err = models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
 
 	if err != nil {
 		if models.IsNotFoundError(err) {
@@ -59,18 +49,9 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(tx, instanceID, user, models.UserRecoveryRequestedAction, nil); terr != nil {
 			return terr
 		}
-		if params.Email != "" {
-			mailer := a.Mailer(ctx)
-			referrer := a.getReferrer(r)
-			return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency, referrer)
-		} else if params.Phone != "" {
-			smsProvider, terr := sms_provider.GetSmsProvider(*config)
-			if terr != nil {
-				return badRequestError("Error sending sms: %v", terr)
-			}
-			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, recoveryVerification, smsProvider)
-		}
-		return nil
+		mailer := a.Mailer(ctx)
+		referrer := a.getReferrer(r)
+		return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency, referrer)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -224,7 +224,7 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 			"newpassword123",
 			"123456",
 			true,
-			expected{code: http.StatusUnauthorized, isAuthenticated: false},
+			expected{code: http.StatusBadRequest, isAuthenticated: false},
 		},
 	}
 
@@ -244,7 +244,7 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 			// Setup response recorder
 			w := httptest.NewRecorder()
 			ts.API.handler.ServeHTTP(w, req)
-			require.Equal(ts.T(), w.Code, c.expected.code)
+			require.Equal(ts.T(), c.expected.code, w.Code)
 
 			// Request body
 			u, err = models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Add tests for phone auth failures
* remove phone recovery logic from recover endpoint (can just use `/otp` for phone recovery)
* return consistent error messages for `/signup`, `/otp`, `/reauthenticate`, `PUT /user` (phone_change) 