### PR TITLE
Update description of /admin/generate_link response

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ body:
 
 ### **POST /admin/generate_link**
 
-Returns the corresponding email action link based on the type specified.
+Returns the corresponding email action link based on the type specified. The response also contains the query params of the action link as separate JSON fields for convenience (along with the email OTP from which the corresponding token is generated).
 
 ```js
 headers:
@@ -613,7 +613,10 @@ Returns
 ```js
 {
   "action_link": "http://localhost:9999/verify?token=TOKEN&type=TYPE&redirect_to=REDIRECT_URL",
-  ...
+  "email_otp": "EMAIL_OTP",
+  "hashed_token": "TOKEN",
+  "verification_type": "TYPE",
+  "redirect_to": "REDIRECT_URL"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ body:
 
 ### **POST /admin/generate_link**
 
-Returns the corresponding email action link based on the type specified. The response also contains the query params of the action link as separate JSON fields for convenience (along with the email OTP from which the corresponding token is generated).
+Returns the corresponding email action link based on the type specified. Among other things, the response also contains the query params of the action link as separate JSON fields for convenience (along with the email OTP from which the corresponding token is generated).
 
 ```js
 headers:
@@ -616,7 +616,8 @@ Returns
   "email_otp": "EMAIL_OTP",
   "hashed_token": "TOKEN",
   "verification_type": "TYPE",
-  "redirect_to": "REDIRECT_URL"
+  "redirect_to": "REDIRECT_URL",
+  ...
 }
 ```
 


### PR DESCRIPTION
The response from ```/admin/generate_link``` now includes additional fields (see https://github.com/supabase/gotrue/pull/537). These are added to the docs.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

https://github.com/supabase/gotrue/issues/538
https://github.com/supabase/gotrue/pull/537
