### PR TITLE
Reintroduce notion of MFAEnabled

### DIFF
--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -601,9 +601,14 @@ func (ts *AdminTestSuite) TestAdminUserCreateWithDisabledLogin() {
 
 // TestAdminUserDeleteRecoveryCodes tests API /admin/users/<user_id>/recovery_codes/
 func (ts *AdminTestSuite) TestAdminUserDeleteRecoveryCodes() {
+	// TODO(Joel): Test case where factor is unverified
 	u, err := models.NewUser(ts.instanceID, "123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
+
+	f, err := models.NewFactor(u, "testSimpleName", "testFactorID", "totp", models.FactorVerifiedState, "secretkey")
+	require.NoError(ts.T(), err, "Error creating test factor model")
+	require.NoError(ts.T(), ts.API.db.Create(f), "Error saving new test factor")
 
 	// Create batch of Recovery Codes
 	for i := 0; i < models.NumRecoveryCodes; i++ {
@@ -627,11 +632,12 @@ func (ts *AdminTestSuite) TestAdminUserDeleteRecoveryCodes() {
 
 // TestAdminUserDeleteFactor tests API /admin/users/<user_id>/factor/<factor_id>/
 func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
+	// TODO(Joel): Test case where factor is unverified
 	u, err := models.NewUser(ts.instanceID, "123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
-	f, err := models.NewFactor(u, "testSimpleName", "testFactorID", "totp", models.FactorDisabledState, "secretkey")
+	f, err := models.NewFactor(u, "testSimpleName", "testFactorID", "totp", models.FactorVerifiedState, "secretkey")
 	require.NoError(ts.T(), err, "Error creating test factor model")
 	require.NoError(ts.T(), ts.API.db.Create(f), "Error saving new test factor")
 

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -228,6 +228,12 @@ func (a *API) UnenrollFactor(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return badRequestError(err.Error())
 	}
+	MFAEnabled, err := models.IsMFAEnabled(a.db, user)
+	if err != nil {
+		return err
+	} else if !MFAEnabled {
+		return forbiddenError("You do not have a verified factor enrolled")
+	}
 
 	valid := totp.Validate(params.Code, factor.SecretKey)
 	if valid != true {

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -218,6 +218,7 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 }
 
 func (ts *MFATestSuite) TestUnenrollFactor() {
+	// TODO(Joel): Test case where factor is unverified
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, ts.instanceID, "test@example.com", ts.Config.JWT.Aud)
 	emailValue, err := u.Email.Value()
 	require.NoError(ts.T(), err)
@@ -232,6 +233,7 @@ func (ts *MFATestSuite) TestUnenrollFactor() {
 	factors, err := models.FindFactorsByUser(ts.API.db, u)
 	f := factors[0]
 	f.SecretKey = sharedSecret
+	err = f.UpdateStatus(ts.API.db, models.FactorVerifiedState)
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), ts.API.db.Update(f), "Error updating new test factor")
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

`MFAEnabled` is no longer a variable on the `User` model  that can be toggled. Rather, a user can only call special MFA methods(like delete factor, unenroll factor) when they have at least one verified factor. It is more a safeguard than anything (and partially for security) because users calling the endpoints without a verified factor would still get an actor but perhaps with a more obscure message.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
