### PR TITLE
feat: Normalize redirection URLs and globs

### DIFF
--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -489,6 +489,34 @@ func (ts *VerifyTestSuite) TestVerifySignupWithredirectURLContainedPath() {
 			requestredirectURL:  "http://test.dev:3000/bar/foo",
 			expectedredirectURL: "http://localhost:3000",
 		},
+		{
+			desc:                "uri allow list with slash",
+			siteURL:             "http://localhost:3000",
+			uriAllowList:        []string{"http://example.org/"},
+			requestredirectURL:  "http://example.org",
+			expectedredirectURL: "http://example.org",
+		},
+		{
+			desc:                "uri allow list without slash",
+			siteURL:             "http://localhost:3000",
+			uriAllowList:        []string{"http://example.org"},
+			requestredirectURL:  "http://example.org/",
+			expectedredirectURL: "http://example.org/",
+		},
+		{
+			desc:                "uri allow list with path and slash",
+			siteURL:             "http://localhost:3000",
+			uriAllowList:        []string{"http://example.org/path/"},
+			requestredirectURL:  "http://example.org/path",
+			expectedredirectURL: "http://example.org/path",
+		},
+		{
+			desc:                "uri allow list with path and no slash",
+			siteURL:             "http://localhost:3000",
+			uriAllowList:        []string{"http://example.org/path"},
+			requestredirectURL:  "http://example.org/path/",
+			expectedredirectURL: "http://example.org/path/",
+		},
 	}
 
 	for _, tC := range testCases {


### PR DESCRIPTION
## What kind of change does this PR introduce?

If a user specifies a redirect URL glob of the form:

```
https://example.com
```

But they send a `redirect_to` parameter to `/authorize` of the form:

```
https://example.com/
```

(Note the trailing slash!)

GoTrue will not match the two URLs, even though in the modern web they are equivalent. This PR normalizes HTTP(S) URLs to remove the trailing slash in the `redirect_to` parameter; as well as ignoring any trailing slashes in the URL allow list.
