### PR TITLE
chore: specify an application_name when running migrations

### DIFF
--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -53,9 +54,16 @@ func migrate(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	u, err := url.Parse(globalConfig.DB.URL)
+	processedUrl := globalConfig.DB.URL
+	if len(u.Query()) != 0 {
+		processedUrl = fmt.Sprintf("%s&application_name=gotrue_migrations", processedUrl)
+	} else {
+		processedUrl = fmt.Sprintf("%s?application_name=gotrue_migrations", processedUrl)
+	}
 	deets := &pop.ConnectionDetails{
 		Dialect: globalConfig.DB.Driver,
-		URL:     globalConfig.DB.URL,
+		URL:     processedUrl,
 	}
 	deets.Options = map[string]string{
 		"migration_table_name": "schema_migrations",


### PR DESCRIPTION
This allows [automated] migrations activity to be differentiated from
user-initiated activity.