### PR TITLE
fix: unique index should not apply to phone otps

### DIFF
--- a/migrations/20220412150300_add_unique_idx.up.sql
+++ b/migrations/20220412150300_add_unique_idx.up.sql
@@ -1,7 +1,0 @@
--- add partial unique indices to confirmation_token, recovery_token, email_change_token_current, email_change_token_new, phone_change_token, reauthentication_token
-
-CREATE UNIQUE INDEX IF NOT EXISTS confirmation_token_idx ON auth.users USING btree (confirmation_token) WHERE confirmation_token != '';
-CREATE UNIQUE INDEX IF NOT EXISTS recovery_token_idx ON auth.users USING btree (recovery_token) WHERE recovery_token != '';
-CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_current_idx ON auth.users USING btree (email_change_token_current) WHERE email_change_token_current != '';
-CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_new_idx ON auth.users USING btree (email_change_token_new) WHERE email_change_token_new != '';
-CREATE UNIQUE INDEX IF NOT EXISTS reauthentication_token_idx ON auth.users USING btree (reauthentication_token) WHERE reauthentication_token != '';

--- a/migrations/20220429010200_add_unique_idx.up.sql
+++ b/migrations/20220429010200_add_unique_idx.up.sql
@@ -1,0 +1,12 @@
+-- add partial unique indices to confirmation_token, recovery_token, email_change_token_current, email_change_token_new, phone_change_token, reauthentication_token
+DROP INDEX IF EXISTS confirmation_token_idx; 
+DROP INDEX IF EXISTS recovery_token_idx;
+DROP INDEX IF EXISTS email_change_token_current_idx;
+DROP INDEX IF EXISTS email_change_token_new_idx;
+DROP INDEX IF EXISTS reauthentication_token_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS confirmation_token_idx ON auth.users USING btree (confirmation_token) WHERE confirmation_token != '' AND confirmation_token !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS recovery_token_idx ON auth.users USING btree (recovery_token) WHERE recovery_token != '' AND confirmation_token !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_current_idx ON auth.users USING btree (email_change_token_current) WHERE email_change_token_current != '';
+CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_new_idx ON auth.users USING btree (email_change_token_new) WHERE email_change_token_new != '';
+CREATE UNIQUE INDEX IF NOT EXISTS reauthentication_token_idx ON auth.users USING btree (reauthentication_token) WHERE reauthentication_token != '' AND confirmation_token !~ '^[0-9 ]*$';


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes bug in migration where unique partial index created fails consider the case where it is acceptable for phone OTPs to not be unique 