### PR TITLE
Link WhatsApp to Phone providers

### DIFF
--- a/api/otp.go
+++ b/api/otp.go
@@ -72,16 +72,17 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	if !config.External.Phone.Enabled {
 		return badRequestError("Unsupported phone provider")
 	}
-	// TODO(Joel): Block for non-Twilio SMS providers
-	if params.Phone != "" && params.Channel == "" {
-		params.Channel = "sms"
-	}
 
 	instanceID := getInstanceID(ctx)
 	params := &SmsParams{}
 	jsonDecoder := json.NewDecoder(r.Body)
 	if err := jsonDecoder.Decode(params); err != nil {
 		return badRequestError("Could not read sms otp params: %v", err)
+	}
+
+	// TODO(Joel): Block for non-Twilio SMS providers
+	if params.Phone != "" && params.Channel == "" {
+		params.Channel = "sms"
 	}
 
 	var err error

--- a/api/phone.go
+++ b/api/phone.go
@@ -43,7 +43,7 @@ func (a *API) formatPhoneNumber(phone string) string {
 }
 
 // sendPhoneConfirmation sends an otp to the user's phone number
-func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection, user *models.User, phone, otpType string, smsProvider sms_provider.SmsProvider) error {
+func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection, user *models.User, phone, otpType string, smsProvider sms_provider.SmsProvider, channel string) error {
 	config := a.getConfig(ctx)
 
 	var token *string
@@ -86,7 +86,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 		message = strings.Replace(config.Sms.Template, "{{ .Code }}", *token, -1)
 	}
 
-	if serr := smsProvider.SendMessage(phone, message, "sms"); serr != nil {
+	if serr := smsProvider.SendMessage(phone, message, channel); serr != nil {
 		*token = oldToken
 		return serr
 	}

--- a/api/phone.go
+++ b/api/phone.go
@@ -86,7 +86,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 		message = strings.Replace(config.Sms.Template, "{{ .Code }}", *token, -1)
 	}
 
-	if serr := smsProvider.SendSms(phone, message); serr != nil {
+	if serr := smsProvider.SendMessage(phone, message, "sms"); serr != nil {
 		*token = oldToken
 		return serr
 	}

--- a/api/phone_test.go
+++ b/api/phone_test.go
@@ -32,7 +32,7 @@ type TestSmsProvider struct {
 	mock.Mock
 }
 
-func (t *TestSmsProvider) SendSms(phone string, message string) error {
+func (t *TestSmsProvider) SendMessage(phone string, message string, messageType string) error {
 	return nil
 }
 

--- a/api/phone_test.go
+++ b/api/phone_test.go
@@ -103,7 +103,7 @@ func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
 
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
-			err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, &TestSmsProvider{})
+			err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, &TestSmsProvider{}, "sms")
 			require.Equal(ts.T(), c.expected, err)
 			u, err = models.FindUserByPhoneAndAudience(ts.API.db, ts.instanceID, "123456789", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)

--- a/api/reauthenticate.go
+++ b/api/reauthenticate.go
@@ -60,7 +60,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return badRequestError("Error sending sms: %v", terr)
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, phone, phoneReauthenticationOtp, smsProvider)
+			return a.sendPhoneConfirmation(ctx, tx, user, phone, phoneReauthenticationOtp, smsProvider, "sms")
 		}
 		return nil
 	})

--- a/api/signup.go
+++ b/api/signup.go
@@ -23,6 +23,7 @@ type SignupParams struct {
 	Data     map[string]interface{} `json:"data"`
 	Provider string                 `json:"-"`
 	Aud      string                 `json:"-"`
+	Channel  string                 `json:"channel"`
 }
 
 // Signup is the endpoint for registering a new user
@@ -57,6 +58,9 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	}
 	if params.Data == nil {
 		params.Data = make(map[string]interface{})
+	}
+	if params.Channel != "sms" && params.Channel != "whatsapp" {
+		params.Channel = "sms"
 	}
 
 	var user *models.User
@@ -164,7 +168,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				if terr != nil {
 					return badRequestError("Error sending confirmation sms: %v", terr)
 				}
-				if terr = a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider); terr != nil {
+				if terr = a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, params.Channel); terr != nil {
 					return badRequestError("Error sending confirmation sms: %v", terr)
 				}
 			}

--- a/api/sms_provider/messagebird.go
+++ b/api/sms_provider/messagebird.go
@@ -58,8 +58,6 @@ func (t *MessagebirdProvider) SendMessage(phone string, message string, messageT
 	switch messageType {
 	case "sms":
 		return t.SendSms(phone, message)
-	case "whatsapp":
-		return t.SendWhatsappMessage(phone, message)
 	default:
 		return nil
 	}
@@ -67,51 +65,6 @@ func (t *MessagebirdProvider) SendMessage(phone string, message string, messageT
 
 // Send an SMS containing the OTP with Messagebird's API
 func (t *MessagebirdProvider) SendSms(phone string, message string) error {
-	body := url.Values{
-		"originator": {t.Config.Originator},
-		"body":       {message},
-		"recipients": {phone},
-		"type":       {"sms"},
-		"datacoding": {"unicode"},
-	}
-
-	client := &http.Client{Timeout: defaultTimeout}
-	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
-	if err != nil {
-		return err
-	}
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	r.Header.Add("Authorization", "AccessKey "+t.Config.AccessKey)
-	res, err := client.Do(r)
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode == http.StatusBadRequest || res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusUnauthorized || res.StatusCode == http.StatusUnprocessableEntity {
-		resp := &MessagebirdErrResponse{}
-		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
-			return err
-		}
-		return resp
-	}
-	defer res.Body.Close()
-
-	// validate sms status
-	resp := &MessagebirdResponse{}
-	derr := json.NewDecoder(res.Body).Decode(resp)
-	if derr != nil {
-		return derr
-	}
-
-	if resp.Recipients.TotalSentCount == 0 {
-		return fmt.Errorf("Messagebird error: total sent count is 0")
-	}
-
-	return nil
-}
-
-// Send an SMS containing the OTP with Messagebird's API
-func (t *MessagebirdProvider) SendWhatsappMessage(phone string, message string) error {
 	body := url.Values{
 		"originator": {t.Config.Originator},
 		"body":       {message},

--- a/api/sms_provider/sms_provider.go
+++ b/api/sms_provider/sms_provider.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 type SmsProvider interface {
-	SendSms(phone, message string) error
+	SendMessage(phone, message, messageType string) error
 }
 
 func GetSmsProvider(config conf.Configuration) (SmsProvider, error) {

--- a/api/sms_provider/textlocal.go
+++ b/api/sms_provider/textlocal.go
@@ -47,8 +47,6 @@ func (t *TextlocalProvider) SendMessage(phone string, message string, messageTyp
 	switch messageType {
 	case "sms":
 		return t.SendSms(phone, message)
-	case "whatsapp":
-		return t.SendWhatsappMessage(phone, message)
 	default:
 		return nil
 	}
@@ -56,45 +54,6 @@ func (t *TextlocalProvider) SendMessage(phone string, message string, messageTyp
 
 // Send an SMS containing the OTP with Textlocal's API
 func (t *TextlocalProvider) SendSms(phone string, message string) error {
-	body := url.Values{
-		"sender":  {t.Config.Sender},
-		"apikey":  {t.Config.ApiKey},
-		"message": {message},
-		"numbers": {phone},
-	}
-
-	client := &http.Client{Timeout: defaultTimeout}
-	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
-	if err != nil {
-		return err
-	}
-
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	res, err := client.Do(r)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	resp := &TextlocalResponse{}
-	derr := json.NewDecoder(res.Body).Decode(resp)
-	if derr != nil {
-		return derr
-	}
-
-	if len(resp.Errors) == 0 {
-		return errors.New("Textlocal error: Internal Error")
-	}
-
-	if resp.Status != "success" {
-		return fmt.Errorf("Textlocal error: %v (code: %v)", resp.Errors[0].Message, resp.Errors[0].Code)
-	}
-
-	return nil
-}
-
-// TODO(Joel): Check API and update
-func (t *TextlocalProvider) SendWhatsappMessage(phone string, message string) error {
 	body := url.Values{
 		"sender":  {t.Config.Sender},
 		"apikey":  {t.Config.ApiKey},

--- a/api/sms_provider/textlocal.go
+++ b/api/sms_provider/textlocal.go
@@ -43,8 +43,58 @@ func NewTextlocalProvider(config conf.TextlocalProviderConfiguration) (SmsProvid
 	}, nil
 }
 
+func (t *TextlocalProvider) SendMessage(phone string, message string, messageType string) error {
+	switch messageType {
+	case "sms":
+		return t.SendSms(phone, message)
+	case "whatsapp":
+		return t.SendWhatsappMessage(phone, message)
+	default:
+		return nil
+	}
+}
+
 // Send an SMS containing the OTP with Textlocal's API
 func (t *TextlocalProvider) SendSms(phone string, message string) error {
+	body := url.Values{
+		"sender":  {t.Config.Sender},
+		"apikey":  {t.Config.ApiKey},
+		"message": {message},
+		"numbers": {phone},
+	}
+
+	client := &http.Client{Timeout: defaultTimeout}
+	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
+	if err != nil {
+		return err
+	}
+
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	res, err := client.Do(r)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	resp := &TextlocalResponse{}
+	derr := json.NewDecoder(res.Body).Decode(resp)
+	if derr != nil {
+		return derr
+	}
+
+	if len(resp.Errors) == 0 {
+		return errors.New("Textlocal error: Internal Error")
+	}
+
+	if resp.Status != "success" {
+		return fmt.Errorf("Textlocal error: %v (code: %v)", resp.Errors[0].Message, resp.Errors[0].Code)
+	}
+
+	return nil
+}
+
+// TODO(Joel): Check API and update
+func (t *TextlocalProvider) SendWhatsappMessage(phone string, message string) error {
 	body := url.Values{
 		"sender":  {t.Config.Sender},
 		"apikey":  {t.Config.ApiKey},

--- a/api/sms_provider/vonage.go
+++ b/api/sms_provider/vonage.go
@@ -46,8 +46,6 @@ func (t *VonageProvider) SendMessage(phone string, message string, messageType s
 	switch messageType {
 	case "sms":
 		return t.SendSms(phone, message)
-	case "whatsapp":
-		return t.SendWhatsappMessage(phone, message)
 	default:
 		return nil
 	}
@@ -59,49 +57,6 @@ func (t *VonageProvider) SendSms(phone string, message string) error {
 		"from":       {t.Config.From},
 		"to":         {phone},
 		"text":       {message},
-		"api_key":    {t.Config.ApiKey},
-		"api_secret": {t.Config.ApiSecret},
-	}
-
-	client := &http.Client{Timeout: defaultTimeout}
-	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
-	if err != nil {
-		return err
-	}
-
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	res, err := client.Do(r)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	resp := &VonageResponse{}
-	derr := json.NewDecoder(res.Body).Decode(resp)
-	if derr != nil {
-		return derr
-	}
-
-	if len(resp.Messages) <= 0 {
-		return errors.New("Vonage error: Internal Error")
-	}
-
-	// A status of zero indicates success; a non-zero value means something went wrong.
-	if resp.Messages[0].Status != "0" {
-		return fmt.Errorf("Vonage error: %v (status: %v)", resp.Messages[0].ErrorText, resp.Messages[0].Status)
-	}
-
-	return nil
-}
-
-// TODO(Joel)-- convert so that it conforms to API
-// Send a Whatsapp Message containing the OTP with Vonage's API
-func (t *VonageProvider) SendWhatsappMessage(phone string, message string) error {
-	body := url.Values{
-		"from":       {t.Config.From},
-		"to":         {phone},
-		"text":       {message},
-		"channel":    {"whatsapp"},
 		"api_key":    {t.Config.ApiKey},
 		"api_secret": {t.Config.ApiSecret},
 	}

--- a/api/sms_provider/vonage.go
+++ b/api/sms_provider/vonage.go
@@ -42,12 +42,66 @@ func NewVonageProvider(config conf.VonageProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
+func (t *VonageProvider) SendMessage(phone string, message string, messageType string) error {
+	switch messageType {
+	case "sms":
+		return t.SendSms(phone, message)
+	case "whatsapp":
+		return t.SendWhatsappMessage(phone, message)
+	default:
+		return nil
+	}
+}
+
 // Send an SMS containing the OTP with Vonage's API
 func (t *VonageProvider) SendSms(phone string, message string) error {
 	body := url.Values{
 		"from":       {t.Config.From},
 		"to":         {phone},
 		"text":       {message},
+		"api_key":    {t.Config.ApiKey},
+		"api_secret": {t.Config.ApiSecret},
+	}
+
+	client := &http.Client{Timeout: defaultTimeout}
+	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
+	if err != nil {
+		return err
+	}
+
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	res, err := client.Do(r)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	resp := &VonageResponse{}
+	derr := json.NewDecoder(res.Body).Decode(resp)
+	if derr != nil {
+		return derr
+	}
+
+	if len(resp.Messages) <= 0 {
+		return errors.New("Vonage error: Internal Error")
+	}
+
+	// A status of zero indicates success; a non-zero value means something went wrong.
+	if resp.Messages[0].Status != "0" {
+		return fmt.Errorf("Vonage error: %v (status: %v)", resp.Messages[0].ErrorText, resp.Messages[0].Status)
+	}
+
+	return nil
+}
+
+// TODO(Joel)-- convert so that it conforms to API
+// Send a Whatsapp Message containing the OTP with Vonage's API
+func (t *VonageProvider) SendWhatsappMessage(phone string, message string) error {
+	body := url.Values{
+		"from":       {t.Config.From},
+		"to":         {phone},
+		"text":       {message},
+		"channel":    {"whatsapp"},
 		"api_key":    {t.Config.ApiKey},
 		"api_secret": {t.Config.ApiSecret},
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -155,7 +155,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				if terr != nil {
 					return badRequestError("Error sending sms: %v", terr)
 				}
-				if terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider); terr != nil {
+				if terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider, "sms"); terr != nil {
 					return internalServerError("Error sending phone change otp").WithInternalError(terr)
 				}
 			}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is one possible implementation of how we could link WhatsApp/Messenger and others to associated providers. Note: currently only the SMS path is live/used as we've yet to finalise how the user would indicate they want to use Whatsapp/sms/messenger.

## What is the current behavior?

One can only send OTP/codes etc through SMS.

## What is the new behavior?

Choose between provider integrations.

## Additional context

Add any other context or screenshots.
