### PR TITLE
Feature: Add AD groups to user_metadata

### DIFF
--- a/api/provider/azure.go
+++ b/api/provider/azure.go
@@ -98,7 +98,9 @@ func (g azureProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 			Name:          u.Name,
 			Email:         u.Email,
 			EmailVerified: true,
-			Groups:		   groups,
+			CustomClaims:  map[string]interface{}{ 
+				"Groups": groups,
+			},
 
 			// To be deprecated
 			FullName:   u.Name,

--- a/api/provider/azure.go
+++ b/api/provider/azure.go
@@ -39,7 +39,7 @@ type azureGroup struct {
 	DisplayName string `json:"displayName"`
 }
 
-// NewAzureProvider creates a Azure account provider.
+// NewAzureProvider creates a Azure account provider
 func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err

--- a/api/provider/azure.go
+++ b/api/provider/azure.go
@@ -39,7 +39,7 @@ type azureGroup struct {
 	DisplayName string `json:"displayName"`
 }
 
-// NewAzureProvider creates a Azure account provider
+// NewAzureProvider creates a Azure account provider.
 func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -35,24 +35,25 @@ type Claims struct {
 	Exp     float64 `json:"exp,omitempty"`
 
 	// Default profile claims
-	Name              string `json:"name,omitempty"`
-	FamilyName        string `json:"family_name,omitempty"`
-	GivenName         string `json:"given_name,omitempty"`
-	MiddleName        string `json:"middle_name,omitempty"`
-	NickName          string `json:"nickname,omitempty"`
-	PreferredUsername string `json:"preferred_username,omitempty"`
-	Profile           string `json:"profile,omitempty"`
-	Picture           string `json:"picture,omitempty"`
-	Website           string `json:"website,omitempty"`
-	Gender            string `json:"gender,omitempty"`
-	Birthdate         string `json:"birthdate,omitempty"`
-	ZoneInfo          string `json:"zoneinfo,omitempty"`
-	Locale            string `json:"locale,omitempty"`
-	UpdatedAt         string `json:"updated_at,omitempty"`
-	Email             string `json:"email,omitempty"`
-	EmailVerified     bool   `json:"email_verified,omitempty"`
-	Phone             string `json:"phone,omitempty"`
-	PhoneVerified     bool   `json:"phone_verified,omitempty"`
+	Name              string   `json:"name,omitempty"`
+	FamilyName        string   `json:"family_name,omitempty"`
+	GivenName         string   `json:"given_name,omitempty"`
+	MiddleName        string   `json:"middle_name,omitempty"`
+	NickName          string   `json:"nickname,omitempty"`
+	PreferredUsername string   `json:"preferred_username,omitempty"`
+	Profile           string   `json:"profile,omitempty"`
+	Picture           string   `json:"picture,omitempty"`
+	Website           string   `json:"website,omitempty"`
+	Gender            string   `json:"gender,omitempty"`
+	Birthdate         string   `json:"birthdate,omitempty"`
+	ZoneInfo          string   `json:"zoneinfo,omitempty"`
+	Locale            string   `json:"locale,omitempty"`
+	UpdatedAt         string   `json:"updated_at,omitempty"`
+	Email             string   `json:"email,omitempty"`
+	EmailVerified     bool     `json:"email_verified,omitempty"`
+	Phone             string   `json:"phone,omitempty"`
+	PhoneVerified     bool     `json:"phone_verified,omitempty"`
+	Groups			  []string `json:"groups,omitempty"`
 
 	// Custom profile claims that are provider specific
 	CustomClaims map[string]interface{} `json:"custom_claims,omitempty"`

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -53,7 +53,7 @@ type Claims struct {
 	EmailVerified     bool     `json:"email_verified,omitempty"`
 	Phone             string   `json:"phone,omitempty"`
 	PhoneVerified     bool     `json:"phone_verified,omitempty"`
-	Groups			  []string `json:"groups,omitempty"`
+	Groups            []string `json:"groups,omitempty"`
 
 	// Custom profile claims that are provider specific
 	CustomClaims map[string]interface{} `json:"custom_claims,omitempty"`

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -35,25 +35,24 @@ type Claims struct {
 	Exp     float64 `json:"exp,omitempty"`
 
 	// Default profile claims
-	Name              string   `json:"name,omitempty"`
-	FamilyName        string   `json:"family_name,omitempty"`
-	GivenName         string   `json:"given_name,omitempty"`
-	MiddleName        string   `json:"middle_name,omitempty"`
-	NickName          string   `json:"nickname,omitempty"`
-	PreferredUsername string   `json:"preferred_username,omitempty"`
-	Profile           string   `json:"profile,omitempty"`
-	Picture           string   `json:"picture,omitempty"`
-	Website           string   `json:"website,omitempty"`
-	Gender            string   `json:"gender,omitempty"`
-	Birthdate         string   `json:"birthdate,omitempty"`
-	ZoneInfo          string   `json:"zoneinfo,omitempty"`
-	Locale            string   `json:"locale,omitempty"`
-	UpdatedAt         string   `json:"updated_at,omitempty"`
-	Email             string   `json:"email,omitempty"`
-	EmailVerified     bool     `json:"email_verified,omitempty"`
-	Phone             string   `json:"phone,omitempty"`
-	PhoneVerified     bool     `json:"phone_verified,omitempty"`
-	Groups            []string `json:"groups,omitempty"`
+	Name              string `json:"name,omitempty"`
+	FamilyName        string `json:"family_name,omitempty"`
+	GivenName         string `json:"given_name,omitempty"`
+	MiddleName        string `json:"middle_name,omitempty"`
+	NickName          string `json:"nickname,omitempty"`
+	PreferredUsername string `json:"preferred_username,omitempty"`
+	Profile           string `json:"profile,omitempty"`
+	Picture           string `json:"picture,omitempty"`
+	Website           string `json:"website,omitempty"`
+	Gender            string `json:"gender,omitempty"`
+	Birthdate         string `json:"birthdate,omitempty"`
+	ZoneInfo          string `json:"zoneinfo,omitempty"`
+	Locale            string `json:"locale,omitempty"`
+	UpdatedAt         string `json:"updated_at,omitempty"`
+	Email             string `json:"email,omitempty"`
+	EmailVerified     bool   `json:"email_verified,omitempty"`
+	Phone             string `json:"phone,omitempty"`
+	PhoneVerified     bool   `json:"phone_verified,omitempty"`
 
 	// Custom profile claims that are provider specific
 	CustomClaims map[string]interface{} `json:"custom_claims,omitempty"`


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature: Add AD groups to metadata user

## What is the current behavior?

No groups are added to metadata of the user

## What is the new behavior?

When a new user is about to be added, a call to `/v1.0/me/memberOf` is made. Here, all the DisplayNames of each group is added to a string array and added to the `user_metadata`. If the request fails for some reason, no groups will be added to the `user_metadata`

