### PR TITLE
Remove sleep from admin test

### DIFF
--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -138,12 +138,12 @@ func (ts *AdminTestSuite) TestAdminUsers_Pagination() {
 // TestAdminUsers tests API /admin/users route
 func (ts *AdminTestSuite) TestAdminUsers_SortAsc() {
 	u, err := models.NewUser(ts.instanceID, "", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u.CreatedAt = time.Now().Add(-time.Minute)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
-	// if the created_at times are the same, then the sort order is not guaranteed
-	time.Sleep(1 * time.Second)
 	u, err = models.NewUser(ts.instanceID, "", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
+	u.CreatedAt = time.Now()
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
@@ -173,12 +173,12 @@ func (ts *AdminTestSuite) TestAdminUsers_SortAsc() {
 // TestAdminUsers tests API /admin/users route
 func (ts *AdminTestSuite) TestAdminUsers_SortDesc() {
 	u, err := models.NewUser(ts.instanceID, "12345678", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u.CreatedAt = time.Now().Add(-time.Minute)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
-	// if the created_at times are the same, then the sort order is not guaranteed
-	time.Sleep(1 * time.Second)
 	u, err = models.NewUser(ts.instanceID, "987654321", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
+	u.CreatedAt = time.Now()
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Remove non-determinism from 2 tests & speed up those tests.

## What is the current behavior?
Tests relied on sleeping to allow underlying library to set `created_at` at `time.Now()`.

## What is the new behavior?
Explicitly set the `CreatedAt` value.

## Additional context
Looks like the library won't set CreatedAt if it's already set:
```
if !IsZeroOfUnderlyingType(v) {
  // Do not override already set CreatedAt
  return
}
```
https://github.com/gobuffalo/pop/blob/2d0cf817d62006ebf9bec1b51ab0a066602e3e5b/model.go#L194

Which is why this works.

Being explicit like this allows for more  advanced cases too. Like, if there was a "Recently added" feature that you wanted tested, you wouldn't be able to rely on sleep.
