### PR TITLE
fix: add email_change support to generateLink

### DIFF
--- a/mailer/template.go
+++ b/mailer/template.go
@@ -317,14 +317,16 @@ func (m TemplateMailer) GetEmailActionLink(user *models.User, actionType, referr
 		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite"+redirectParam)
 	case "signup":
 		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup"+redirectParam)
+	case "email_change_current":
+		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.EmailChange, "token="+user.EmailChangeTokenCurrent+"&type=email_change"+redirectParam)
+	case "email_change_new":
+		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.EmailChange, "token="+user.EmailChangeTokenNew+"&type=email_change"+redirectParam)
 	default:
 		return "", fmt.Errorf("Invalid email action link type: %s", actionType)
 	}
-
 	if err != nil {
 		return "", err
 	}
-
 	return url, nil
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds support to generate email links for changing a user's email

## What is the current behavior?
* `/admin/generate_link` endpoint does not support generating email links for changing emails 
* https://github.com/supabase/supabase/discussions/5125#discussioncomment-3172735
* Addresses #365 

## What is the new behavior?
* Introduces 2 new types for generating email links: `email_change_current`, `email_change_new` 
```bash

# Change email from foo@example.com --> bar@example.com

curl -X POST 'http://localhost:9999/admin/generate_link' 
-H 'Authorization: Bearer token' 
-d '{
  "type": "email_change_current", 
  "new_email": "bar@example.com", 
  "email": "foo@example.com"
}'

# Response
{
  "action_link": "http://localhost:9999/verify?token=813...2f8&type=email_change&redirect_to=http://localhost:3000",
  "email": "foo@example.com",
  "email_change_sent_at": "2022-07-22T12:49:45.906546+08:00",
  "email_confirmed_at": "2022-07-22T11:58:38.056107+08:00",
  "email_otp": "412620",
  "hashed_token": "813...2f8",
  "new_email": "bar@example.com",
  "verification_type": "email_change_current"
}

curl -X POST 'http://localhost:9999/admin/generate_link' 
-H 'Authorization: Bearer token' 
-d '{
  "type": "email_change_new", 
  "new_email": "bar@example.com", 
  "email": "foo@example.com"
}'

# Response {
  "action_link": "http://localhost:9999/verify?token=209...9de&type=email_change&redirect_to=http://localhost:3000",
  "email": "foo@example.com",
  "email_change_sent_at": "2022-07-22T12:49:45.906546+08:00",
  "email_confirmed_at": "2022-07-22T11:58:38.056107+08:00",
  "email_otp": "111222",
  "hashed_token": "209...9d3",
  "new_email": "bar@example.com",
  "verification_type": "email_change_new"
}
```
## Additional Context
* If `GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED` is set to `false`, the following error message will be returned when attempting to generate an email link for the current email:

```bash
{
  "code": 422,
  "msg": "Enable secure email change to generate link for current email"
}
```

* If `GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED` is set to `true`, then you will need to generate an email link using both `email_change_current` and `email_change_new` types.