### PR TITLE
MFA fixes 

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -188,7 +188,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 				r.Use(api.loadUser)
 				r.Put("/disable", api.DisableMFA)
 				r.Put("/enable", api.EnableMFA)
-				r.Get("/recovery_codes", api.GenerateRecoveryCodes)
+				r.Post("/recovery_codes", api.GenerateRecoveryCodes)
 				r.Post("/factor", api.EnrollFactor)
 				r.Post("/challenge", api.ChallengeFactor)
 				r.Post("/verify", api.VerifyFactor)

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -51,7 +51,6 @@ type ChallengeFactorResponse struct {
 }
 
 type VerifyFactorResponse struct {
-	MFAType string `json:"mfa_type"`
 	Success string `json:"success"`
 }
 
@@ -342,7 +341,6 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	return sendJSON(w, http.StatusOK, &VerifyFactorResponse{
-		MFAType: factor.FactorType,
 		Success: fmt.Sprintf("%v", valid),
 	})
 

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -259,7 +259,6 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			require.NoError(ts.T(), err)
 			testEmail := emailValue.(string)
 			testDomain := strings.Split(testEmail, "@")[1]
-			testFactorType := "totp"
 			// set factor secret
 			key, err := totp.Generate(totp.GenerateOpts{
 				Issuer:      testDomain,
@@ -312,7 +311,6 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			data := VerifyFactorResponse{}
 			if v.expectedHTTPCode == http.StatusOK {
 				require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
-				require.Equal(ts.T(), data.MFAType, testFactorType)
 				require.Equal(ts.T(), data.Success, "true")
 			}
 			if !v.validChallenge {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Change `/recovery_codes` from GET to POST
- Allow only `factor_id` to be passed in on the `/challenge` endpoint
- update responses for  `/challenge`(remove `factor_id` and `friendly_name`) and `/verify` (remove `/challenge_id` from response)
- Remove  type from `/verify` endpoint
- Update associated tests
## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
