### PR TITLE
fix: user email & phone update

### DIFF
--- a/api/reauthenticate.go
+++ b/api/reauthenticate.go
@@ -3,7 +3,6 @@ package api
 import (
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/api/sms_provider"
@@ -80,11 +79,9 @@ func (a *API) verifyReauthentication(nonce string, tx *storage.Connection, confi
 	}
 	var isValid bool
 	if user.GetEmail() != "" {
-		mailerOtpExpiresAt := time.Second * time.Duration(config.Mailer.OtpExp)
-		isValid = isOtpValid(nonce, user.ReauthenticationToken, user.ReauthenticationSentAt.Add(mailerOtpExpiresAt))
+		isValid = isOtpValid(nonce, user.ReauthenticationToken, user.ReauthenticationSentAt, config.Mailer.OtpExp)
 	} else if user.GetPhone() != "" {
-		smsOtpExpiresAt := time.Second * time.Duration(config.Sms.OtpExp)
-		isValid = isOtpValid(nonce, user.ReauthenticationToken, user.ReauthenticationSentAt.Add(smsOtpExpiresAt))
+		isValid = isOtpValid(nonce, user.ReauthenticationToken, user.ReauthenticationSentAt, config.Sms.OtpExp)
 	} else {
 		return unprocessableEntityError("Reauthentication requires an email or a phone number")
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -137,7 +137,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		if params.Phone != "" {
+		if params.Phone != "" && params.Phone != user.GetPhone() {
 			params.Phone, err = a.validatePhone(params.Phone)
 			if err != nil {
 				return err

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -148,7 +148,7 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 			map[string]string{
 				"phone": "123456789",
 			},
-			http.StatusUnprocessableEntity,
+			http.StatusOK,
 		},
 		{
 			"New phone number is different from current phone number",

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -138,6 +138,11 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
+	existingUser, err := models.NewUser(ts.instanceID, "", "", ts.Config.JWT.Aud, nil)
+	existingUser.Phone = "22222222"
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.API.db.Create(existingUser))
+
 	cases := []struct {
 		desc         string
 		userData     map[string]string
@@ -149,6 +154,13 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 				"phone": "123456789",
 			},
 			http.StatusOK,
+		},
+		{
+			"New phone number exists already",
+			map[string]string{
+				"phone": "22222222",
+			},
+			http.StatusUnprocessableEntity,
 		},
 		{
 			"New phone number is different from current phone number",

--- a/api/verify.go
+++ b/api/verify.go
@@ -355,7 +355,12 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 		if err != nil {
 			return nil, err
 		}
-		user, err = models.FindUserByPhoneAndAudience(conn, instanceID, params.Phone, aud)
+		switch params.Type {
+		case phoneChangeVerification:
+			user, err = models.FindUserWithPhoneChange(conn, params.Phone)
+		case smsVerification:
+			user, err = models.FindUserByPhoneAndAudience(conn, instanceID, params.Phone, aud)
+		}
 	} else if isEmailOtpVerification(params) {
 		if err := a.validateEmail(ctx, params.Email); err != nil {
 			return nil, unprocessableEntityError("Invalid email format").WithInternalError(err)
@@ -377,25 +382,22 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 	}
 
 	var isValid bool
-	mailerOtpExpiresAt := time.Second * time.Duration(config.Mailer.OtpExp)
-	smsOtpExpiresAt := time.Second * time.Duration(config.Sms.OtpExp)
 	switch params.Type {
 	case signupVerification, inviteVerification:
-		isValid = isOtpValid(params.Token, user.ConfirmationToken, user.ConfirmationSentAt.Add(mailerOtpExpiresAt))
+		isValid = isOtpValid(params.Token, user.ConfirmationToken, user.ConfirmationSentAt, config.Mailer.OtpExp)
 	case recoveryVerification, magicLinkVerification:
-		isValid = isOtpValid(params.Token, user.RecoveryToken, user.RecoverySentAt.Add(mailerOtpExpiresAt))
+		isValid = isOtpValid(params.Token, user.RecoveryToken, user.RecoverySentAt, config.Mailer.OtpExp)
 	case emailChangeVerification:
-		expiresAt := user.EmailChangeSentAt.Add(mailerOtpExpiresAt)
-		isValid = isOtpValid(params.Token, user.EmailChangeTokenCurrent, expiresAt) || isOtpValid(params.Token, user.EmailChangeTokenNew, expiresAt)
+		isValid = isOtpValid(params.Token, user.EmailChangeTokenCurrent, user.EmailChangeSentAt, config.Mailer.OtpExp) || isOtpValid(params.Token, user.EmailChangeTokenNew, user.EmailChangeSentAt, config.Mailer.OtpExp)
 		if !isValid {
 			// reset email confirmation status
 			user.EmailChangeConfirmStatus = zeroConfirmation
 			err = conn.UpdateOnly(user, "email_change_confirm_status")
 		}
 	case phoneChangeVerification:
-		isValid = isOtpValid(params.Token, user.PhoneChangeToken, user.PhoneChangeSentAt.Add(smsOtpExpiresAt))
+		isValid = isOtpValid(params.Token, user.PhoneChangeToken, user.PhoneChangeSentAt, config.Sms.OtpExp)
 	case smsVerification:
-		isValid = isOtpValid(params.Token, user.ConfirmationToken, user.ConfirmationSentAt.Add(smsOtpExpiresAt))
+		isValid = isOtpValid(params.Token, user.ConfirmationToken, user.ConfirmationSentAt, config.Sms.OtpExp)
 	}
 
 	if !isValid || err != nil {
@@ -405,7 +407,11 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 }
 
 // isOtpValid checks the actual otp sent against the expected otp and ensures that it's within the valid window
-func isOtpValid(actual, expected string, expiresAt time.Time) bool {
+func isOtpValid(actual, expected string, sentAt *time.Time, otpExp uint) bool {
+	if expected == "" || sentAt == nil {
+		return false
+	}
+	expiresAt := sentAt.Add(time.Second * time.Duration(otpExp))
 	return time.Now().Before(expiresAt) && (actual == expected)
 }
 

--- a/models/user.go
+++ b/models/user.go
@@ -444,9 +444,9 @@ func FindUsersInAudience(tx *storage.Connection, instanceID uuid.UUID, aud strin
 	return users, err
 }
 
-// FindUserWithPhoneAndPhoneChangeToken finds a user with the matching phone and phone change token
-func FindUserWithPhoneAndPhoneChangeToken(tx *storage.Connection, phone, token string) (*User, error) {
-	return findUser(tx, "phone = ? and phone_change_token = ?", phone, token)
+// FindUserWithPhoneChange finds a user with the matching phone_change
+func FindUserWithPhoneChange(tx *storage.Connection, phoneChange string) (*User, error) {
+	return findUser(tx, "phone_change = ?", phoneChange)
 }
 
 // IsDuplicatedEmail returns whether a user exists with a matching email and audience.


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Modifies DX for verifying a phone update
```
// Previous (POST /verify)
{
  "phone": "11111111", // old phone number
  "token": "123456",  // token sent to new phone number
  "type": "phone_change"
}

// New (POST /verify)
{
  "phone": "222222222", // new phone number
  "token": "123456",  // token sent to new phone number
  "type": "phone_change"
}
```

* Return clearer response for email change verification (when `SECURE_EMAIL_CHANGE_ENABLED = true`)
```
// Previous (POST /verify) - First confirmation
{
  "email": "foo@example.com", 
  "token": "123456",  
  "type": "email_change"
}
// Response
null

// New (POST /verify) - First confirmation
{
  "email": "foo@example.com",
  "token": "123456",  
  "type": "email_change"
}

// Response
{
  "code": "200",
  "msg": "Confirmation link accepted. Please proceed to confirm link sent to the other email"
}
```

* Refactored `isOtpValid` to include:
  * Calculation of the sentAt expiry time
  * Check if the token is empty or if the sentAt is nil

* Fix bug in email change verification where the following was allowed (when `SECURE_EMAIL_CHANGE_ENABLED = true`):
  * Sending an email verification request with an email and either the token sent to the old email or new email will result in a successful response (it should only return a successful response when the email and token came from the same pair)
