### PR TITLE
[WIP] fix: shorten email otp length 

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -235,7 +235,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 				if !emailData.Verified && !config.Mailer.Autoconfirm {
 					mailer := a.Mailer(ctx)
 					referrer := a.getReferrer(r)
-					if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer); terr != nil {
+					if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer, config.Mailer.OtpLength); terr != nil {
 						if errors.Is(terr, MaxFrequencyLimitError) {
 							return tooManyRequestsError("For security purposes, you can only request this once every minute")
 						}

--- a/api/invite.go
+++ b/api/invite.go
@@ -17,6 +17,7 @@ type InviteParams struct {
 // Invite is the endpoint for inviting a new user
 func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	config := a.getConfig(ctx)
 	instanceID := getInstanceID(ctx)
 	adminUser := getAdminUser(ctx)
 	params := &InviteParams{}
@@ -64,7 +65,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 
 		mailer := a.Mailer(ctx)
 		referrer := a.getReferrer(r)
-		if err := sendInvite(tx, user, mailer, referrer); err != nil {
+		if err := sendInvite(tx, user, mailer, referrer, config.Mailer.OtpLength); err != nil {
 			return internalServerError("Error inviting user").WithInternalError(err)
 		}
 		return nil

--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -82,7 +82,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 
 		mailer := a.Mailer(ctx)
 		referrer := a.getReferrer(r)
-		return a.sendMagicLink(tx, user, mailer, config.SMTP.MaxFrequency, referrer)
+		return a.sendMagicLink(tx, user, mailer, config.SMTP.MaxFrequency, referrer, config.Mailer.OtpLength)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/api/phone.go
+++ b/api/phone.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/md5"
 	"fmt"
 	"regexp"
 	"strings"
@@ -77,13 +78,13 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 	if err != nil {
 		return internalServerError("error generating otp").WithInternalError(err)
 	}
-	*token = otp
+	*token = fmt.Sprintf("%x", md5.Sum([]byte(phone+otp)))
 
 	var message string
 	if config.Sms.Template == "" {
-		message = fmt.Sprintf(defaultSmsMessage, *token)
+		message = fmt.Sprintf(defaultSmsMessage, otp)
 	} else {
-		message = strings.Replace(config.Sms.Template, "{{ .Code }}", *token, -1)
+		message = strings.Replace(config.Sms.Template, "{{ .Code }}", otp, -1)
 	}
 
 	if serr := smsProvider.SendSms(phone, message); serr != nil {

--- a/api/recover.go
+++ b/api/recover.go
@@ -51,7 +51,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		}
 		mailer := a.Mailer(ctx)
 		referrer := a.getReferrer(r)
-		return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency, referrer)
+		return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency, referrer, config.Mailer.OtpLength)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/api/signup.go
+++ b/api/signup.go
@@ -132,7 +132,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				}); terr != nil {
 					return terr
 				}
-				if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer); terr != nil {
+				if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer, config.Mailer.OtpLength); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						now := time.Now()
 						left := user.ConfirmationSentAt.Add(config.SMTP.MaxFrequency).Sub(now) / time.Second

--- a/api/token.go
+++ b/api/token.go
@@ -481,7 +481,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 			if (!ok || !isEmailVerified) && !config.Mailer.Autoconfirm {
 				mailer := a.Mailer(ctx)
 				referrer := a.getReferrer(r)
-				if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer); terr != nil {
+				if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer, config.Mailer.OtpLength); terr != nil {
 					return internalServerError("Error sending confirmation mail").WithInternalError(terr)
 				}
 				return unauthorizedError("Error unverified email")

--- a/api/user.go
+++ b/api/user.go
@@ -132,7 +132,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 			mailer := a.Mailer(ctx)
 			referrer := a.getReferrer(r)
-			if terr = a.sendEmailChange(tx, config, user, mailer, params.Email, referrer); terr != nil {
+			if terr = a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, config.Mailer.OtpLength); terr != nil {
 				return internalServerError("Error sending change email").WithInternalError(terr)
 			}
 		}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -131,6 +131,7 @@ type MailerConfiguration struct {
 	URLPaths                 EmailContentConfiguration `json:"url_paths"`
 	SecureEmailChangeEnabled bool                      `json:"secure_email_change_enabled" split_words:"true" default:"true"`
 	OtpExp                   uint                      `json:"otp_exp" split_words:"true"`
+	OtpLength                int                       `json:"otp_length" split_words:"true"`
 }
 
 type PhoneProviderConfiguration struct {
@@ -306,6 +307,11 @@ func (config *Configuration) ApplyDefaults() {
 
 	if config.Mailer.OtpExp == 0 {
 		config.Mailer.OtpExp = 86400 // 1 day
+	}
+
+	if config.Mailer.OtpLength == 0 || config.Mailer.OtpLength < 6 || config.Mailer.OtpLength > 10 {
+		// 6-digit otp by default
+		config.Mailer.OtpLength = 6
 	}
 
 	if config.SMTP.MaxFrequency == 0 {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -28,6 +28,7 @@ func GenerateOtp(digits int) (string, error) {
 	if err != nil {
 		return "", errors.WithMessage(err, "Error generating otp")
 	}
+	// adds a variable zero-padding to the left to ensure otp is uniformly random
 	expr := "%0" + strconv.Itoa(digits) + "v"
 	otp := fmt.Sprintf(expr, val.String())
 	return otp, nil

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -14,12 +14,12 @@ import (
 // Mailer defines the interface a mailer must implement.
 type Mailer interface {
 	Send(user *models.User, subject, body string, data map[string]interface{}) error
-	InviteMail(user *models.User, referrerURL string) error
-	ConfirmationMail(user *models.User, referrerURL string) error
-	RecoveryMail(user *models.User, referrerURL string) error
-	MagicLinkMail(user *models.User, referrerURL string) error
-	EmailChangeMail(user *models.User, referrerURL string) error
-	ReauthenticateMail(user *models.User) error
+	InviteMail(user *models.User, otp, referrerURL string) error
+	ConfirmationMail(user *models.User, otp, referrerURL string) error
+	RecoveryMail(user *models.User, otp, referrerURL string) error
+	MagicLinkMail(user *models.User, otp, referrerURL string) error
+	EmailChangeMail(user *models.User, otpNew, otpCurrent, referrerURL string) error
+	ReauthenticateMail(user *models.User, otp string) error
 	ValidateEmail(email string) error
 	GetEmailActionLink(user *models.User, actionType, referrerURL string) (string, error)
 }

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -64,7 +64,7 @@ func (m TemplateMailer) ValidateEmail(email string) error {
 }
 
 // InviteMail sends a invite mail to a new user
-func (m *TemplateMailer) InviteMail(user *models.User, referrerURL string) error {
+func (m *TemplateMailer) InviteMail(user *models.User, otp, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
 
 	redirectParam := ""
@@ -80,7 +80,7 @@ func (m *TemplateMailer) InviteMail(user *models.User, referrerURL string) error
 		"SiteURL":         m.Config.SiteURL,
 		"ConfirmationURL": url,
 		"Email":           user.Email,
-		"Token":           formatEmailOtp(user.ConfirmationToken),
+		"Token":           otp,
 		"Data":            user.UserMetaData,
 	}
 
@@ -94,14 +94,15 @@ func (m *TemplateMailer) InviteMail(user *models.User, referrerURL string) error
 }
 
 // ConfirmationMail sends a signup confirmation mail to a new user
-func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string) error {
+func (m *TemplateMailer) ConfirmationMail(user *models.User, otp, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
-
+	if err != nil {
+		return err
+	}
 	redirectParam := ""
 	if len(referrerURL) > 0 {
 		redirectParam = "&redirect_to=" + referrerURL
 	}
-
 	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup"+redirectParam)
 	if err != nil {
 		return err
@@ -110,7 +111,7 @@ func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string)
 		"SiteURL":         m.Config.SiteURL,
 		"ConfirmationURL": url,
 		"Email":           user.Email,
-		"Token":           formatEmailOtp(user.ConfirmationToken),
+		"Token":           otp,
 		"Data":            user.UserMetaData,
 	}
 
@@ -124,11 +125,11 @@ func (m *TemplateMailer) ConfirmationMail(user *models.User, referrerURL string)
 }
 
 // ReauthenticateMail sends a reauthentication mail to an authenticated user
-func (m *TemplateMailer) ReauthenticateMail(user *models.User) error {
+func (m *TemplateMailer) ReauthenticateMail(user *models.User, otp string) error {
 	data := map[string]interface{}{
 		"SiteURL": m.Config.SiteURL,
 		"Email":   user.Email,
-		"Token":   formatEmailOtp(user.ReauthenticationToken),
+		"Token":   otp,
 		"Data":    user.UserMetaData,
 	}
 
@@ -142,29 +143,32 @@ func (m *TemplateMailer) ReauthenticateMail(user *models.User) error {
 }
 
 // EmailChangeMail sends an email change confirmation mail to a user
-func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) error {
+func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, referrerURL string) error {
 	type Email struct {
-		Address  string
-		Token    string
-		Subject  string
-		Template string
+		Address   string
+		Otp       string
+		TokenHash string
+		Subject   string
+		Template  string
 	}
 	emails := []Email{
 		{
-			Address:  user.EmailChange,
-			Token:    formatEmailOtp(user.EmailChangeTokenNew),
-			Subject:  string(withDefault(m.Config.Mailer.Subjects.EmailChange, "Confirm Email Change")),
-			Template: m.Config.Mailer.Templates.EmailChange,
+			Address:   user.EmailChange,
+			Otp:       otpNew,
+			TokenHash: user.EmailChangeTokenNew,
+			Subject:   string(withDefault(m.Config.Mailer.Subjects.EmailChange, "Confirm Email Change")),
+			Template:  m.Config.Mailer.Templates.EmailChange,
 		},
 	}
 
 	currentEmail := user.GetEmail()
 	if m.Config.Mailer.SecureEmailChangeEnabled && currentEmail != "" {
 		emails = append(emails, Email{
-			Address:  currentEmail,
-			Token:    formatEmailOtp(user.EmailChangeTokenCurrent),
-			Subject:  string(withDefault(m.Config.Mailer.Subjects.Confirmation, "Confirm Email Address")),
-			Template: m.Config.Mailer.Templates.EmailChange,
+			Address:   currentEmail,
+			Otp:       otpCurrent,
+			TokenHash: user.EmailChangeTokenCurrent,
+			Subject:   string(withDefault(m.Config.Mailer.Subjects.Confirmation, "Confirm Email Address")),
+			Template:  m.Config.Mailer.Templates.EmailChange,
 		})
 	}
 
@@ -183,7 +187,7 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) 
 			referrerURL,
 			globalConfig.API.ExternalURL,
 			m.Config.Mailer.URLPaths.EmailChange,
-			"token="+email.Token+"&type=email_change"+redirectParam,
+			"token="+email.TokenHash+"&type=email_change"+redirectParam,
 		)
 		if err != nil {
 			return err
@@ -204,7 +208,7 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) 
 				defaultEmailChangeMail,
 				data,
 			)
-		}(email.Address, email.Token, email.Template)
+		}(email.Address, email.Otp, email.Template)
 	}
 
 	for i := 0; i < len(emails); i++ {
@@ -218,8 +222,11 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, referrerURL string) 
 }
 
 // RecoveryMail sends a password recovery mail
-func (m *TemplateMailer) RecoveryMail(user *models.User, referrerURL string) error {
+func (m *TemplateMailer) RecoveryMail(user *models.User, otp, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
+	if err != nil {
+		return err
+	}
 
 	redirectParam := ""
 	if len(referrerURL) > 0 {
@@ -234,7 +241,7 @@ func (m *TemplateMailer) RecoveryMail(user *models.User, referrerURL string) err
 		"SiteURL":         m.Config.SiteURL,
 		"ConfirmationURL": url,
 		"Email":           user.Email,
-		"Token":           formatEmailOtp(user.RecoveryToken),
+		"Token":           otp,
 		"Data":            user.UserMetaData,
 	}
 
@@ -248,8 +255,11 @@ func (m *TemplateMailer) RecoveryMail(user *models.User, referrerURL string) err
 }
 
 // MagicLinkMail sends a login link mail
-func (m *TemplateMailer) MagicLinkMail(user *models.User, referrerURL string) error {
+func (m *TemplateMailer) MagicLinkMail(user *models.User, otp, referrerURL string) error {
 	globalConfig, err := conf.LoadGlobal(configFile)
+	if err != nil {
+		return err
+	}
 
 	redirectParam := ""
 	if len(referrerURL) > 0 {
@@ -264,7 +274,7 @@ func (m *TemplateMailer) MagicLinkMail(user *models.User, referrerURL string) er
 		"SiteURL":         m.Config.SiteURL,
 		"ConfirmationURL": url,
 		"Email":           user.Email,
-		"Token":           formatEmailOtp(user.RecoveryToken),
+		"Token":           otp,
 		"Data":            user.UserMetaData,
 	}
 

--- a/migrations/20220624094435_add_token_view.up.sql
+++ b/migrations/20220624094435_add_token_view.up.sql
@@ -1,3 +1,0 @@
--- add encrypted_email column
-alter table auth.users
-add column encrypted_email varchar(255) generated always as (md5(email)) stored;

--- a/migrations/20220624094435_add_token_view.up.sql
+++ b/migrations/20220624094435_add_token_view.up.sql
@@ -1,0 +1,3 @@
+-- add encrypted_email column
+alter table auth.users
+add column encrypted_email varchar(255) generated always as (md5(email)) stored;


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Shorten email otp length to range between 6-10 digits
* Email link token param is now a hash(email + otp)
* Values stored in `xxx_token` in the db is now hash(email + otp) instead of just the otp
* Email link verification works by matching the token param with the token field in the db (since both are hashed, we can just compare the hashes)
* Email otp works by taking hash(email + otp) and comparing the value with the token field in the db (for sms otps, the hash will be hash(phone + otp))
* support old otp format (to be deprecated within a week - current otps only last for 24 hrs so users will have to regenerate new ones regardless)
* Potentially a breaking change if user has already built a UI to account for the old token format (`xxxxx-xxxxx-xxxxx-xxxxx`)

## To-Dos
- [ ] Fix tests
