### PR TITLE
chore: Add deprecation notices for unsupported features

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -77,9 +77,33 @@ func NewAPI(globalConfig *conf.GlobalConfiguration, db *storage.Connection) *API
 	return NewAPIWithVersion(context.Background(), globalConfig, db, defaultVersion)
 }
 
+func (a *API) deprecationNotices(ctx context.Context) {
+	instanceConfig := a.getConfig(ctx)
+
+	log := logrus.WithField("component", "api")
+
+	if a.config.External.Saml.Enabled {
+		log.Warn("DEPRECATION NOTICE: SAML not supported by Supabase's GoTrue, will be removed soon")
+	}
+
+	if instanceConfig.JWT.AdminGroupName != "" {
+		log.Warn("DEPRECATION NOTICE: GOTRUE_JWT_ADMIN_GROUP_NAME not supported by Supabase's GoTrue, will be removed soon")
+	}
+
+	if len(instanceConfig.JWT.AdminRoles) > 0 {
+		log.Warn("DEPRECATION NOTICE: GOTRUE_JWT_ADMIN_ROLES not supported by Supabase's GoTrue, will be removed soon")
+	}
+
+	if instanceConfig.JWT.DefaultGroupName != "" {
+		log.Warn("DEPRECATION NOTICE: GOTRUE_JWT_DEFAULT_GROUP_NAME not supported by Supabase's GoTrue, will be removed soon")
+	}
+}
+
 // NewAPIWithVersion creates a new REST API using the specified version
 func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfiguration, db *storage.Connection, version string) *API {
 	api := &API{config: globalConfig, db: db, version: version}
+
+	api.deprecationNotices(ctx)
 
 	xffmw, _ := xff.Default()
 	logger := logger.NewStructuredLogger(logrus.StandardLogger())

--- a/cmd/multi_cmd.go
+++ b/cmd/multi_cmd.go
@@ -23,9 +23,8 @@ func multi(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logrus.Fatalf("Failed to load configuration: %+v", err)
 	}
-	if globalConfig.OperatorToken == "" {
-		logrus.Fatal("Operator token secret is required")
-	}
+
+	logrus.Warn("DEPRECATION NOTICE: multi-instance mode is not supported by Supabase's GoTrue, will be removed soon")
 
 	var db *storage.Connection
 	// try a couple times to connect to the database

--- a/storage/dial.go
+++ b/storage/dial.go
@@ -28,6 +28,10 @@ func Dial(config *conf.GlobalConfiguration) (*Connection, error) {
 		config.DB.Driver = u.Scheme
 	}
 
+	if config.DB.Driver != "postgres" {
+		logrus.Warn("DEPRECATION NOTICE: only PostgreSQL is supported by Supabase's GoTrue, will be removed soon")
+	}
+
 	db, err := pop.NewConnection(&pop.ConnectionDetails{
 		Dialect: config.DB.Driver,
 		URL:     config.DB.URL,


### PR DESCRIPTION
These features inherited from [Netlify's GoTrue](https://github.com/netlify/gotrue) are not supported by Supabase and are due for removal in the next few minor releases:

- Multi-instance mode
- JWT groups
- SAML external provider