### PR TITLE
Change Discord's discriminator type to string

### DIFF
--- a/api/provider/discord.go
+++ b/api/provider/discord.go
@@ -21,7 +21,7 @@ type discordProvider struct {
 
 type discordUser struct {
 	Avatar        string `json:"avatar"`
-	Discriminator int    `json:"discriminator,string"`
+	Discriminator string    `json:"discriminator,string"`
 	Email         string `json:"email"`
 	ID            string `json:"id"`
 	Name          string `json:"username"`
@@ -80,7 +80,7 @@ func (g discordProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*U
 	// In the case of the Default User Avatar endpoint, the value for
 	// user_discriminator in the path should be the user's discriminator modulo 5
 	if u.Avatar == "" {
-		avatarURL = fmt.Sprintf("https://cdn.discordapp.com/embed/avatars/%d.%s", u.Discriminator%5, extension)
+		avatarURL = fmt.Sprintf("https://cdn.discordapp.com/embed/avatars/%s.%s", u.Discriminator, extension)
 	} else {
 		// https://discord.com/developers/docs/reference#image-formatting:
 		// "In the case of endpoints that support GIFs, the hash will begin with a_

--- a/api/provider/discord.go
+++ b/api/provider/discord.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/netlify/gotrue/conf"
@@ -21,7 +22,7 @@ type discordProvider struct {
 
 type discordUser struct {
 	Avatar        string `json:"avatar"`
-	Discriminator string    `json:"discriminator,string"`
+	Discriminator string `json:"discriminator,string"`
 	Email         string `json:"email"`
 	ID            string `json:"id"`
 	Name          string `json:"username"`
@@ -76,11 +77,15 @@ func (g discordProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*U
 
 	var avatarURL string
 	extension := "png"
-	// https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints:
-	// In the case of the Default User Avatar endpoint, the value for
-	// user_discriminator in the path should be the user's discriminator modulo 5
 	if u.Avatar == "" {
-		avatarURL = fmt.Sprintf("https://cdn.discordapp.com/embed/avatars/%s.%s", u.Discriminator, extension)
+		if intDiscriminator, err := strconv.Atoi(u.Discriminator); err != nil {
+			return nil, err
+		} else {
+			// https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints:
+			// In the case of the Default User Avatar endpoint, the value for
+			// user_discriminator in the path should be the user's discriminator modulo 5
+			avatarURL = fmt.Sprintf("https://cdn.discordapp.com/embed/avatars/%d.%s", intDiscriminator%5, extension)
+		}
 	} else {
 		// https://discord.com/developers/docs/reference#image-formatting:
 		// "In the case of endpoints that support GIFs, the hash will begin with a_


### PR DESCRIPTION
Signed-off-by: Bariq <bariqhibat@gmail.com>

## What kind of change does this PR introduce?

Fix #442

## What is the current behavior?

(Referenced from the issue)
> If you have a Discord discriminator that is #0999 or lower, the metadata stored doesn't respect the 4 int/string length and will show up as #999. In my case it just shows up as #1.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
