### PR TITLE
feat: Remove system user (deprecated)

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -62,9 +62,6 @@ func getUserFromClaims(ctx context.Context, conn *storage.Connection) (*models.U
 	// System User
 	instanceID := getInstanceID(ctx)
 
-	if claims.Subject == models.SystemUserUUID.String() || claims.Subject == models.SystemUserID {
-		return models.NewSystemUser(instanceID, claims.Audience), nil
-	}
 	userID, err := uuid.FromString(claims.Subject)
 	if err != nil {
 		return nil, errors.New("Invalid user ID")

--- a/models/user.go
+++ b/models/user.go
@@ -13,9 +13,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-const SystemUserID = "0"
-
-var SystemUserUUID = uuid.Nil
 var PasswordHashCost = bcrypt.DefaultCost
 
 // User respresents a registered user with email/password authentication
@@ -93,42 +90,14 @@ func NewUser(instanceID uuid.UUID, phone, email, password, aud string, userData 
 	return user, nil
 }
 
-// NewSystemUser returns a user with the id as SystemUserUUID
-func NewSystemUser(instanceID uuid.UUID, aud string) *User {
-	return &User{
-		InstanceID:   instanceID,
-		ID:           SystemUserUUID,
-		Aud:          aud,
-		IsSuperAdmin: true,
-	}
-}
-
 // TableName overrides the table name used by pop
 func (User) TableName() string {
 	tableName := "users"
 	return tableName
 }
 
-// BeforeCreate is invoked before a create operation is ran
-func (u *User) BeforeCreate(tx *pop.Connection) error {
-	return u.BeforeUpdate(tx)
-}
-
-// BeforeUpdate is invoked before an update operation is ran
-func (u *User) BeforeUpdate(tx *pop.Connection) error {
-	if u.ID == SystemUserUUID {
-		return errors.New("Cannot persist system user")
-	}
-
-	return nil
-}
-
 // BeforeSave is invoked before the user is saved to the database
 func (u *User) BeforeSave(tx *pop.Connection) error {
-	if u.ID == SystemUserUUID {
-		return errors.New("Cannot persist system user")
-	}
-
 	if u.EmailConfirmedAt != nil && u.EmailConfirmedAt.IsZero() {
 		u.EmailConfirmedAt = nil
 	}


### PR DESCRIPTION
Supabase does not use the "system user" concept, thus it is not supported and removed from the codebase.