### PR TITLE
fix: add auth.jwt() function

### DIFF
--- a/migrations/20220531120530_add_auth_jwt_function.up.sql
+++ b/migrations/20220531120530_add_auth_jwt_function.up.sql
@@ -1,0 +1,12 @@
+-- add auth.jwt function
+
+comment on function auth.uid() is 'Deprecated. Use auth.jwt() -> ''sub'' instead.';
+comment on function auth.role() is 'Deprecated. Use auth.jwt() -> ''role'' instead.';
+comment on function auth.email() is 'Deprecated. Use auth.jwt() -> ''email'' instead.';
+
+create or replace function auth.jwt()
+returns jsonb
+language sql stable
+as $$
+  select nullif(current_setting('request.jwt.claims', true), '')::jsonb
+$$;


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Add `auth.jwt()` function to return the user's jwt claims
* Add comments to signal deprecating `auth.email`, `auth.uid`, `auth.role` and to use `auth.jwt` instead
