### PR TITLE
feat: add captcha to verify and token endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -127,7 +127,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			tollbooth.NewLimiter(api.config.RateLimitTokenRefresh/(60*5), &limiter.ExpirableOptions{
 				DefaultExpirationTTL: time.Hour,
 			}).SetBurst(30),
-		)).Post("/token", api.Token)
+		)).With(api.verifyCaptcha).Post("/token", api.Token)
 
 		r.With(api.limitHandler(
 			// Allow requests at the specified rate per 5 minutes.
@@ -136,7 +136,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			}).SetBurst(30),
 		)).Route("/verify", func(r *router) {
 			r.Get("/", api.Verify)
-			r.Post("/", api.Verify)
+			r.With(api.verifyCaptcha).Post("/", api.Verify)
 		})
 
 		r.With(api.requireAuthentication).Post("/logout", api.Logout)

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -48,7 +48,7 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaValid() {
 		"email":    "test@example.com",
 		"password": "secret",
 		"gotrue_meta_security": map[string]interface{}{
-			"hcaptcha_token": HCaptchaResponse,
+			"captcha_token": HCaptchaResponse,
 		},
 	}))
 
@@ -75,7 +75,7 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaValid() {
 		"email":    "test@example.com",
 		"password": "secret",
 		"gotrue_meta_security": map[string]interface{}{
-			"hcaptcha_token": HCaptchaResponse,
+			"captcha_token": HCaptchaResponse,
 		},
 	}))
 
@@ -129,7 +129,7 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaInvalid() {
 				"email":    "test@example.com",
 				"password": "secret",
 				"gotrue_meta_security": map[string]interface{}{
-					"hcaptcha_token": HCaptchaResponse,
+					"captcha_token": HCaptchaResponse,
 				},
 			}))
 			req := httptest.NewRequest(http.MethodPost, "http://localhost", &buffer)

--- a/security/hcaptcha.go
+++ b/security/hcaptcha.go
@@ -56,6 +56,10 @@ func init() {
 }
 
 func VerifyRequest(r *http.Request, secretKey string) (VerificationResult, error) {
+	if r.FormValue("grant_type") == "refresh_token" {
+		// captcha shouldn't be enabled on requests to refresh the token
+		return SuccessfullyVerified, nil
+	}
 	res := GotrueRequest{}
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/security/hcaptcha.go
+++ b/security/hcaptcha.go
@@ -22,7 +22,7 @@ type GotrueRequest struct {
 }
 
 type GotrueSecurity struct {
-	Token string `json:"hcaptcha_token"`
+	Token string `json:"captcha_token"`
 }
 
 type VerificationResponse struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Add captcha protection to `/verify` and `/token` endpoints
* Captcha protection is excluded from any `GET /verify` requests and `POST /token?grant_type=refresh_token`
* Renamed the captcha token field to make it more generic for future implementations of other captcha providers (e.g. reCaptcha) - this should only affect anyone self-hosting gotrue and using the captcha feature already 
* Decided not to enable captcha on the following endpoints
  * `/admin` routes since those endpoint should only be called on the server-side
  * `/user` since the user has to be logged in first in order to make calls to this endpoint
  * `/settings`, `/authorize`, `/logout` - seems irrelevant 