### PR TITLE
fix: Revert URL normalization (#535, #591)

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -111,38 +111,13 @@ func getRedirectTo(r *http.Request) (reqref string) {
 	return
 }
 
-func parseURL(u string) (*url.URL, error) {
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return nil, err
-	}
-
-	if parsed.Scheme == "https" || parsed.Scheme == "http" {
-		// this normalizes URLs that end with just a `/` as you would
-		// get from window.location.href on the frontend, so that they
-		// would match glob rules correctly
-
-		// applied only http and https URLs as trailing slashes don't
-		// change the behavior, while in other schemes they may have
-		// another meaning
-
-		// see: https://en.wikipedia.org/wiki/URI_normalization#Normalizations_that_usually_preserve_semantics
-
-		parsed.Path = strings.TrimSuffix(parsed.Path, "/")
-	}
-
-	return parsed, nil
-}
-
 func isRedirectURLValid(config *conf.Configuration, redirectURL string) bool {
 	if redirectURL == "" {
 		return false
 	}
 
-	base, berr := parseURL(config.SiteURL)
-	refurl, rerr := parseURL(redirectURL)
-
-	matchURL := refurl.String()
+	base, berr := url.Parse(config.SiteURL)
+	refurl, rerr := url.Parse(redirectURL)
 
 	// As long as the referrer came from the site, we will redirect back there
 	if berr == nil && rerr == nil && base.Hostname() == refurl.Hostname() {
@@ -153,11 +128,10 @@ func isRedirectURLValid(config *conf.Configuration, redirectURL string) bool {
 	for uri, g := range config.URIAllowListMap {
 		// Only allow wildcard matching if url scheme is http(s)
 		if strings.HasPrefix(uri, "http") || strings.HasPrefix(uri, "https") {
-			if g.Match(matchURL) {
+			if g.Match(redirectURL) {
 				return true
 			}
 		} else if redirectURL == uri {
-			// checking the raw URL as this is no longer a http(s) URL
 			return true
 		}
 	}

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -517,13 +517,6 @@ func (ts *VerifyTestSuite) TestVerifySignupWithredirectURLContainedPath() {
 			requestredirectURL:  "http://example.org/path/",
 			expectedredirectURL: "http://example.org/path/",
 		},
-		{
-			desc:                "uri allow list with deeplink and trailing slash",
-			siteURL:             "http://localhost:3000",
-			uriAllowList:        []string{"io.deeplink.example://path/"},
-			requestredirectURL:  "io.deeplink.example://path/",
-			expectedredirectURL: "io.deeplink.example://path/",
-		},
 	}
 
 	for _, tC := range testCases {

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -489,34 +489,6 @@ func (ts *VerifyTestSuite) TestVerifySignupWithredirectURLContainedPath() {
 			requestredirectURL:  "http://test.dev:3000/bar/foo",
 			expectedredirectURL: "http://localhost:3000",
 		},
-		{
-			desc:                "uri allow list with slash",
-			siteURL:             "http://localhost:3000",
-			uriAllowList:        []string{"http://example.org/"},
-			requestredirectURL:  "http://example.org",
-			expectedredirectURL: "http://example.org",
-		},
-		{
-			desc:                "uri allow list without slash",
-			siteURL:             "http://localhost:3000",
-			uriAllowList:        []string{"http://example.org"},
-			requestredirectURL:  "http://example.org/",
-			expectedredirectURL: "http://example.org/",
-		},
-		{
-			desc:                "uri allow list with path and slash",
-			siteURL:             "http://localhost:3000",
-			uriAllowList:        []string{"http://example.org/path/"},
-			requestredirectURL:  "http://example.org/path",
-			expectedredirectURL: "http://example.org/path",
-		},
-		{
-			desc:                "uri allow list with path and no slash",
-			siteURL:             "http://localhost:3000",
-			uriAllowList:        []string{"http://example.org/path"},
-			requestredirectURL:  "http://example.org/path/",
-			expectedredirectURL: "http://example.org/path/",
-		},
 	}
 
 	for _, tC := range testCases {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -355,13 +355,14 @@ func (config *Configuration) ApplyDefaults() error {
 		config.URIAllowList = []string{}
 	}
 	if config.URIAllowList != nil {
+		for i, item := range config.URIAllowList {
+			// remove trailing slashes from the glob as they may confuse users
+			// when passing redirect_to URLs with or without slashes at the end
+			config.URIAllowList[i] = strings.TrimSuffix(item, "/")
+		}
+
 		config.URIAllowListMap = make(map[string]glob.Glob)
 		for _, uri := range config.URIAllowList {
-			if strings.HasPrefix(uri, "http") || strings.HasPrefix(uri, "https") {
-				// remove trailing slashes from the glob as they may confuse users
-				// when passing redirect_to URLs with or without slashes at the end
-				uri = strings.TrimSuffix(uri, "/")
-			}
 			g := glob.MustCompile(uri, '.', '/')
 			config.URIAllowListMap[uri] = g
 		}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/gobwas/glob"
@@ -272,15 +271,12 @@ func LoadConfig(filename string) (*Configuration, error) {
 	if err := envconfig.Process("gotrue", config); err != nil {
 		return nil, err
 	}
-	if err := config.ApplyDefaults(); err != nil {
-		return nil, err
-	}
-
+	config.ApplyDefaults()
 	return config, nil
 }
 
 // ApplyDefaults sets defaults for a Configuration
-func (config *Configuration) ApplyDefaults() error {
+func (config *Configuration) ApplyDefaults() {
 	if config.JWT.AdminGroupName == "" {
 		config.JWT.AdminGroupName = "admin"
 	}
@@ -355,12 +351,6 @@ func (config *Configuration) ApplyDefaults() error {
 		config.URIAllowList = []string{}
 	}
 	if config.URIAllowList != nil {
-		for i, item := range config.URIAllowList {
-			// remove trailing slashes from the glob as they may confuse users
-			// when passing redirect_to URLs with or without slashes at the end
-			config.URIAllowList[i] = strings.TrimSuffix(item, "/")
-		}
-
 		config.URIAllowListMap = make(map[string]glob.Glob)
 		for _, uri := range config.URIAllowList {
 			g := glob.MustCompile(uri, '.', '/')
@@ -370,8 +360,6 @@ func (config *Configuration) ApplyDefaults() error {
 	if config.PasswordMinLength < defaultMinPasswordLength {
 		config.PasswordMinLength = defaultMinPasswordLength
 	}
-
-	return nil
 }
 
 func (config *Configuration) Value() (driver.Value, error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Previously in #591 and #535 we introduced a change to normalize redirect URLs and match patterns, but that does not apply for the scenario:

`https://example.com/*` won't match `https://example.com/` since the slash is stripped.

If we fix this later, it will be in a new PR.
