### PR TITLE
Generate Recovery Codes 

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -68,7 +68,7 @@ func (a *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Bad Pagination Parameters: %v", err)
 	}
 
-	sortParams, err := sort(r, map[string]bool{models.CreatedAt: true}, []models.SortField{models.SortField{Name: models.CreatedAt, Dir: models.Descending}})
+	sortParams, err := sort(r, map[string]bool{models.CreatedAt: true}, []models.SortField{{Name: models.CreatedAt, Dir: models.Descending}})
 	if err != nil {
 		return badRequestError("Bad Sort Parameters: %v", err)
 	}

--- a/api/admin.go
+++ b/api/admin.go
@@ -175,7 +175,7 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		if terr := models.NewAuditLogEntry(tx, instanceID, adminUser, models.UserModifiedAction, "",  map[string]interface{}{
+		if terr := models.NewAuditLogEntry(tx, instanceID, adminUser, models.UserModifiedAction, "", map[string]interface{}{
 			"user_id":    user.ID,
 			"user_email": user.Email,
 			"user_phone": user.Phone,

--- a/api/api.go
+++ b/api/api.go
@@ -188,7 +188,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 				r.Use(api.loadUser)
 				r.Put("/disable", api.DisableMFA)
 				r.Put("/enable", api.EnableMFA)
-        r.Get("/generate_recovery_codes", api.GenerateRecoveryCodes)
+				r.Get("/generate_recovery_codes", api.GenerateRecoveryCodes)
 			})
 		})
 	})

--- a/api/api.go
+++ b/api/api.go
@@ -188,6 +188,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 				r.Use(api.loadUser)
 				r.Put("/disable_mfa", api.DisableMFA)
 				r.Put("/enable_mfa", api.EnableMFA)
+				r.Get("/generate_recovery_codes", api.GenerateRecoveryCodes)
 			})
 		})
 	})

--- a/api/audit.go
+++ b/api/audit.go
@@ -8,9 +8,9 @@ import (
 )
 
 var filterColumnMap = map[string][]string{
-	"author": []string{"actor_username", "actor_name"},
-	"action": []string{"action"},
-	"type":   []string{"log_type"},
+	"author": {"actor_username", "actor_name"},
+	"action": {"action"},
+	"type":   {"log_type"},
 }
 
 func (a *API) adminAuditLog(w http.ResponseWriter, r *http.Request) error {

--- a/api/errors.go
+++ b/api/errors.go
@@ -18,8 +18,9 @@ var (
 	DuplicatePhoneMsg       = "A user with this phone number has already been registered"
 	UserExistsError   error = errors.New("User already exists")
 	// MFA Related errors
-	MFANotDisabled error = errors.New("MFA can only be enabled when it is Disabled")
-	MFANotEnabled  error = errors.New("MFA can only be disabled when it is enabled")
+	MFANotDisabled     error = errors.New("MFA can only be enabled when it is Disabled")
+	MFANotEnabled      error = errors.New("MFA can only be disabled when it is Enabled")
+	MFANotEnabledError error = errors.New("MFA not enabled")
 )
 
 var oauthErrorMap = map[int]string{

--- a/api/errors.go
+++ b/api/errors.go
@@ -18,8 +18,6 @@ var (
 	DuplicatePhoneMsg       = "A user with this phone number has already been registered"
 	UserExistsError   error = errors.New("User already exists")
 	// MFA Related errors
-	MFANotDisabled     error = errors.New("MFA can only be enabled when it is Disabled")
-	MFANotEnabled      error = errors.New("MFA can only be disabled when it is Enabled")
 	MFANotEnabledError error = errors.New("MFA not enabled")
 )
 

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -99,7 +99,7 @@ func TestSignupHookFromClaims(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = withFunctionHooks(ctx, map[string][]string{
-		"signup": []string{svr.URL},
+		"signup": {svr.URL},
 	})
 
 	require.NoError(t, triggerEventHooks(ctx, conn, SignupEvent, user, iid, config))

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -10,7 +10,7 @@ import (
 
 // RecoveryCodesResponse repreesnts a successful recovery code generation response
 type RecoveryCodesResponse struct {
-	RecoveryCodes []string
+	RecoveryCodes []string `json:"recovery_codes"`
 }
 
 func (a *API) EnableMFA(w http.ResponseWriter, r *http.Request) error {
@@ -62,7 +62,6 @@ func (a *API) DisableMFA(w http.ResponseWriter, r *http.Request) error {
 func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) error {
 	const NUM_RECOVERY_CODES = 8
 	const RECOVERY_CODE_LENGTH = 8
-
 	ctx := r.Context()
 	user := getUser(ctx)
 	instanceID := getInstanceID(ctx)
@@ -75,7 +74,6 @@ func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) erro
 	var recoveryCode string
 	var recoveryCodes []string
 	var recoveryCodeModel *models.RecoveryCode
-
 	for i := 0; i < NUM_RECOVERY_CODES; i++ {
 		recoveryCode = crypto.SecureToken(RECOVERY_CODE_LENGTH)
 		recoveryCodeModel, terr = models.NewRecoveryCode(user, recoveryCode, &now)
@@ -95,7 +93,6 @@ func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) erro
 		}
 		return nil
 	})
-
 	return sendJSON(w, http.StatusOK, &RecoveryCodesResponse{
 		RecoveryCodes: recoveryCodes,
 	})

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -93,6 +93,9 @@ func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) erro
 		}
 		return nil
 	})
+	if terr != nil {
+		return terr
+	}
 
 	return sendJSON(w, http.StatusOK, &RecoveryCodesResponse{
 		RecoveryCodes: recoveryCodes,

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -1,10 +1,17 @@
 package api
 
 import (
+	"github.com/netlify/gotrue/crypto"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 	"net/http"
+	"time"
 )
+
+// RecoveryCodesResponse repreesnts a successful Backup code generation response
+type RecoveryCodesResponse struct {
+	RecoveryCodes []string
+}
 
 func (a *API) EnableMFA(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
@@ -61,4 +68,46 @@ func (a *API) DisableMFA(w http.ResponseWriter, r *http.Request) error {
 	}
 	return sendJSON(w, http.StatusOK, user)
 
+}
+
+func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) error {
+	const NUM_RECOVERY_CODES = 8
+	const RECOVERY_CODE_LENGTH = 8
+
+	ctx := r.Context()
+	user := getUser(ctx)
+	instanceID := getInstanceID(ctx)
+	if !user.MFAEnabled {
+		return MFANotEnabledError
+	}
+	now := time.Now()
+	recoveryCodeModels := []*models.RecoveryCode{}
+	var terr error
+	var recoveryCode string
+	var recoveryCodes []string
+	var recoveryCodeModel *models.RecoveryCode
+
+	for i := 0; i < NUM_RECOVERY_CODES; i++ {
+		recoveryCode = crypto.SecureToken(RECOVERY_CODE_LENGTH)
+		recoveryCodeModel, terr = models.NewRecoveryCode(user, recoveryCode, &now)
+		if terr != nil {
+			return internalServerError("Error creating backup code").WithInternalError(terr)
+		}
+		recoveryCodes = append(recoveryCodes, recoveryCode)
+		recoveryCodeModels = append(recoveryCodeModels, recoveryCodeModel)
+	}
+	terr = a.db.Transaction(func(tx *storage.Connection) error {
+		if terr = tx.Create(recoveryCodeModels); terr != nil {
+			return terr
+		}
+
+		if terr := models.NewAuditLogEntry(tx, instanceID, user, models.GenerateRecoveryCodesAction, r.RemoteAddr, nil); terr != nil {
+			return terr
+		}
+		return nil
+	})
+
+	return sendJSON(w, http.StatusOK, &RecoveryCodesResponse{
+		RecoveryCodes: recoveryCodes,
+	})
 }

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -84,8 +84,10 @@ func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) erro
 		recoveryCodeModels = append(recoveryCodeModels, recoveryCodeModel)
 	}
 	terr = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr = tx.Create(recoveryCodeModels); terr != nil {
-			return terr
+		for _, recoveryCodeModel := range recoveryCodeModels {
+			if terr = tx.Create(recoveryCodeModel); terr != nil {
+				return terr
+			}
 		}
 
 		if terr := models.NewAuditLogEntry(tx, instanceID, user, models.GenerateRecoveryCodesAction, r.RemoteAddr, nil); terr != nil {
@@ -93,6 +95,7 @@ func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) erro
 		}
 		return nil
 	})
+
 	return sendJSON(w, http.StatusOK, &RecoveryCodesResponse{
 		RecoveryCodes: recoveryCodes,
 	})

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -59,8 +59,8 @@ func (a *API) DisableMFA(w http.ResponseWriter, r *http.Request) error {
 }
 
 func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) error {
-	const NUM_RECOVERY_CODES = 8
-	const RECOVERY_CODE_LENGTH = 8
+	const numRecoveryCodes = 8
+	const recoveryCodeLength = 8
 	ctx := r.Context()
 	user := getUser(ctx)
 	instanceID := getInstanceID(ctx)
@@ -72,8 +72,8 @@ func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) erro
 	var recoveryCode string
 	var recoveryCodes []string
 	var recoveryCodeModel *models.RecoveryCode
-	for i := 0; i < NUM_RECOVERY_CODES; i++ {
-		recoveryCode = crypto.SecureToken(RECOVERY_CODE_LENGTH)
+	for i := 0; i < numRecoveryCodes; i++ {
+		recoveryCode = crypto.SecureToken(recoveryCodeLength)
 		recoveryCodeModel, terr = models.NewRecoveryCode(user, recoveryCode)
 		if terr != nil {
 			return internalServerError("Error creating recovery code").WithInternalError(terr)

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -5,7 +5,6 @@ import (
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 	"net/http"
-	"time"
 )
 
 // RecoveryCodesResponse repreesnts a successful recovery code generation response
@@ -68,7 +67,6 @@ func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) erro
 	if !user.MFAEnabled {
 		return MFANotEnabledError
 	}
-	now := time.Now()
 	recoveryCodeModels := []*models.RecoveryCode{}
 	var terr error
 	var recoveryCode string
@@ -76,7 +74,7 @@ func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) erro
 	var recoveryCodeModel *models.RecoveryCode
 	for i := 0; i < NUM_RECOVERY_CODES; i++ {
 		recoveryCode = crypto.SecureToken(RECOVERY_CODE_LENGTH)
-		recoveryCodeModel, terr = models.NewRecoveryCode(user, recoveryCode, &now)
+		recoveryCodeModel, terr = models.NewRecoveryCode(user, recoveryCode)
 		if terr != nil {
 			return internalServerError("Error creating recovery code").WithInternalError(terr)
 		}

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// RecoveryCodesResponse repreesnts a successful Backup code generation response
+// RecoveryCodesResponse repreesnts a successful recovery code generation response
 type RecoveryCodesResponse struct {
 	RecoveryCodes []string
 }
@@ -91,7 +91,7 @@ func (a *API) GenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) erro
 		recoveryCode = crypto.SecureToken(RECOVERY_CODE_LENGTH)
 		recoveryCodeModel, terr = models.NewRecoveryCode(user, recoveryCode, &now)
 		if terr != nil {
-			return internalServerError("Error creating backup code").WithInternalError(terr)
+			return internalServerError("Error creating recovery code").WithInternalError(terr)
 		}
 		recoveryCodes = append(recoveryCodes, recoveryCode)
 		recoveryCodeModels = append(recoveryCodeModels, recoveryCodeModel)

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -81,27 +81,22 @@ func (ts *MFATestSuite) TestMFADisable() {
 func (ts *MFATestSuite) TestMFARecoveryCodeGeneration() {
 	const EXPECTED_NUM_OF_RECOVERY_CODES = 8
 
-	u, err := models.NewUser(ts.instanceID, "", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
-	u.EnableMFA()
-
-	err = ts.API.db.Create(u)
-	require.NoError(ts.T(), err)
-	token, err := generateAccessToken(u, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
-	require.NoError(ts.T(), err)
-
-	user, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test1@example.com", ts.Config.JWT.Aud)
+	user, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)
 	ts.Require().NoError(err)
+	require.NoError(ts.T(), user.EnableMFA(ts.API.db))
+
+	token, err := generateAccessToken(user, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	require.NoError(ts.T(), err)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/mfa/%s/generate_recovery_codes", user.ID), nil)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
 
 	data := make(map[string]interface{})
-	require.Equal(ts.T(), http.StatusOK, w.Code)
 	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
 
-	recoveryCodes := data["RecoveryCodes"].([]interface{})
-	numCodes := len(recoveryCodes)
-	require.Equal(ts.T(), EXPECTED_NUM_OF_RECOVERY_CODES, numCodes)
+	recoveryCodes := data["recovery_codes"].([]interface{})
+	require.Equal(ts.T(), EXPECTED_NUM_OF_RECOVERY_CODES, len(recoveryCodes))
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -13,8 +13,12 @@ import (
 )
 
 // SecureToken creates a new random token
-func SecureToken() string {
-	b := make([]byte, 16)
+func SecureToken(options ...int) string {
+	length := 16
+	if len(options) > 0 {
+		length = options[0]
+	}
+	b := make([]byte, length)
 	if _, err := io.ReadFull(rand.Reader, b); err != nil {
 		panic(err.Error()) // rand should never fail
 	}

--- a/migrations/20220607041349_add_mfa_schema.up.sql
+++ b/migrations/20220607041349_add_mfa_schema.up.sql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS auth.mfa_recovery_codes(
        user_id uuid NOT NULL,
        recovery_code VARCHAR(32) NOT NULL,
        created_at timestamptz NOT NULL,
-       verified_at timestamptz NULL,
+       used_at timestamptz NULL,
        CONSTRAINT mfa_recovery_codes_user_id_recovery_code_pkey UNIQUE(user_id, recovery_code),
        CONSTRAINT mfa_recovery_codes_user_id_fkey FOREIGN KEY(user_id) REFERENCES auth.users(id) ON DELETE CASCADE
 );

--- a/migrations/20220607041349_add_mfa_schema.up.sql
+++ b/migrations/20220607041349_add_mfa_schema.up.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS auth.mfa_challenges(
        id VARCHAR(255) NOT NULL,
        factor_id VARCHAR(255) NOT NULL,
        created_at timestamptz NOT NULL,
-       verified_at timestamptz NOT NULL,
+       verified_at timestamptz  NULL,
        CONSTRAINT mfa_challenges_pkey PRIMARY KEY (id),
        CONSTRAINT mfa_challenges_auth_factor_id_fkey FOREIGN KEY (factor_id) REFERENCES auth.mfa_factors(id) ON DELETE CASCADE
 );
@@ -35,11 +35,11 @@ comment on table auth.mfa_challenges is 'Auth: stores metadata about challenge r
 
 -- auth.mfa_recovery_codes definition
 CREATE TABLE IF NOT EXISTS auth.mfa_recovery_codes(
-       id bigint generated always as identity,
+	id uuid NOT NULL,
        user_id uuid NOT NULL,
        recovery_code VARCHAR(32) NOT NULL,
        created_at timestamptz NOT NULL,
-       used_at timestamptz NOT NULL,
+       verified_at timestamptz NULL,
        CONSTRAINT mfa_recovery_codes_user_id_recovery_code_pkey UNIQUE(user_id, recovery_code),
        CONSTRAINT mfa_recovery_codes_user_id_fkey FOREIGN KEY(user_id) REFERENCES auth.users(id) ON DELETE CASCADE
 );

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -28,6 +28,7 @@ const (
 	UserRepeatedSignUpAction        AuditAction = "user_repeated_signup"
 	TokenRevokedAction              AuditAction = "token_revoked"
 	TokenRefreshedAction            AuditAction = "token_refreshed"
+	GenerateRecoveryCodesAction     AuditAction = "generate_recovery_codes"
 
 	account auditLogType = "account"
 	team    auditLogType = "team"
@@ -48,15 +49,16 @@ var actionLogTypeMap = map[AuditAction]auditLogType{
 	UserRecoveryRequestedAction:     user,
 	UserConfirmationRequestedAction: user,
 	UserRepeatedSignUpAction:        user,
+	GenerateRecoveryCodesAction:     user,
 }
 
 // AuditLogEntry is the database model for audit log entries.
 type AuditLogEntry struct {
 	InstanceID uuid.UUID `json:"-" db:"instance_id"`
 	ID         uuid.UUID `json:"id" db:"id"`
-	Payload JSONMap `json:"payload" db:"payload"`
-	CreatedAt time.Time `json:"created_at" db:"created_at"`
-	IPAddress string `json:"ip_address" db:"ip_address"`
+	Payload    JSONMap   `json:"payload" db:"payload"`
+	CreatedAt  time.Time `json:"created_at" db:"created_at"`
+	IPAddress  string    `json:"ip_address" db:"ip_address"`
 }
 
 func (AuditLogEntry) TableName() string {

--- a/models/instance.go
+++ b/models/instance.go
@@ -74,8 +74,8 @@ func GetInstanceByUUID(tx *storage.Connection, uuid uuid.UUID) (*Instance, error
 func DeleteInstance(conn *storage.Connection, instance *Instance) error {
 	return conn.Transaction(func(tx *storage.Connection) error {
 		delModels := map[string]*pop.Model{
-			"user":          &pop.Model{Value: &User{}},
-			"refresh token": &pop.Model{Value: &RefreshToken{}},
+			"user":          {Value: &User{}},
+			"refresh token": {Value: &RefreshToken{}},
 		}
 
 		for name, dm := range delModels {

--- a/models/recovery_code.go
+++ b/models/recovery_code.go
@@ -3,7 +3,6 @@ package models
 import (
 	"database/sql"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/crypto"
 	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
 	"time"
@@ -24,7 +23,6 @@ func (RecoveryCode) TableName() string {
 
 // Returns a new recovery code associated with the user
 func NewRecoveryCode(user *User, recoveryCode string, now *time.Time) (*RecoveryCode, error) {
-	tokenLength := 10
 
 	id, err := uuid.NewV4()
 	if err != nil {
@@ -33,7 +31,7 @@ func NewRecoveryCode(user *User, recoveryCode string, now *time.Time) (*Recovery
 	code := &RecoveryCode{
 		ID:           id,
 		UserID:       user.ID,
-		RecoveryCode: crypto.SecureToken(tokenLength),
+		RecoveryCode: recoveryCode,
 		CreatedAt:    now,
 	}
 

--- a/models/recovery_code.go
+++ b/models/recovery_code.go
@@ -13,7 +13,7 @@ type RecoveryCode struct {
 	UserID       uuid.UUID  `json:"user_id" db:"user_id"`
 	CreatedAt    *time.Time `json:"created_at" db:"created_at"`
 	RecoveryCode string     `json:"recovery_code" db:"recovery_code"`
-	VerifiedAt   *time.Time `json:"verified_at" db:"verified_at"`
+	UsedAt   *time.Time `json:"used_at" db:"used_at"`
 }
 
 func (RecoveryCode) TableName() string {

--- a/models/recovery_code.go
+++ b/models/recovery_code.go
@@ -39,8 +39,8 @@ func NewRecoveryCode(user *User, recoveryCode string, now *time.Time) (*Recovery
 	return code, nil
 }
 
-// FindRecoveryCodes returns all valid recovery codes associated to a user
-func FindRecoveryCodesByUser(tx *storage.Connection, user *User) ([]*RecoveryCode, error) {
+// FindValidRecoveryCodes returns all valid recovery codes associated to a user
+func FindValidRecoveryCodesByUser(tx *storage.Connection, user *User) ([]*RecoveryCode, error) {
 	recoveryCodes := []*RecoveryCode{}
 	if err := tx.Q().Where("user_id = ? AND valid = ?", user.ID, true).All(&recoveryCodes); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {

--- a/models/recovery_code.go
+++ b/models/recovery_code.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"database/sql"
+	"github.com/gofrs/uuid"
+	"github.com/netlify/gotrue/storage"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
+	"time"
+)
+
+type RecoveryCode struct {
+	UserID       uuid.UUID  `json:"user_id" db:"user_id"`
+	CreatedAt    *time.Time `json:"created_at" db:"created_at"`
+	RecoveryCode string     `json:"recovery_code" db:"recovery_code"`
+	Valid        bool       `json:"valid" db:"valid"`
+	TimeUsed     time.Time  `json:"time_used" db:"time_used"`
+}
+
+func (RecoveryCode) TableName() string {
+	tableName := "recovery_codes"
+	return tableName
+}
+
+// Returns a new recovery code associated with the user
+func NewRecoveryCode(user *User, recoveryCode string, now *time.Time) (*RecoveryCode, error) {
+	rc, err := hashRecoveryCode(recoveryCode)
+	if err != nil {
+		return nil, err
+	}
+
+	code := &RecoveryCode{
+		UserID:       user.ID,
+		RecoveryCode: rc,
+		CreatedAt:    now,
+		Valid:        true,
+	}
+
+	return code, nil
+}
+
+// FindRecoveryCodes returns all valid recovery codes associated to a user
+func FindRecoveryCodesByUser(tx *storage.Connection, user *User) ([]*RecoveryCode, error) {
+	recoveryCodes := []*RecoveryCode{}
+	if err := tx.Q().Where("user_id = ? AND valid = ?", user.ID, true).All(&recoveryCodes); err != nil {
+		if errors.Cause(err) == sql.ErrNoRows {
+			return recoveryCodes, nil
+		}
+		return nil, errors.Wrap(err, "Error finding recovery codes")
+	}
+	return recoveryCodes, nil
+}
+
+// hashRecoveryCode generates a hashed recoveryCode from a plaintext string
+func hashRecoveryCode(recoveryCode string) (string, error) {
+	rc, err := bcrypt.GenerateFromPassword([]byte(recoveryCode), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(rc), nil
+}

--- a/models/recovery_code.go
+++ b/models/recovery_code.go
@@ -11,9 +11,9 @@ import (
 type RecoveryCode struct {
 	ID           uuid.UUID  `json:"id" db:"id"`
 	UserID       uuid.UUID  `json:"user_id" db:"user_id"`
-	CreatedAt    time.Time `json:"created_at" db:"created_at"`
+	CreatedAt    time.Time  `json:"created_at" db:"created_at"`
 	RecoveryCode string     `json:"recovery_code" db:"recovery_code"`
-	UsedAt   *time.Time `json:"used_at" db:"used_at"`
+	UsedAt       *time.Time `json:"used_at" db:"used_at"`
 }
 
 func (RecoveryCode) TableName() string {

--- a/models/recovery_code_test.go
+++ b/models/recovery_code_test.go
@@ -1,15 +1,15 @@
 package models
 
 import (
-	"testing"
 	"fmt"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/crypto"
 	"github.com/netlify/gotrue/conf"
+	"github.com/netlify/gotrue/crypto"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"testing"
 )
 
 type RecoveryCodeTestSuite struct {
@@ -19,8 +19,6 @@ type RecoveryCodeTestSuite struct {
 
 func (ts *RecoveryCodeTestSuite) SetupTest() {
 	TruncateAll(ts.db)
-
-
 
 }
 
@@ -39,33 +37,31 @@ func TestRecoveryCode(t *testing.T) {
 	suite.Run(t, ts)
 }
 
-
-func (ts *RecoveryCodeTestSuite)TestFindValidRecoveryCodesByUser() {
+func (ts *RecoveryCodeTestSuite) TestFindValidRecoveryCodesByUser() {
 	// TODO: Joel -- convert numRecoveryCodes and recoveryCodeLength into constants in mfa.go
 	numRecoveryCodes := 8
 	var expectedRecoveryCodes []string
 	user, err := NewUser(uuid.Nil, "", "", "", "", nil)
 	err = ts.db.Create(user)
- 	require.NoError(ts.T(), err)
-	for i:=0;i <= numRecoveryCodes;i++ {
+	require.NoError(ts.T(), err)
+	for i := 0; i <= numRecoveryCodes; i++ {
 		rc := ts.createRecoveryCode(user)
 		expectedRecoveryCodes = append(expectedRecoveryCodes, rc.RecoveryCode)
 	}
-	recoveryCodes, err:= FindValidRecoveryCodesByUser(ts.db, user)
- 	require.NoError(ts.T(), err)
+	recoveryCodes, err := FindValidRecoveryCodesByUser(ts.db, user)
+	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), numRecoveryCodes, len(recoveryCodes), fmt.Sprintf("Expected %d recovery codes but got %d", numRecoveryCodes, len(recoveryCodes)))
 
-for index, recoveryCode := range(recoveryCodes) {
+	for index, recoveryCode := range recoveryCodes {
 		require.Equal(ts.T(), expectedRecoveryCodes[index], recoveryCode, "Recovery codes should match")
 	}
 }
 
-
 func (ts *RecoveryCodeTestSuite) createRecoveryCode(u *User) *RecoveryCode {
 	recoveryCodeLength := 8
- 	rc, err := NewRecoveryCode(u, crypto.SecureToken(recoveryCodeLength))
- 	require.NoError(ts.T(), err)
- 	err = ts.db.Create(rc)
- 	require.NoError(ts.T(), err)
- 	return rc
- }
+	rc, err := NewRecoveryCode(u, crypto.SecureToken(recoveryCodeLength))
+	require.NoError(ts.T(), err)
+	err = ts.db.Create(rc)
+	require.NoError(ts.T(), err)
+	return rc
+}

--- a/models/recovery_code_test.go
+++ b/models/recovery_code_test.go
@@ -1,27 +1,23 @@
-package api
+package models
 
 import (
 	"testing"
 
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-
 type RecoveryCodeTestSuite struct {
-    suite.Suite
-    db *storage.Connection
+	suite.Suite
+	db *storage.Connection
 }
 
 func (ts *RecoveryCodeTestSuite) SetupTest() {
-    TruncateAll(ts.db)
+	TruncateAll(ts.db)
 }
-
 
 func TestRecoveryCode(t *testing.T) {
 	globalConfig, err := conf.LoadGlobal(modelsTestConfig)

--- a/models/recovery_code_test.go
+++ b/models/recovery_code_test.go
@@ -41,6 +41,7 @@ func TestRecoveryCode(t *testing.T) {
 
 
 func (ts *RecoveryCodeTestSuite)TestFindValidRecoveryCodesByUser() {
+	// TODO: Joel -- convert numRecoveryCodes and recoveryCodeLength into constants in mfa.go
 	numRecoveryCodes := 8
 	var expectedRecoveryCodes []string
 	user, err := NewUser(uuid.Nil, "", "", "", "", nil)

--- a/models/recovery_code_test.go
+++ b/models/recovery_code_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/netlify/gotrue/conf"
+	"github.com/netlify/gotrue/storage"
+	"github.com/netlify/gotrue/storage/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+
+type RecoveryCodeTestSuite struct {
+    suite.Suite
+    db *storage.Connection
+}
+
+func (ts *RecoveryCodeTestSuite) SetupTest() {
+    TruncateAll(ts.db)
+}
+
+
+func TestRecoveryCode(t *testing.T) {
+	globalConfig, err := conf.LoadGlobal(modelsTestConfig)
+	require.NoError(t, err)
+
+	conn, err := test.SetupDBConnection(globalConfig)
+	require.NoError(t, err)
+
+	ts := &UserTestSuite{
+		db: conn,
+	}
+	defer ts.db.Close()
+
+	suite.Run(t, ts)
+}

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -125,7 +125,7 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 
 	sp := &SortParams{
 		Fields: []SortField{
-			SortField{Name: "created_at", Dir: Descending},
+			{Name: "created_at", Dir: Descending},
 		},
 	}
 	n, err = FindUsersInAudience(ts.db, u.InstanceID, u.Aud, nil, sp, "")


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR  should add the ability for a user signed in with a single factor(or more factors) to call `/mfa/%s/generate_recovery_codes` to produce recovery codes which will eventually be used to `SignIn`, recover a factor. 

Given the all encompassing nature of this endpoint it should eventually move out of the `/mfa` route.

There should also be a rate limiter on this but haven't decided on value.

## What is the current behavior?
None

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.
