### PR TITLE
fix: shorten email otp 

### DIFF
--- a/api/mail.go
+++ b/api/mail.go
@@ -174,7 +174,7 @@ func sendConfirmation(tx *storage.Connection, u *models.User, mailer mailer.Mail
 		return MaxFrequencyLimitError
 	}
 	oldToken := u.ConfirmationToken
-	u.ConfirmationToken, err = generateUniqueEmailOtp(tx, "confirmation_token")
+	u.ConfirmationToken, err = generateUniqueEmailOtp(tx, confirmationToken)
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func sendConfirmation(tx *storage.Connection, u *models.User, mailer mailer.Mail
 func sendInvite(tx *storage.Connection, u *models.User, mailer mailer.Mailer, referrerURL string) error {
 	var err error
 	oldToken := u.ConfirmationToken
-	u.ConfirmationToken, err = generateUniqueEmailOtp(tx, "confirmation_token")
+	u.ConfirmationToken, err = generateUniqueEmailOtp(tx, confirmationToken)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (a *API) sendPasswordRecovery(tx *storage.Connection, u *models.User, maile
 	}
 
 	oldToken := u.RecoveryToken
-	u.RecoveryToken, err = generateUniqueEmailOtp(tx, "recovery_token")
+	u.RecoveryToken, err = generateUniqueEmailOtp(tx, recoveryToken)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (a *API) sendReauthenticationOtp(tx *storage.Connection, u *models.User, ma
 	}
 
 	oldToken := u.ReauthenticationToken
-	u.ReauthenticationToken, err = generateUniqueEmailOtp(tx, "reauthentication_token")
+	u.ReauthenticationToken, err = generateUniqueEmailOtp(tx, reauthenticationToken)
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func (a *API) sendMagicLink(tx *storage.Connection, u *models.User, mailer maile
 		return MaxFrequencyLimitError
 	}
 	oldToken := u.RecoveryToken
-	u.RecoveryToken, err = generateUniqueEmailOtp(tx, "recovery_token")
+	u.RecoveryToken, err = generateUniqueEmailOtp(tx, recoveryToken)
 	if err != nil {
 		return err
 	}
@@ -268,12 +268,12 @@ func (a *API) sendMagicLink(tx *storage.Connection, u *models.User, mailer maile
 // sendEmailChange sends out an email change token to the new email.
 func (a *API) sendEmailChange(tx *storage.Connection, config *conf.Configuration, u *models.User, mailer mailer.Mailer, email string, referrerURL string) error {
 	var err error
-	u.EmailChangeTokenNew, err = generateUniqueEmailOtp(tx, "email_change_token_new")
+	u.EmailChangeTokenNew, err = generateUniqueEmailOtp(tx, emailChangeTokenNew)
 	if err != nil {
 		return err
 	}
 	if config.Mailer.SecureEmailChangeEnabled && u.GetEmail() != "" {
-		u.EmailChangeTokenCurrent, err = generateUniqueEmailOtp(tx, "email_change_token_current")
+		u.EmailChangeTokenCurrent, err = generateUniqueEmailOtp(tx, emailChangeTokenCurrent)
 		if err != nil {
 			return err
 		}
@@ -308,7 +308,7 @@ func (a *API) validateEmail(ctx context.Context, email string) error {
 }
 
 // generateUniqueEmailOtp returns a unique otp
-func generateUniqueEmailOtp(tx *storage.Connection, tokenType string) (string, error) {
+func generateUniqueEmailOtp(tx *storage.Connection, tokenType tokenType) (string, error) {
 	maxRetries := 5
 	otpLength := 10
 	var otp string
@@ -318,7 +318,7 @@ func generateUniqueEmailOtp(tx *storage.Connection, tokenType string) (string, e
 		if err != nil {
 			return "", err
 		}
-		_, err = models.FindUserByTokenAndTokenType(tx, otp, tokenType)
+		_, err = models.FindUserByTokenAndTokenType(tx, otp, string(tokenType))
 		if err != nil {
 			if models.IsNotFoundError(err) {
 				return otp, nil

--- a/api/mail.go
+++ b/api/mail.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-password/password"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -168,12 +169,15 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 }
 
 func sendConfirmation(tx *storage.Connection, u *models.User, mailer mailer.Mailer, maxFrequency time.Duration, referrerURL string) error {
+	var err error
 	if u.ConfirmationSentAt != nil && !u.ConfirmationSentAt.Add(maxFrequency).Before(time.Now()) {
 		return MaxFrequencyLimitError
 	}
-
 	oldToken := u.ConfirmationToken
-	u.ConfirmationToken = crypto.SecureToken()
+	u.ConfirmationToken, err = generateUniqueEmailOtp(tx, "confirmation_token")
+	if err != nil {
+		return err
+	}
 	now := time.Now()
 	if err := mailer.ConfirmationMail(u, referrerURL); err != nil {
 		u.ConfirmationToken = oldToken
@@ -184,8 +188,12 @@ func sendConfirmation(tx *storage.Connection, u *models.User, mailer mailer.Mail
 }
 
 func sendInvite(tx *storage.Connection, u *models.User, mailer mailer.Mailer, referrerURL string) error {
+	var err error
 	oldToken := u.ConfirmationToken
-	u.ConfirmationToken = crypto.SecureToken()
+	u.ConfirmationToken, err = generateUniqueEmailOtp(tx, "confirmation_token")
+	if err != nil {
+		return err
+	}
 	now := time.Now()
 	if err := mailer.InviteMail(u, referrerURL); err != nil {
 		u.ConfirmationToken = oldToken
@@ -197,12 +205,16 @@ func sendInvite(tx *storage.Connection, u *models.User, mailer mailer.Mailer, re
 }
 
 func (a *API) sendPasswordRecovery(tx *storage.Connection, u *models.User, mailer mailer.Mailer, maxFrequency time.Duration, referrerURL string) error {
+	var err error
 	if u.RecoverySentAt != nil && !u.RecoverySentAt.Add(maxFrequency).Before(time.Now()) {
 		return MaxFrequencyLimitError
 	}
 
 	oldToken := u.RecoveryToken
-	u.RecoveryToken = crypto.SecureToken()
+	u.RecoveryToken, err = generateUniqueEmailOtp(tx, "recovery_token")
+	if err != nil {
+		return err
+	}
 	now := time.Now()
 	if err := mailer.RecoveryMail(u, referrerURL); err != nil {
 		u.RecoveryToken = oldToken
@@ -213,12 +225,16 @@ func (a *API) sendPasswordRecovery(tx *storage.Connection, u *models.User, maile
 }
 
 func (a *API) sendReauthenticationOtp(tx *storage.Connection, u *models.User, mailer mailer.Mailer, maxFrequency time.Duration) error {
+	var err error
 	if u.ReauthenticationSentAt != nil && !u.ReauthenticationSentAt.Add(maxFrequency).Before(time.Now()) {
 		return MaxFrequencyLimitError
 	}
 
 	oldToken := u.ReauthenticationToken
-	u.ReauthenticationToken = crypto.SecureToken()
+	u.ReauthenticationToken, err = generateUniqueEmailOtp(tx, "reauthentication_token")
+	if err != nil {
+		return err
+	}
 	now := time.Now()
 	if err := mailer.ReauthenticateMail(u); err != nil {
 		u.ReauthenticationToken = oldToken
@@ -229,14 +245,17 @@ func (a *API) sendReauthenticationOtp(tx *storage.Connection, u *models.User, ma
 }
 
 func (a *API) sendMagicLink(tx *storage.Connection, u *models.User, mailer mailer.Mailer, maxFrequency time.Duration, referrerURL string) error {
+	var err error
 	// since Magic Link is just a recovery with a different template and behaviour
 	// around new users we will reuse the recovery db timer to prevent potential abuse
 	if u.RecoverySentAt != nil && !u.RecoverySentAt.Add(maxFrequency).Before(time.Now()) {
 		return MaxFrequencyLimitError
 	}
-
 	oldToken := u.RecoveryToken
-	u.RecoveryToken = crypto.SecureToken()
+	u.RecoveryToken, err = generateUniqueEmailOtp(tx, "recovery_token")
+	if err != nil {
+		return err
+	}
 	now := time.Now()
 	if err := mailer.MagicLinkMail(u, referrerURL); err != nil {
 		u.RecoveryToken = oldToken
@@ -248,9 +267,16 @@ func (a *API) sendMagicLink(tx *storage.Connection, u *models.User, mailer maile
 
 // sendEmailChange sends out an email change token to the new email.
 func (a *API) sendEmailChange(tx *storage.Connection, config *conf.Configuration, u *models.User, mailer mailer.Mailer, email string, referrerURL string) error {
-	u.EmailChangeTokenNew = crypto.SecureToken()
+	var err error
+	u.EmailChangeTokenNew, err = generateUniqueEmailOtp(tx, "email_change_token_new")
+	if err != nil {
+		return err
+	}
 	if config.Mailer.SecureEmailChangeEnabled && u.GetEmail() != "" {
-		u.EmailChangeTokenCurrent = crypto.SecureToken()
+		u.EmailChangeTokenCurrent, err = generateUniqueEmailOtp(tx, "email_change_token_current")
+		if err != nil {
+			return err
+		}
 	}
 	u.EmailChange = email
 	u.EmailChangeConfirmStatus = zeroConfirmation
@@ -279,4 +305,31 @@ func (a *API) validateEmail(ctx context.Context, email string) error {
 		return unprocessableEntityError("Unable to validate email address: " + err.Error())
 	}
 	return nil
+}
+
+// generateUniqueEmailOtp returns a unique otp
+func generateUniqueEmailOtp(tx *storage.Connection, tokenType string) (string, error) {
+	maxRetries := 5
+	otpLength := 10
+	var otp string
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		otp, err = crypto.GenerateEmailOtp(otpLength)
+		if err != nil {
+			return "", err
+		}
+		_, err = models.FindUserByTokenAndTokenType(tx, otp, tokenType)
+		if err != nil {
+			if models.IsNotFoundError(err) {
+				return otp, nil
+			}
+			return "", err
+		}
+		logrus.Warn("otp generated is not unique, retrying.")
+		err = errors.New("Could not generate a unique email otp")
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", errors.New("Could not generate a unique email otp")
 }

--- a/api/mail.go
+++ b/api/mail.go
@@ -310,7 +310,7 @@ func (a *API) validateEmail(ctx context.Context, email string) error {
 // generateUniqueEmailOtp returns a unique otp
 func generateUniqueEmailOtp(tx *storage.Connection, tokenType tokenType) (string, error) {
 	maxRetries := 5
-	otpLength := 10
+	otpLength := 20
 	var otp string
 	var err error
 	for i := 0; i < maxRetries; i++ {

--- a/api/token.go
+++ b/api/token.go
@@ -58,6 +58,16 @@ type IdTokenGrantParams struct {
 	Issuer   string `json:"issuer"`
 }
 
+type tokenType string
+
+const (
+	confirmationToken       tokenType = "confirmation_token"
+	recoveryToken           tokenType = "recovery_token"
+	emailChangeTokenNew     tokenType = "email_change_token_new"
+	emailChangeTokenCurrent tokenType = "email_change_token_current"
+	reauthenticationToken   tokenType = "reauthentication_token"
+)
+
 const useCookieHeader = "x-use-cookie"
 const useSessionCookie = "session"
 const InvalidLoginMessage = "Invalid login credentials"

--- a/api/verify.go
+++ b/api/verify.go
@@ -36,6 +36,7 @@ const (
 )
 
 const (
+	// v1 uses crypto.SecureToken()
 	v1OtpLength = 22
 )
 

--- a/api/verify.go
+++ b/api/verify.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/netlify/gotrue/models"
@@ -32,6 +33,10 @@ const (
 const (
 	zeroConfirmation int = iota
 	singleConfirmation
+)
+
+const (
+	v1OtpLength = 22
 )
 
 // Only applicable when SECURE_EMAIL_CHANGE_ENABLED
@@ -76,6 +81,10 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 		var terr error
 		if params.Token == "" {
 			return badRequestError("Verify requires a token")
+		}
+		if len(params.Token) > v1OtpLength {
+			// token follows the v2 format and includes "-"
+			params.Token = strings.ReplaceAll(params.Token, "-", "")
 		}
 		if params.Type == "" {
 			return badRequestError("Verify requires a verification type")
@@ -152,6 +161,10 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
 
 	if params.Token == "" {
 		return badRequestError("Verify requires a token")
+	}
+	if len(params.Token) > v1OtpLength {
+		// token follows the v2 format and includes "-"
+		params.Token = strings.ReplaceAll(params.Token, "-", "")
 	}
 
 	if params.Type == "" {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -37,3 +37,22 @@ func GenerateOtp(digits int) (string, error) {
 	otp := fmt.Sprintf(expr, val.String())
 	return otp, nil
 }
+
+// GenerateOtpFromCharset generates a random n-length otp from a charset
+func GenerateOtpFromCharset(length int, charset string) (string, error) {
+	b := make([]byte, length)
+	for i := range b {
+		val, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			return "", errors.WithMessage(err, "Error generating otp from charset")
+		}
+		b[i] = charset[val.Int64()]
+	}
+	return string(b), nil
+}
+
+// GenerateEmailOtp generates a random n-length alphanumeric otp
+func GenerateEmailOtp(length int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	return GenerateOtpFromCharset(length, charset)
+}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"math/big"
 	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -19,11 +18,7 @@ func SecureToken() string {
 	if _, err := io.ReadFull(rand.Reader, b); err != nil {
 		panic(err.Error()) // rand should never fail
 	}
-	return removePadding(base64.URLEncoding.EncodeToString(b))
-}
-
-func removePadding(token string) string {
-	return strings.TrimRight(token, "=")
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 // GenerateOtp generates a random n digit otp

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -48,6 +48,6 @@ func GenerateOtpFromCharset(length int, charset string) (string, error) {
 
 // GenerateEmailOtp generates a random n-length alphanumeric otp
 func GenerateEmailOtp(length int) (string, error) {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	const charset = "abcdefghijklmnopqrstuvwxyz"
 	return GenerateOtpFromCharset(length, charset)
 }

--- a/migrations/20220412150300_add_unique_idx.up.sql
+++ b/migrations/20220412150300_add_unique_idx.up.sql
@@ -4,5 +4,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS confirmation_token_idx ON auth.users USING btr
 CREATE UNIQUE INDEX IF NOT EXISTS recovery_token_idx ON auth.users USING btree (recovery_token) WHERE recovery_token != '';
 CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_current_idx ON auth.users USING btree (email_change_token_current) WHERE email_change_token_current != '';
 CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_new_idx ON auth.users USING btree (email_change_token_new) WHERE email_change_token_new != '';
-CREATE UNIQUE INDEX IF NOT EXISTS phone_change_token_idx ON auth.users USING btree (phone_change_token) WHERE phone_change_token != '';
 CREATE UNIQUE INDEX IF NOT EXISTS reauthentication_token_idx ON auth.users USING btree (reauthentication_token) WHERE reauthentication_token != '';

--- a/migrations/20220412150300_add_unique_idx.up.sql
+++ b/migrations/20220412150300_add_unique_idx.up.sql
@@ -1,0 +1,8 @@
+-- add partial unique indices to confirmation_token, recovery_token, email_change_token_current, email_change_token_new, phone_change_token, reauthentication_token
+
+CREATE UNIQUE INDEX IF NOT EXISTS confirmation_token_idx ON auth.users USING btree (confirmation_token) WHERE confirmation_token != '';
+CREATE UNIQUE INDEX IF NOT EXISTS recovery_token_idx ON auth.users USING btree (recovery_token) WHERE recovery_token != '';
+CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_current_idx ON auth.users USING btree (email_change_token_current) WHERE email_change_token_current != '';
+CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_new_idx ON auth.users USING btree (email_change_token_new) WHERE email_change_token_new != '';
+CREATE UNIQUE INDEX IF NOT EXISTS phone_change_token_idx ON auth.users USING btree (phone_change_token) WHERE phone_change_token != '';
+CREATE UNIQUE INDEX IF NOT EXISTS reauthentication_token_idx ON auth.users USING btree (reauthentication_token) WHERE reauthentication_token != '';

--- a/models/user.go
+++ b/models/user.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 	"time"
 
@@ -396,6 +397,12 @@ func FindUserByRecoveryToken(tx *storage.Connection, token string) (*User, error
 // FindUserByEmailChangeToken finds a user with the matching email change token.
 func FindUserByEmailChangeToken(tx *storage.Connection, token string) (*User, error) {
 	return findUser(tx, "email_change_token_current = ? or email_change_token_new = ?", token, token)
+}
+
+// FindUserByTokenAndTokenType finds a user with the matching token and token type.
+func FindUserByTokenAndTokenType(tx *storage.Connection, token string, tokenType string) (*User, error) {
+	query := fmt.Sprintf("%v = ?", tokenType)
+	return findUser(tx, query, token)
 }
 
 // FindUserWithRefreshToken finds a user from the provided refresh token.


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Shortens email otp sent when the user requests for a confirmation, recovery, invite, email change, reauthentication and magic links
* Email otps will now be sent with a fixed length of 10 and will only contain alphanumeric characters
* Adds a partial unique index on the following db fields: `confirmation_token`, `recovery_token`, `email_change_token_new`, `email_change_token_current`, `reauthentication_token`
