### PR TITLE
Add dev containers with hot reload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,48 @@ Docs aren't perfect and so we're here to help. If you're stuck on setup for more
 
 Please help us keep all our projects open and inclusive. Kindly follow our [Code of Conduct](<(CODE_OF_CONDUCT.md)>) to keep the ecosystem healthy and friendly for all.
 
+## Quick Start
+
+GoTrue has a development container setup that makes it easy to get started contributing. This setup only requires that [Docker](https://www.docker.com/get-started) is setup on your system. The development container setup includes a PostgreSQL container with migrations already applied and a container running GoTrue that will perform a hot reload when changes to the source code are detected.
+
+If you would like to run GoTrue locally or learn more about what these containers are doing for you, continue reading the [Setup and Tooling](#setup-and-tooling) section below. Otherwise, you can skip ahead to the [How To Verify that GoTrue is Available](#how-to-verify-that-gotrue-is-available) section to learn about working with and developing GoTrue.
+
+Before using the containers, you will need to make sure an `.env` file exists by making a copy of `example.env` and configuring it for your needs. A required change for the containers is that the `DATABASE_URL` be changed to `postgres://supabase_auth_admin:root@localhost:5432/postgres` where the address of the Postgres container is changed to `localhost`.
+
+The following are some basic commands. A full and up to date list of commands can be found in the project's `Makefile` or by running `make help`.
+
+### Starting the containers
+
+Start the containers as described above in an attached state with log output.
+
+``` bash
+make dev
+```
+
+### Running tests in the containers
+
+Start the containers with a fresh database and run the project's tests.
+
+``` bash
+make docker-test
+```
+
+### Removing the containers
+
+Remove both containers and their volumes. This removes any data associated with the containers.
+
+``` bash
+make docker-clean
+```
+
+### Rebuild the containers
+
+Fully rebuild the containers without using any cached layers.
+
+``` bash
+make docker-build
+```
+
 ## Setup and Tooling
 
 GoTrue -- as the name implies -- is a user registration and authentication API developed in [Go](https://go.dev).

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,22 @@
+FROM golang:1.17-alpine
+ENV GO111MODULE=on
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+
+RUN apk add --no-cache make git bash
+
+WORKDIR /go/src/github.com/netlify/gotrue
+
+# Pulling dependencies
+COPY ./Makefile ./go.* ./
+
+# Production dependencies
+RUN make deps
+
+# Development dependences
+RUN go get -u github.com/Thatooine/go-test-html-report
+RUN go get github.com/githubnemo/CompileDaemon
+RUN go install github.com/githubnemo/CompileDaemon
+
+RUN adduser -D -u 1000 netlify
+USER netlify

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: ## Build the binary.
 	GOOS=linux GOARCH=arm64 go build $(FLAGS) -o gotrue-arm64
 
 deps: ## Install dependencies.
-	@go install github.com/gobuffalo/pop/soda@latest	
+	@go install github.com/gobuffalo/pop/soda@latest
 	@go install golang.org/x/lint/golint@latest
 	@go mod download
 
@@ -33,3 +33,23 @@ test: ## Run tests.
 
 vet: # Vet the code
 	go vet $(CHECK_FILES)
+
+
+# Run the development containers
+dev:
+	docker-compose -f docker-compose-dev.yml up
+
+# Run the tests using the development containers
+docker-test:
+	docker-compose -f docker-compose-dev.yml up -d postgres
+	docker-compose -f docker-compose-dev.yml run gotrue sh -c "./hack/migrate.sh postgres"
+	docker-compose -f docker-compose-dev.yml run gotrue sh -c "make test"
+	docker-compose -f docker-compose-dev.yml down -v
+
+# Remove the development containers and volumes
+docker-build:
+	docker-compose -f docker-compose-dev.yml build --no-cache
+
+# Remove the development containers and volumes
+docker-clean:
+	docker-compose -f docker-compose-dev.yml rm -fsv

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  gotrue:
+    container_name: gotrue
+    depends_on:
+      - postgres
+    build:
+      context: ./
+      dockerfile: Dockerfile.dev
+    # Not sure why ports aren't working. Using host as a hack
+    # ports:
+    #   - "9999:9999"
+    network_mode: "host"
+    environment:
+      - GOTRUE_DB_MIGRATIONS_PATH=/go/src/github.com/netlify/gotrue/migrations
+    volumes:
+      - ./:/go/src/github.com/netlify/gotrue
+    command: CompileDaemon --build="make build" --directory=/go/src/github.com/netlify/gotrue --recursive=true -pattern=(.+\.go|.+\.env) -exclude=gotrue -exclude=gotrue-arm64 --command=/go/src/github.com/netlify/gotrue/gotrue
+  postgres:
+    image: postgres:13
+    container_name: postgres
+    network_mode: "host"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ${PWD}/hack/init_postgres.sql:/docker-entrypoint-initdb.d/init.sql
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=root
+      - POSTGRES_DB=postgres
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## What kind of change does this PR introduce?

I setup my local development to use containers with hot reload. I made the changes pretty quick so there is room for improvement but I figured others could benefit from the changes. Everything was done without effecting the current development work flow. Improving the development setup will make it easier for others to get involved in the project. If these changes look good then I will do a followup PR to update documentation.

## What is the current behavior?

Anyone wishing to work on GoTrue must install manually dependencies locally and rebuild the binary every time they make a change.

## What is the new behavior?

Dependencies are installed within a container which will automatically rebuild GoTrue when a change is made to the source code. Everthing is captured in a handful of Makefile commands
