### PR TITLE
Refactor MFA Routes

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -48,6 +48,21 @@ func (a *API) loadUser(w http.ResponseWriter, r *http.Request) (context.Context,
 	return withUser(r.Context(), u), nil
 }
 
+func (a *API) loadFactor(w http.ResponseWriter, r *http.Request) (context.Context, error) {
+	factorID := chi.URLParam(r, "factor_id")
+
+	logEntrySetField(r, "factor_id", factorID)
+	f, err := models.FindFactorByFactorID(a.db, factorID)
+	if err != nil {
+		if models.IsNotFoundError(err) {
+			return nil, notFoundError("Factor not found")
+		}
+		return nil, internalServerError("Database error loading factor").WithInternalError(err)
+	}
+	// write withFactor
+	return withFactor(r.Context(), f), nil
+}
+
 func (a *API) getAdminParams(r *http.Request) (*adminUserParams, error) {
 	params := adminUserParams{}
 	err := json.NewDecoder(r.Body).Decode(&params)

--- a/api/admin.go
+++ b/api/admin.go
@@ -59,7 +59,6 @@ func (a *API) loadFactor(w http.ResponseWriter, r *http.Request) (context.Contex
 		}
 		return nil, internalServerError("Database error loading factor").WithInternalError(err)
 	}
-	// write withFactor
 	return withFactor(r.Context(), f), nil
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -153,9 +153,9 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			r.Route("/{user_id}", func(r *router) {
 				r.Use(api.loadUser)
 				r.Route("/factor", func(r *router) {
+					r.Post("/", api.EnrollFactor)
 					r.Route("/{factor_id}", func(r *router) {
 						r.Use(api.loadFactor)
-						r.Post("/enroll", api.EnrollFactor)
 						r.Post("/verify", api.VerifyFactor)
 						r.Post("/challenge", api.ChallengeFactor)
 

--- a/api/api.go
+++ b/api/api.go
@@ -150,6 +150,20 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			r.Use(api.requireAuthentication)
 			r.Get("/", api.UserGet)
 			r.With(sharedLimiter).Put("/", api.UserUpdate)
+			r.Route("/{user_id}", func(r *router) {
+				r.Use(api.loadUser)
+				r.Route("/factor", func(r *router) {
+					r.Route("/{factor_id}", func(r *router) {
+						r.Use(api.loadFactor)
+						r.Post("/enroll", api.EnrollFactor)
+						r.Post("/verify", api.VerifyFactor)
+						r.Post("/challenge", api.ChallengeFactor)
+
+					})
+				})
+				r.Post("/recovery_codes", api.GenerateRecoveryCodes)
+			})
+
 		})
 
 		r.Route("/admin", func(r *router) {
@@ -182,16 +196,6 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			})
 
 			r.Get("/metadata", api.SAMLMetadata)
-		})
-		r.Route("/mfa", func(r *router) {
-			r.Route("/{user_id}", func(r *router) {
-				r.Use(api.loadUser)
-				r.Post("/recovery_codes", api.GenerateRecoveryCodes)
-				r.Post("/factor", api.EnrollFactor)
-				r.Post("/challenge", api.ChallengeFactor)
-				r.Post("/verify", api.VerifyFactor)
-
-			})
 		})
 	})
 

--- a/api/context.go
+++ b/api/context.go
@@ -26,6 +26,7 @@ const (
 	netlifyIDKey            = contextKey("netlify_id")
 	externalProviderTypeKey = contextKey("external_provider_type")
 	userKey                 = contextKey("user")
+	factorKey               = contextKey("factor")
 	externalReferrerKey     = contextKey("external_referrer")
 	functionHooksKey        = contextKey("function_hooks")
 	adminUserKey            = contextKey("admin_user")
@@ -117,6 +118,11 @@ func withUser(ctx context.Context, u *models.User) context.Context {
 	return context.WithValue(ctx, userKey, u)
 }
 
+// with Factor adds the factor id to the context.
+func withFactor(ctx context.Context, f *models.Factor) context.Context {
+	return context.WithValue(ctx, factorKey, f)
+}
+
 // getUser reads the user id from the context.
 func getUser(ctx context.Context) *models.User {
 	obj := ctx.Value(userKey)
@@ -124,6 +130,15 @@ func getUser(ctx context.Context) *models.User {
 		return nil
 	}
 	return obj.(*models.User)
+}
+
+// getFactor reads the factor id from the context
+func getFactor(ctx context.Context) *models.Factor {
+	obj := ctx.Value(factorKey)
+	if obj == nil {
+		return nil
+	}
+	return obj.(*models.Factor)
 }
 
 // withSignature adds the provided request ID to the context.

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -104,9 +104,6 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	user := getUser(ctx)
 	instanceID := getInstanceID(ctx)
-	if !user.MFAEnabled {
-		return forbiddenError(MFANotEnabledMsg)
-	}
 
 	params := &EnrollFactorParams{}
 	jsonDecoder := json.NewDecoder(r.Body)

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -33,11 +33,6 @@ type EnrollFactorResponse struct {
 	TOTP      TOTPObject
 }
 
-type ChallengeFactorParams struct {
-	FactorID     string `json:"factor_id"`
-	FriendlyName string `json:"friendly_name"`
-}
-
 type VerifyFactorParams struct {
 	ChallengeID string `json:"challenge_id"`
 	Code        string `json:"code"`
@@ -166,36 +161,11 @@ func (a *API) ChallengeFactor(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.getConfig(ctx)
 	user := getUser(ctx)
+	factor := getFactor(ctx)
 	instanceID := getInstanceID(ctx)
-	if !user.MFAEnabled {
-		return forbiddenError(MFANotEnabledMsg)
-	}
-	var factor *models.Factor
-	var err error
-
-	params := &ChallengeFactorParams{}
-	jsonDecoder := json.NewDecoder(r.Body)
-	err = jsonDecoder.Decode(params)
-	if err != nil {
-		return badRequestError("Could not read EnrollFactor params: %v", err)
-	}
-	factorID := params.FactorID
-
-	if factorID != "" {
-		factor, err = models.FindFactorByFactorID(a.db, factorID)
-	} else {
-		return unprocessableEntityError("FactorID should be provided to create a challenge")
-	}
-	if err != nil {
-		if models.IsNotFoundError(err) {
-			return notFoundError(err.Error())
-		}
-		return internalServerError("Database error finding factor").WithInternalError(err)
-	}
-
 	challenge, terr := models.NewChallenge(factor)
 	if terr != nil {
-		return internalServerError("Database error creating challenge").WithInternalError(err)
+		return internalServerError("Database error creating challenge").WithInternalError(terr)
 	}
 
 	terr = a.db.Transaction(func(tx *storage.Connection) error {
@@ -203,23 +173,23 @@ func (a *API) ChallengeFactor(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 		if terr := models.NewAuditLogEntry(tx, instanceID, user, models.CreateChallengeAction, r.RemoteAddr, map[string]interface{}{
-			"factor_id":     params.FactorID,
+			"factor_id":     factor.ID,
 			"factor_status": factor.Status,
 		}); terr != nil {
 			return terr
 		}
-
 		return nil
 	})
-	creationTime := challenge.CreatedAt
-	if err != nil {
-		return internalServerError("Error parsing database timestamp").WithInternalError(err)
+	if terr != nil {
+		return terr
 	}
 
+	creationTime := challenge.CreatedAt
+	expiryTime := creationTime.Add(time.Second * time.Duration(config.MFA.ChallengeExpiryDuration))
 	return sendJSON(w, http.StatusOK, &ChallengeFactorResponse{
 		ID:        challenge.ID,
 		CreatedAt: creationTime.String(),
-		ExpiresAt: creationTime.Add(time.Second * time.Duration(config.MFA.ChallengeExpiryDuration)).String(),
+		ExpiresAt: expiryTime.String(),
 	})
 }
 
@@ -228,6 +198,7 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.getConfig(ctx)
 	user := getUser(ctx)
+	factor := getFactor(ctx)
 	instanceID := getInstanceID(ctx)
 	if !user.MFAEnabled {
 		return forbiddenError(MFANotEnabledMsg)
@@ -238,14 +209,6 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 	err = jsonDecoder.Decode(params)
 	if err != nil {
 		return badRequestError("Please check the params passed into VerifyFactor: %v", err)
-	}
-
-	factor, err := models.FindFactorByChallengeID(a.db, params.ChallengeID)
-	if err != nil {
-		if models.IsNotFoundError(err) {
-			return notFoundError(err.Error())
-		}
-		return internalServerError("Database error finding factor").WithInternalError(err)
 	}
 
 	challenge, err := models.FindChallengeByChallengeID(a.db, params.ChallengeID)

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -106,7 +106,7 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 			require.NoError(ts.T(), err)
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/user/%s/factor", user.ID), &buffer)
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/user/%s/factor/", user.ID), &buffer)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 			req.Header.Set("Content-Type", "application/json")
 			ts.API.handler.ServeHTTP(w, req)
@@ -222,7 +222,7 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			require.NoError(ts.T(), err)
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/users/%s/factor/%s/verify", user.ID, f.ID), &buffer)
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/user/%s/factor/%s/verify", user.ID, f.ID), &buffer)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 			ts.API.handler.ServeHTTP(w, req)
 			require.Equal(ts.T(), v.expectedHTTPCode, w.Code)

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -41,7 +41,6 @@ func TestMFA(t *testing.T) {
 
 func (ts *MFATestSuite) SetupTest() {
 	models.TruncateAll(ts.API.db)
-
 	// Create user
 	u, err := models.NewUser(ts.instanceID, "123456789", "test@example.com", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
@@ -61,7 +60,7 @@ func (ts *MFATestSuite) TestMFARecoveryCodeGeneration() {
 	require.NoError(ts.T(), err)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/mfa/%s/recovery_codes", user.ID), nil)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/user/%s/recovery_codes", user.ID), nil)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	ts.API.handler.ServeHTTP(w, req)
 	require.Equal(ts.T(), http.StatusOK, w.Code)
@@ -79,23 +78,13 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 		FriendlyName string
 		FactorType   string
 		Issuer       string
-		MFAEnabled   bool
 		expectedCode int
 	}{
-		{
-			"TOTP: MFA is disabled",
-			"",
-			"totp",
-			"supabase.com",
-			false,
-			http.StatusForbidden,
-		},
 		{
 			"TOTP: Factor has friendly name",
 			"bob",
 			"totp",
 			"supabase.com",
-			true,
 			http.StatusOK,
 		},
 		{
@@ -103,7 +92,6 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 			"",
 			"totp",
 			"supabase.com",
-			true,
 			http.StatusOK,
 		},
 	}
@@ -113,13 +101,12 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]string{"friendly_name": c.FriendlyName, "factor_type": c.FactorType, "issuer": c.Issuer}))
 			user, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)
 			ts.Require().NoError(err)
-			require.NoError(ts.T(), user.EnableMFA(ts.API.db))
 
 			token, err := generateAccessToken(user, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 			require.NoError(ts.T(), err)
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/mfa/%s/factor", user.ID), &buffer)
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/user/%s/factor", user.ID), &buffer)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 			req.Header.Set("Content-Type", "application/json")
 			ts.API.handler.ServeHTTP(w, req)
@@ -138,57 +125,23 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 }
 
 func (ts *MFATestSuite) TestChallengeFactor() {
-	cases := []struct {
-		desc         string
-		id           string
-		mfaEnabled   bool
-		expectedCode int
-	}{
-		{
-			"MFA Not Enabled",
-			"",
-			false,
-			http.StatusForbidden,
-		},
-		{
-			"Factor ID present",
-			"testFactorID",
-			true,
-			http.StatusOK,
-		},
-		{
-			"Factor ID missing",
-			"",
-			true,
-			http.StatusUnprocessableEntity,
-		},
-	}
-	for _, c := range cases {
-		ts.Run(c.desc, func() {
-			u, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)
-			require.NoError(ts.T(), err)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
 
-			if c.mfaEnabled {
-				require.NoError(ts.T(), u.EnableMFA(ts.API.db), "Error setting MFA to disabled")
-			}
+	f, err := models.FindFactorByFactorID(ts.API.db, "testFactorID")
+	require.NoError(ts.T(), err)
 
-			token, err := generateAccessToken(u, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
-			require.NoError(ts.T(), err, "Error generating access token")
+	token, err := generateAccessToken(u, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	require.NoError(ts.T(), err, "Error generating access token")
 
-			var buffer bytes.Buffer
-			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
-				"factor_id": c.id,
-			}))
+	var buffer bytes.Buffer
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost/user/%s/factor/%s/challenge", u.ID, f.ID), &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost/mfa/%s/challenge", u.ID), &buffer)
-			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-
-			w := httptest.NewRecorder()
-			ts.API.handler.ServeHTTP(w, req)
-			require.Equal(ts.T(), c.expectedCode, w.Code)
-		})
-	}
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
 }
 
 func (ts *MFATestSuite) TestMFAVerifyFactor() {
@@ -269,7 +222,7 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			require.NoError(ts.T(), err)
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/mfa/%s/verify", user.ID), &buffer)
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/users/%s/factor/%s/verify", user.ID, f.ID), &buffer)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 			ts.API.handler.ServeHTTP(w, req)
 			require.Equal(ts.T(), v.expectedHTTPCode, w.Code)

--- a/api/token_test.go
+++ b/api/token_test.go
@@ -64,7 +64,7 @@ func (ts *TokenTestSuite) TestRateLimitTokenRefresh() {
 	req.Header.Set("My-Custom-Header", "1.2.3.4")
 
 	// It rate limits after 30 requests
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 35; i++ {
 		w := httptest.NewRecorder()
 		ts.API.handler.ServeHTTP(w, req)
 		assert.Equal(ts.T(), http.StatusBadRequest, w.Code)

--- a/api/token_test.go
+++ b/api/token_test.go
@@ -64,7 +64,7 @@ func (ts *TokenTestSuite) TestRateLimitTokenRefresh() {
 	req.Header.Set("My-Custom-Header", "1.2.3.4")
 
 	// It rate limits after 30 requests
-	for i := 0; i < 35; i++ {
+	for i := 0; i < 30; i++ {
 		w := httptest.NewRecorder()
 		ts.API.handler.ServeHTTP(w, req)
 		assert.Equal(ts.T(), http.StatusBadRequest, w.Code)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactors MFA Routes to conform to a more REST-ful format


now, routes are of the form `/user/<user_id>/factor/<factor_id>/<action>` . Concretely, this means

- [x]  Change `/mfa/user_id/challenge` to /users/{user_id}/factors/{factor_id}/challenge
- [x]  `/mfa/user_id/verify` to `/users/{user_id}/factors/{factor_id}/verify`
- [x] `/mfa/user_id/enroll` to `/users/{user_id}/factors/{factor_id}/`
And more


This is done by storing and loading factors from the context and making use of them to perform relevant operations. 



## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
