### PR TITLE
fix: add http timeout to add external provider requests

### DIFF
--- a/api/provider/apple.go
+++ b/api/provider/apple.go
@@ -32,7 +32,6 @@ const (
 // AppleProvider stores the custom config for apple provider
 type AppleProvider struct {
 	*oauth2.Config
-	httpClient  *http.Client
 	UserInfoURL string
 }
 

--- a/api/provider/notion.go
+++ b/api/provider/notion.go
@@ -77,7 +77,7 @@ func (g notionProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 	req.Header.Set("Notion-Version", notionApiVersion)
 	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: defaultTimeout}
 	resp, err := client.Do(req)
 
 	if err != nil {

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -5,13 +5,26 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"golang.org/x/oauth2"
 )
 
-const defaultTimeout = time.Second * 10
+var defaultTimeout time.Duration = time.Second * 10
+
+func init() {
+	timeoutStr := os.Getenv("GOTRUE_INTERNAL_HTTP_TIMEOUT")
+	if timeoutStr != "" {
+		if timeout, err := time.ParseDuration(timeoutStr); err != nil {
+			log.Fatalf("error loading GOTRUE_INTERNAL_HTTP_TIMEOUT: %v", err.Error())
+		} else if timeout != 0 {
+			defaultTimeout = timeout
+		}
+	}
+}
 
 type Claims struct {
 	// Reserved claims

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -6,9 +6,12 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"golang.org/x/oauth2"
 )
+
+const defaultTimeout = time.Second * 10
 
 type Claims struct {
 	// Reserved claims
@@ -103,6 +106,7 @@ func chooseHost(base, defaultHost string) string {
 
 func makeRequest(ctx context.Context, tok *oauth2.Token, g *oauth2.Config, url string, dst interface{}) error {
 	client := g.Client(ctx, tok)
+	client.Timeout = defaultTimeout
 	res, err := client.Get(url)
 	if err != nil {
 		return err

--- a/api/provider/twitch.go
+++ b/api/provider/twitch.go
@@ -92,7 +92,7 @@ func (t twitchProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 	req.Header.Set("Client-Id", t.Config.ClientID)
 	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: defaultTimeout}
 	resp, err := client.Do(req)
 
 	if err != nil {

--- a/api/sms_provider/messagebird.go
+++ b/api/sms_provider/messagebird.go
@@ -64,7 +64,7 @@ func (t *MessagebirdProvider) SendSms(phone string, message string) error {
 		"datacoding": {"unicode"},
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: defaultTimeout}
 	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
 	if err != nil {
 		return err

--- a/api/sms_provider/sms_provider.go
+++ b/api/sms_provider/sms_provider.go
@@ -2,12 +2,25 @@ package sms_provider
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"time"
 
 	"github.com/netlify/gotrue/conf"
 )
 
-const defaultTimeout = time.Second * 10
+var defaultTimeout time.Duration = time.Second * 10
+
+func init() {
+	timeoutStr := os.Getenv("GOTRUE_INTERNAL_HTTP_TIMEOUT")
+	if timeoutStr != "" {
+		if timeout, err := time.ParseDuration(timeoutStr); err != nil {
+			log.Fatalf("error loading GOTRUE_INTERNAL_HTTP_TIMEOUT: %v", err.Error())
+		} else if timeout != 0 {
+			defaultTimeout = timeout
+		}
+	}
+}
 
 type SmsProvider interface {
 	SendSms(phone, message string) error

--- a/api/sms_provider/sms_provider.go
+++ b/api/sms_provider/sms_provider.go
@@ -2,9 +2,12 @@ package sms_provider
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/netlify/gotrue/conf"
 )
+
+const defaultTimeout = time.Second * 10
 
 type SmsProvider interface {
 	SendSms(phone, message string) error

--- a/api/sms_provider/textlocal.go
+++ b/api/sms_provider/textlocal.go
@@ -52,7 +52,7 @@ func (t *TextlocalProvider) SendSms(phone string, message string) error {
 		"numbers": {phone},
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: defaultTimeout}
 	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
 	if err != nil {
 		return err

--- a/api/sms_provider/twilio.go
+++ b/api/sms_provider/twilio.go
@@ -62,7 +62,7 @@ func (t *TwilioProvider) SendSms(phone string, message string) error {
 		"Body":    {message},
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: defaultTimeout}
 	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
 	if err != nil {
 		return err

--- a/api/sms_provider/vonage.go
+++ b/api/sms_provider/vonage.go
@@ -52,7 +52,7 @@ func (t *VonageProvider) SendSms(phone string, message string) error {
 		"api_secret": {t.Config.ApiSecret},
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: defaultTimeout}
 	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
 	if err != nil {
 		return err


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds a default 10 sec http timeout to all external oauth / sms provider requests