### PR TITLE
fix(oauth): Remove password, phone on subsequent OAuth login

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -479,6 +479,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 				isEmailVerified = getEmailVerified(emailVerified)
 			}
 			if (!ok || !isEmailVerified) && !config.Mailer.Autoconfirm {
+
 				mailer := a.Mailer(ctx)
 				referrer := a.getReferrer(r)
 				if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer, config.Mailer.OtpLength); terr != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

An unconfirmed user account using email + password login, that is then connected to an OAuth account presents a security risk since the user logging in with OAuth does not expect for there to be a (potentially malicious) email + password combination (or unconfirmed phone number). Therefore, the password / phone is removed, the email and/or phone providers removed from the user.

## What is the current behavior?

Email + password combination can be used to log-in after linking with an OAuth account occurs.

