### PR TITLE
feat: Add MagicLink verification via JavaScript

### DIFF
--- a/api/verify.html
+++ b/api/verify.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+	</head>
+	<body>
+		<form id="form" method="POST">
+		</form>
+
+		<script>
+			"use strict";
+
+			const form = document.getElementById("form");
+
+			setTimeout(() => {
+				form.requestSubmit();
+			}, 250);
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Certain email clients and enterprise security software like to open links in messages. Magic Links are "verified" when the GET request happens. Thus, this software is automatically verifying magic links, making them useless when a user attempts to click on them in the email.

This PR adds a `usejs` query param that can be added to the Magic Link URL which will serve a tiny HTML page when visited. The page uses JavaScript to submit a POST request after 250ms have passed, ensuring that the email client or security software understands JavaScript and is able to wait and execute the code. 

It is believed that this will reduce, but not eliminate, issues with Magic Links.
