### PR TITLE
Remove created_at field

### DIFF
--- a/api/mfa.go
+++ b/api/mfa.go
@@ -40,7 +40,6 @@ type VerifyFactorParams struct {
 
 type ChallengeFactorResponse struct {
 	ID        string `json:"id"`
-	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
 	ExpiresAt string `json:"expires_at"`
 }
@@ -143,7 +142,6 @@ func (a *API) ChallengeFactor(w http.ResponseWriter, r *http.Request) error {
 	expiryTime := creationTime.Add(time.Second * time.Duration(config.MFA.ChallengeExpiryDuration))
 	return sendJSON(w, http.StatusOK, &ChallengeFactorResponse{
 		ID:        challenge.ID,
-		CreatedAt: creationTime.String(),
 		ExpiresAt: expiryTime.String(),
 	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removing the `created_at` field as I'm guessing use mainly cares about when the challenge expires which is given by the `expires_at` field. Can reinstate if user asks, adding via PR so we can track all changes


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
