### PR TITLE
fix$docker-compose: add double quotes to command

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,7 @@ services:
       - GOTRUE_DB_MIGRATIONS_PATH=/go/src/github.com/netlify/gotrue/migrations
     volumes:
       - ./:/go/src/github.com/netlify/gotrue
-    command: CompileDaemon --build="make build" --directory=/go/src/github.com/netlify/gotrue --recursive=true -pattern=(.+\.go|.+\.env) -exclude=gotrue -exclude=gotrue-arm64 -exclude=.env --command="/go/src/github.com/netlify/gotrue/gotrue -c=.env.docker"
+    command: CompileDaemon --build="make build" --directory=/go/src/github.com/netlify/gotrue --recursive=true -pattern="(.+\.go|.+\.env)" -exclude=gotrue -exclude=gotrue-arm64 -exclude=.env --command="/go/src/github.com/netlify/gotrue/gotrue -c=.env.docker"
   postgres:
     image: postgres:13
     container_name: postgres


### PR DESCRIPTION
Running the make dev command fails without double quotes at the '-pattern' parameter

## What kind of change does this PR introduce?

Bug fix (see #485)

## What is the current behavior?

`-pattern` Parameter is without double quotes " " and this causes issues running docker-compose command.

## What is the new behavior?

I added the double quotes and with these it works flawlessly (at least on my Debian WSL).