### PR TITLE
Add missing migration from supabase/supabase

### DIFF
--- a/migrations/00_init_auth_schema.up.sql
+++ b/migrations/00_init_auth_schema.up.sql
@@ -27,14 +27,30 @@ CREATE extension IF NOT EXISTS pgcrypto         with schema extensions;
 CREATE extension IF NOT EXISTS pgjwt            with schema extensions;
 
 -- Set up auth roles for the developer
+-- create role anon
 DO $$
 BEGIN
 CREATE ROLE anon 			nologin noinherit;
 EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
+-- create role authenticated
+DO $$
+BEGIN
 CREATE ROLE authenticated 	nologin noinherit;
 EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
+-- create role service_role
+DO $$
+BEGIN
 CREATE ROLE service_role 	nologin noinherit bypassrls;
 EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
+-- create user authenticator
+DO $$
+BEGIN
 CREATE user authenticator 	noinherit;
 EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
 END

--- a/migrations/00_init_auth_schema.up.sql
+++ b/migrations/00_init_auth_schema.up.sql
@@ -1,13 +1,5 @@
--- Supabase super admin
-DO $$
-BEGIN
-CREATE USER supabase_admin;
-EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
-END
-$$;
-
 -- auth schema creation
-CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_admin;
+CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_auth_admin;
 
 -- Set up realtime
 CREATE SCHEMA IF NOT EXISTS realtime;
@@ -57,7 +49,7 @@ $$;
 grant anon              to authenticator;
 grant authenticated     to authenticator;
 grant service_role      to authenticator;
-grant supabase_admin    to authenticator;
+grant supabase_auth_admin    to authenticator;
 
 grant usage                     on schema public to postgres, anon, authenticated, service_role;
 ALTER DEFAULT privileges in schema public grant all on tables to postgres, anon, authenticated, service_role;
@@ -68,14 +60,14 @@ ALTER DEFAULT privileges in schema public grant all on sequences to postgres, an
 grant usage                     on schema extensions to postgres, anon, authenticated, service_role;
 
 -- Set up namespacing
-ALTER user supabase_admin SET search_path TO public, extensions; -- don't include the "auth" schema
+ALTER user supabase_auth_admin SET search_path TO public, extensions; -- don't include the "auth" schema
 
--- These are required so that the users receive grants whenever "supabase_admin" creates tables/function
-ALTER DEFAULT privileges for user supabase_admin in schema public grant all
+-- These are required so that the users receive grants whenever "supabase_auth_admin" creates tables/function
+ALTER DEFAULT privileges for user supabase_auth_admin in schema public grant all
     on sequences to postgres, anon, authenticated, service_role;
-ALTER DEFAULT privileges for user supabase_admin in schema public grant all
+ALTER DEFAULT privileges for user supabase_auth_admin in schema public grant all
     on tables to postgres, anon, authenticated, service_role;
-ALTER DEFAULT privileges for user supabase_admin in schema public grant all
+ALTER DEFAULT privileges for user supabase_auth_admin in schema public grant all
     on functions to postgres, anon, authenticated, service_role;
 
 -- Set short statement/query timeouts for API roles

--- a/migrations/00_init_auth_schema.up.sql
+++ b/migrations/00_init_auth_schema.up.sql
@@ -1,6 +1,11 @@
 -- Supabase super admin
-CREATE user supabase_admin;
-ALTER user  supabase_admin with superuser createdb createrole replication bypassrls;
+DO $$
+BEGIN
+CREATE USER supabase_admin;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
+ALTER user supabase_admin with superuser createdb createrole replication bypassrls;
 
 -- auth schema creation
 CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_admin;
@@ -8,7 +13,12 @@ CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_admin;
 -- Set up realtime
 CREATE SCHEMA IF NOT EXISTS realtime;
 -- CREATE publication supabase_realtime; -- defaults to empty publication
+DO $$
+BEGIN
 CREATE publication supabase_realtime;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
 
 -- Extension namespacing
 CREATE schema IF NOT EXISTS extensions;
@@ -17,11 +27,18 @@ CREATE extension IF NOT EXISTS pgcrypto         with schema extensions;
 CREATE extension IF NOT EXISTS pgjwt            with schema extensions;
 
 -- Set up auth roles for the developer
-CREATE role anon                nologin noinherit;
-CREATE role authenticated       nologin noinherit; -- "logged in" user: web_user, app_user, etc
-CREATE role service_role        nologin noinherit bypassrls; -- allow developers to CREATE JWT's that bypass their policies
-
-CREATE user authenticator noinherit;
+DO $$
+BEGIN
+CREATE ROLE anon 			nologin noinherit;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+CREATE ROLE authenticated 	nologin noinherit;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+CREATE ROLE service_role 	nologin noinherit bypassrls;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+CREATE user authenticator 	noinherit;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
 grant anon              to authenticator;
 grant authenticated     to authenticator;
 grant service_role      to authenticator;

--- a/migrations/00_init_auth_schema.up.sql
+++ b/migrations/00_init_auth_schema.up.sql
@@ -5,7 +5,6 @@ CREATE USER supabase_admin;
 EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
 END
 $$;
-ALTER user supabase_admin with superuser createdb createrole replication bypassrls;
 
 -- auth schema creation
 CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_admin;

--- a/migrations/00_init_auth_schema.up.sql
+++ b/migrations/00_init_auth_schema.up.sql
@@ -15,7 +15,7 @@ $$;
 CREATE schema IF NOT EXISTS extensions;
 CREATE extension IF NOT EXISTS "uuid-ossp"      with schema extensions;
 CREATE extension IF NOT EXISTS pgcrypto         with schema extensions;
-CREATE extension IF NOT EXISTS pgjwt            with schema extensions;
+-- CREATE extension IF NOT EXISTS pgjwt            with schema extensions;
 
 -- Set up auth roles for the developer
 -- create role anon


### PR DESCRIPTION
Signed-off-by: Bariq <bariqhibat@gmail.com>

## What kind of change does this PR introduce?

Fix #452

## What is the current behavior?

(Referenced from issue)
> When trying to start a GoTrue instance with an external database the first migration 00_init_auth_schema.up.sql fails because the auth schema is not defined. In the supabase documentation and repo a volume is mounted with a sql script 00-initial-schema.sql responsible for creating the user supabase_admin, roles and extensions. While the first script 01-auth-schema.sql has as its first instruction the creation of the auth schema. It might be useful to bring it into the GoTrue repo as well to allow instances to be launched without manual intervention.

## What is the new behavior?

Added migration 
1. Create `auth` schema if doesn't exists before all other migrations ([ref](https://github.com/supabase/supabase/blob/9db54c2269f5ceaba7588a823bbdac42b18ce06b/docker/volumes/db/init/01-auth-schema.sql#L2))
2. Create `supabase_admin` user
3. Create other schemas for extensions

## Additional context

Add any other context or screenshots.
