### PR TITLE
fix: use email change template for current and new

### DIFF
--- a/mailer/template.go
+++ b/mailer/template.go
@@ -153,7 +153,7 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) 
 			Address:  user.EmailChange,
 			Token:    user.EmailChangeTokenNew,
 			Subject:  string(withDefault(m.Config.Mailer.Subjects.EmailChange, "Confirm Email Change")),
-			Template: m.Config.Mailer.Templates.Confirmation,
+			Template: m.Config.Mailer.Templates.EmailChange,
 		},
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* When a user updates their email, an email change template will always be sent to the new email instead of a confirm email template 