### PR TITLE
Remove `auth` schema prefix, reply on `search_path`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,6 @@ COPY --from=build /go/src/github.com/netlify/gotrue/migrations /usr/local/etc/go
 
 ENV GOTRUE_DB_MIGRATIONS_PATH /usr/local/etc/gotrue/migrations
 
+
 USER netlify
 CMD ["gotrue"]

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -55,12 +55,9 @@ func migrate(cmd *cobra.Command, args []string) {
 	}
 
 	u, err := url.Parse(globalConfig.DB.URL)
+
 	processedUrl := globalConfig.DB.URL
-	if len(u.Query()) != 0 {
-		processedUrl = fmt.Sprintf("%s&application_name=gotrue_migrations", processedUrl)
-	} else {
-		processedUrl = fmt.Sprintf("%s?application_name=gotrue_migrations", processedUrl)
-	}
+
 	deets := &pop.ConnectionDetails{
 		Dialect: globalConfig.DB.Driver,
 		URL:     processedUrl,

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -55,9 +55,12 @@ func migrate(cmd *cobra.Command, args []string) {
 	}
 
 	u, err := url.Parse(globalConfig.DB.URL)
-
 	processedUrl := globalConfig.DB.URL
-
+	if len(u.Query()) != 0 {
+		processedUrl = fmt.Sprintf("%s&application_name=gotrue_migrations", processedUrl)
+	} else {
+		processedUrl = fmt.Sprintf("%s?application_name=gotrue_migrations", processedUrl)
+	}
 	deets := &pop.ConnectionDetails{
 		Dialect: globalConfig.DB.Driver,
 		URL:     processedUrl,

--- a/migrations/00_init_auth_schema.up.sql
+++ b/migrations/00_init_auth_schema.up.sql
@@ -1,6 +1,6 @@
--- auth.users definition
+-- users definition
 
-CREATE TABLE IF NOT EXISTS auth.users (
+CREATE TABLE IF NOT EXISTS users (
 	instance_id uuid NULL,
 	id uuid NOT NULL UNIQUE,
 	aud varchar(255) NULL,
@@ -24,13 +24,13 @@ CREATE TABLE IF NOT EXISTS auth.users (
 	updated_at timestamptz NULL,
 	CONSTRAINT users_pkey PRIMARY KEY (id)
 );
-CREATE INDEX IF NOT EXISTS users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
-CREATE INDEX IF NOT EXISTS users_instance_id_idx ON auth.users USING btree (instance_id);
-comment on table auth.users is 'Auth: Stores user login data within a secure schema.';
+CREATE INDEX IF NOT EXISTS users_instance_id_email_idx ON users USING btree (instance_id, email);
+CREATE INDEX IF NOT EXISTS users_instance_id_idx ON users USING btree (instance_id);
+comment on table users is 'Auth: Stores user login data within a secure schema.';
 
--- auth.refresh_tokens definition
+-- refresh_tokens definition
 
-CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
+CREATE TABLE IF NOT EXISTS refresh_tokens (
 	instance_id uuid NULL,
 	id bigserial NOT NULL,
 	"token" varchar(255) NULL,
@@ -40,14 +40,14 @@ CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
 	updated_at timestamptz NULL,
 	CONSTRAINT refresh_tokens_pkey PRIMARY KEY (id)
 );
-CREATE INDEX IF NOT EXISTS refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
-CREATE INDEX IF NOT EXISTS refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
-CREATE INDEX IF NOT EXISTS refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
-comment on table auth.refresh_tokens is 'Auth: Store of tokens used to refresh JWT tokens once they expire.';
+CREATE INDEX IF NOT EXISTS refresh_tokens_instance_id_idx ON refresh_tokens USING btree (instance_id);
+CREATE INDEX IF NOT EXISTS refresh_tokens_instance_id_user_id_idx ON refresh_tokens USING btree (instance_id, user_id);
+CREATE INDEX IF NOT EXISTS refresh_tokens_token_idx ON refresh_tokens USING btree (token);
+comment on table refresh_tokens is 'Auth: Store of tokens used to refresh JWT tokens once they expire.';
 
--- auth.instances definition
+-- instances definition
 
-CREATE TABLE IF NOT EXISTS auth.instances (
+CREATE TABLE IF NOT EXISTS instances (
 	id uuid NOT NULL,
 	uuid uuid NULL,
 	raw_base_config text NULL,
@@ -55,34 +55,34 @@ CREATE TABLE IF NOT EXISTS auth.instances (
 	updated_at timestamptz NULL,
 	CONSTRAINT instances_pkey PRIMARY KEY (id)
 );
-comment on table auth.instances is 'Auth: Manages users across multiple sites.';
+comment on table instances is 'Auth: Manages users across multiple sites.';
 
--- auth.audit_log_entries definition
+-- audit_log_entries definition
 
-CREATE TABLE IF NOT EXISTS auth.audit_log_entries (
+CREATE TABLE IF NOT EXISTS audit_log_entries (
 	instance_id uuid NULL,
 	id uuid NOT NULL,
 	payload json NULL,
 	created_at timestamptz NULL,
 	CONSTRAINT audit_log_entries_pkey PRIMARY KEY (id)
 );
-CREATE INDEX IF NOT EXISTS audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
-comment on table auth.audit_log_entries is 'Auth: Audit trail for user actions.';
+CREATE INDEX IF NOT EXISTS audit_logs_instance_id_idx ON audit_log_entries USING btree (instance_id);
+comment on table audit_log_entries is 'Auth: Audit trail for user actions.';
 
--- auth.schema_migrations definition
+-- schema_migrations definition
 
-CREATE TABLE IF NOT EXISTS auth.schema_migrations (
+CREATE TABLE IF NOT EXISTS schema_migrations (
 	"version" varchar(255) NOT NULL,
 	CONSTRAINT schema_migrations_pkey PRIMARY KEY ("version")
 );
-comment on table auth.schema_migrations is 'Auth: Manages updates to the auth system.';
+comment on table schema_migrations is 'Auth: Manages updates to the auth system.';
 		
 -- Gets the User ID from the request cookie
-create or replace function auth.uid() returns uuid as $$
+create or replace function uid() returns uuid as $$
   select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
 $$ language sql stable;
 
 -- Gets the User ID from the request cookie
-create or replace function auth.role() returns text as $$
+create or replace function role() returns text as $$
   select nullif(current_setting('request.jwt.claim.role', true), '')::text;
 $$ language sql stable;

--- a/migrations/20210710035447_alter_users.up.sql
+++ b/migrations/20210710035447_alter_users.up.sql
@@ -1,6 +1,6 @@
 -- alter user schema
 
-ALTER TABLE auth.users 
+ALTER TABLE users
 ADD COLUMN IF NOT EXISTS phone VARCHAR(15) NULL UNIQUE DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS phone_confirmed_at timestamptz NULL DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS phone_change VARCHAR(15) NULL DEFAULT '',
@@ -13,7 +13,7 @@ BEGIN
     FROM information_schema.columns
     WHERE table_schema = 'auth' and table_name='users' and column_name='email_confirmed_at')
   THEN
-      ALTER TABLE "auth"."users" RENAME COLUMN "confirmed_at" TO "email_confirmed_at";
+      ALTER TABLE "users" RENAME COLUMN "confirmed_at" TO "email_confirmed_at";
   END IF;
 END $$;
 

--- a/migrations/20210710035447_alter_users.up.sql
+++ b/migrations/20210710035447_alter_users.up.sql
@@ -7,13 +7,5 @@ ADD COLUMN IF NOT EXISTS phone_change VARCHAR(15) NULL DEFAULT '',
 ADD COLUMN IF NOT EXISTS phone_change_token VARCHAR(255) NULL DEFAULT '',
 ADD COLUMN IF NOT EXISTS phone_change_sent_at timestamptz NULL DEFAULT NULL;
 
-DO $$
-BEGIN
-  IF NOT EXISTS(SELECT *
-    FROM information_schema.columns
-    WHERE table_schema = 'auth' and table_name='users' and column_name='email_confirmed_at')
-  THEN
-      ALTER TABLE "users" RENAME COLUMN "confirmed_at" TO "email_confirmed_at";
-  END IF;
-END $$;
+ALTER TABLE "users" RENAME COLUMN "confirmed_at" TO "email_confirmed_at";
 

--- a/migrations/20210722035447_adds_confirmed_at.up.sql
+++ b/migrations/20210722035447_adds_confirmed_at.up.sql
@@ -1,4 +1,4 @@
 -- adds confirmed at
 
-ALTER TABLE auth.users
+ALTER TABLE users
 ADD COLUMN IF NOT EXISTS confirmed_at timestamptz GENERATED ALWAYS AS (LEAST (users.email_confirmed_at, users.phone_confirmed_at)) STORED;

--- a/migrations/20210730183235_add_email_change_confirmed.up.sql
+++ b/migrations/20210730183235_add_email_change_confirmed.up.sql
@@ -1,6 +1,6 @@
 -- adds email_change_confirmed
 
-ALTER TABLE auth.users
+ALTER TABLE users
 ADD COLUMN IF NOT EXISTS email_change_token_current varchar(255) null DEFAULT '', 
 ADD COLUMN IF NOT EXISTS email_change_confirm_status smallint DEFAULT 0 CHECK (email_change_confirm_status >= 0 AND email_change_confirm_status <= 2);
 
@@ -10,6 +10,6 @@ BEGIN
     FROM information_schema.columns
     WHERE table_schema = 'auth' and table_name='users' and column_name='email_change_token_new')
   THEN
-      ALTER TABLE "auth"."users" RENAME COLUMN "email_change_token" TO "email_change_token_new";
+      ALTER TABLE "users" RENAME COLUMN "email_change_token" TO "email_change_token_new";
   END IF;
 END $$;

--- a/migrations/20210730183235_add_email_change_confirmed.up.sql
+++ b/migrations/20210730183235_add_email_change_confirmed.up.sql
@@ -4,12 +4,4 @@ ALTER TABLE users
 ADD COLUMN IF NOT EXISTS email_change_token_current varchar(255) null DEFAULT '', 
 ADD COLUMN IF NOT EXISTS email_change_confirm_status smallint DEFAULT 0 CHECK (email_change_confirm_status >= 0 AND email_change_confirm_status <= 2);
 
-DO $$
-BEGIN
-  IF NOT EXISTS(SELECT *
-    FROM information_schema.columns
-    WHERE table_schema = 'auth' and table_name='users' and column_name='email_change_token_new')
-  THEN
-      ALTER TABLE "users" RENAME COLUMN "email_change_token" TO "email_change_token_new";
-  END IF;
-END $$;
+ALTER TABLE "users" RENAME COLUMN "email_change_token" TO "email_change_token_new";

--- a/migrations/20210909172000_create_identities_table.up.sql
+++ b/migrations/20210909172000_create_identities_table.up.sql
@@ -1,6 +1,6 @@
 -- adds identities table 
 
-CREATE TABLE IF NOT EXISTS auth.identities (
+CREATE TABLE IF NOT EXISTS identities (
     id text NOT NULL,
     user_id uuid NOT NULL,
     identity_data JSONB NOT NULL,
@@ -9,6 +9,6 @@ CREATE TABLE IF NOT EXISTS auth.identities (
     created_at timestamptz NULL,
     updated_at timestamptz NULL,
     CONSTRAINT identities_pkey PRIMARY KEY (provider, id),
-    CONSTRAINT identities_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE
+    CONSTRAINT identities_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
-COMMENT ON TABLE auth.identities is 'Auth: Stores identities associated to a user.';
+COMMENT ON TABLE identities is 'Auth: Stores identities associated to a user.';

--- a/migrations/20210927181326_add_refresh_token_parent.up.sql
+++ b/migrations/20210927181326_add_refresh_token_parent.up.sql
@@ -1,8 +1,8 @@
 -- adds parent column
 
-ALTER TABLE auth.refresh_tokens
+ALTER TABLE refresh_tokens
 ADD COLUMN IF NOT EXISTS parent varchar(255) NULL,
 ADD CONSTRAINT refresh_tokens_token_unique UNIQUE ("token"),
-ADD CONSTRAINT refresh_tokens_parent_fkey FOREIGN KEY (parent) REFERENCES auth.refresh_tokens("token");
+ADD CONSTRAINT refresh_tokens_parent_fkey FOREIGN KEY (parent) REFERENCES refresh_tokens("token");
 
 CREATE INDEX IF NOT EXISTS refresh_tokens_parent_idx ON refresh_tokens USING btree (parent);

--- a/migrations/20211124214934_update_auth_functions.up.sql
+++ b/migrations/20211124214934_update_auth_functions.up.sql
@@ -1,6 +1,6 @@
 -- update auth functions
 
-create or replace function auth.uid() 
+create or replace function uid()
 returns uuid 
 language sql stable
 as $$
@@ -11,7 +11,7 @@ as $$
 	)::uuid
 $$;
 
-create or replace function auth.role() 
+create or replace function role()
 returns text 
 language sql stable
 as $$
@@ -22,7 +22,7 @@ as $$
 	)::text
 $$;
 
-create or replace function auth.email() 
+create or replace function email()
 returns text 
 language sql stable
 as $$

--- a/migrations/20211202183645_update_auth_uid.up.sql
+++ b/migrations/20211202183645_update_auth_uid.up.sql
@@ -1,6 +1,6 @@
--- update auth.uid()
+-- update uid()
 
-create or replace function auth.uid()
+create or replace function uid()
 returns uuid
 language sql stable
 as $$

--- a/migrations/20220114185340_add_banned_until.up.sql
+++ b/migrations/20220114185340_add_banned_until.up.sql
@@ -1,4 +1,4 @@
 -- adds banned_until column
 
-ALTER TABLE auth.users
+ALTER TABLE users
 ADD COLUMN IF NOT EXISTS banned_until timestamptz NULL;

--- a/migrations/20220224000811_update_auth_functions.up.sql
+++ b/migrations/20220224000811_update_auth_functions.up.sql
@@ -1,6 +1,6 @@
 -- update auth functions
 
-create or replace function auth.uid() 
+create or replace function uid()
 returns uuid 
 language sql stable
 as $$
@@ -11,7 +11,7 @@ as $$
 	)::uuid
 $$;
 
-create or replace function auth.role() 
+create or replace function role()
 returns text 
 language sql stable
 as $$
@@ -22,7 +22,7 @@ as $$
 	)::text
 $$;
 
-create or replace function auth.email() 
+create or replace function email()
 returns text 
 language sql stable
 as $$

--- a/migrations/20220323170000_add_user_reauthentication.up.sql
+++ b/migrations/20220323170000_add_user_reauthentication.up.sql
@@ -1,5 +1,5 @@
 -- adds reauthentication_token and reauthentication_sent_at 
 
-ALTER TABLE auth.users
+ALTER TABLE users
 ADD COLUMN IF NOT EXISTS reauthentication_token varchar(255) null default '',
 ADD COLUMN IF NOT EXISTS reauthentication_sent_at timestamptz null default null;

--- a/migrations/20220429102000_add_unique_idx.up.sql
+++ b/migrations/20220429102000_add_unique_idx.up.sql
@@ -7,8 +7,8 @@ DROP INDEX IF EXISTS email_change_token_current_idx;
 DROP INDEX IF EXISTS email_change_token_new_idx;
 DROP INDEX IF EXISTS reauthentication_token_idx;
 
-CREATE UNIQUE INDEX IF NOT EXISTS confirmation_token_idx ON auth.users USING btree (confirmation_token) WHERE confirmation_token !~ '^[0-9 ]*$';
-CREATE UNIQUE INDEX IF NOT EXISTS recovery_token_idx ON auth.users USING btree (recovery_token) WHERE recovery_token !~ '^[0-9 ]*$';
-CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_current_idx ON auth.users USING btree (email_change_token_current) WHERE email_change_token_current !~ '^[0-9 ]*$';
-CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_new_idx ON auth.users USING btree (email_change_token_new) WHERE email_change_token_new !~ '^[0-9 ]*$';
-CREATE UNIQUE INDEX IF NOT EXISTS reauthentication_token_idx ON auth.users USING btree (reauthentication_token) WHERE reauthentication_token !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS confirmation_token_idx ON users USING btree (confirmation_token) WHERE confirmation_token !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS recovery_token_idx ON users USING btree (recovery_token) WHERE recovery_token !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_current_idx ON users USING btree (email_change_token_current) WHERE email_change_token_current !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_new_idx ON users USING btree (email_change_token_new) WHERE email_change_token_new !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS reauthentication_token_idx ON users USING btree (reauthentication_token) WHERE reauthentication_token !~ '^[0-9 ]*$';

--- a/migrations/20220531120530_add_auth_jwt_function.up.sql
+++ b/migrations/20220531120530_add_auth_jwt_function.up.sql
@@ -1,10 +1,10 @@
--- add auth.jwt function
+-- add jwt function
 
-comment on function auth.uid() is 'Deprecated. Use auth.jwt() -> ''sub'' instead.';
-comment on function auth.role() is 'Deprecated. Use auth.jwt() -> ''role'' instead.';
-comment on function auth.email() is 'Deprecated. Use auth.jwt() -> ''email'' instead.';
+comment on function uid() is 'Deprecated. Use jwt() -> ''sub'' instead.';
+comment on function role() is 'Deprecated. Use jwt() -> ''role'' instead.';
+comment on function email() is 'Deprecated. Use jwt() -> ''email'' instead.';
 
-create or replace function auth.jwt()
+create or replace function jwt()
 returns jsonb
 language sql stable
 as $$

--- a/migrations/20220614074223_add_ip_address_to_audit_log.postgres.up.sql
+++ b/migrations/20220614074223_add_ip_address_to_audit_log.postgres.up.sql
@@ -1,3 +1,3 @@
 -- Add IP Address to audit log
-ALTER TABLE auth.audit_log_entries
+ALTER TABLE audit_log_entries
 ADD COLUMN IF NOT EXISTS ip_address VARCHAR(64) NOT NULL DEFAULT '';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Current implementation hardcodes `auth` schema in migration, making it hard to change it if a developer wants it.

In our use case specifically, we don't want to deploy gotrue into the auth schema, but rather into a standard `public` inside dedicated database.

## What is the new behavior?

Removed `auth` schema from migrations, delegating it to `search_path` postgres setting to decide which schema to use. 

## Additional context

Non-breaking change. 
