### PR TITLE
Edit Keycloak OpenID endpoint url

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The URI a OAuth2 provider will redirect to with the `code` and `state` values.
 
 `EXTERNAL_X_URL` - `string`
 
-The base URL used for constructing the URLs to request authorization and access tokens. Used by `gitlab` and `keycloak`. For `gitlab` it defaults to `https://gitlab.com`. For `keycloak` you need to set this to your instance, for example: `https://keycloak.example.com/auth/realms/myrealm`
+The base URL used for constructing the URLs to request authorization and access tokens. Used by `gitlab` and `keycloak`. For `gitlab` it defaults to `https://gitlab.com`. For `keycloak` you need to set this to your instance, for example: `https://keycloak.example.com/realms/myrealm`
 
 #### Apple OAuth
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
OpenID Endpoint Configuration as mentioned in realm admin panel is not included '/auth/' in URL. keycloak [documents](https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_authorization_api) describe endpoint URLs.

EXTERNAL_KEYCLOAK_URL = https://keycloak.example.com/auth/realms/myrealm IS NOT Correct.
EXTERNAL_KEYCLOAK_URL = https://keycloak.example.com/realms/myrealm IS Correct.

Bug fix, feature, docs update, ...

## What is the current behavior?
Readme show a bad URL example.
Please link any relevant issues here.

## What is the new behavior?
This PR can help users to have a better deploy without confusion.
Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
