### PR TITLE
fix: mirror gotrue image to public ECR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Publish to Image Registry
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Image tag"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            supabase/gotrue
+            public.ecr.aws/t3w2s2c9/gotrue
+            436098097459.dkr.ecr.us-east-1.amazonaws.com/gotrue
+            646182064048.dkr.ecr.us-east-1.amazonaws.com/gotrue
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ inputs.version }},enable=${{ github.event_name != 'push' }}
+
+      - uses: docker/setup-qemu-action@v2
+        with:
+          platforms: amd64,arm64
+      - uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to ECR
+        uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.PROD_ACCESS_KEY_ID }}
+          password: ${{ secrets.PROD_SECRET_ACCESS_KEY }}
+
+      - name: Login to ECR account - staging
+        uses: docker/login-action@v2
+        with:
+          registry: 436098097459.dkr.ecr.us-east-1.amazonaws.com
+          username: ${{ secrets.DEV_ACCESS_KEY_ID }}
+          password: ${{ secrets.DEV_SECRET_ACCESS_KEY }}
+
+      - name: Login to ECR account - prod
+        uses: docker/login-action@v2
+        with:
+          registry: 646182064048.dkr.ecr.us-east-1.amazonaws.com
+          username: ${{ secrets.PROD_ACCESS_KEY_ID }}
+          password: ${{ secrets.PROD_SECRET_ACCESS_KEY }}
+
+      - uses: docker/build-push-action@v3
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
 
     outputs:
       status: ${{ steps.pre-release.outputs.release != steps.post-release.outputs.release }}
+      version: ${{ steps.post-release.outputs.release }}
 
     runs-on: ubuntu-18.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -62,67 +63,23 @@ jobs:
           go-version: "^1.17.0" # The Go version to download (if necessary) and use.
 
       - run: make deps
-
       - run: make all
-
-      - id: releases
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          owner: supabase
-          repo: gotrue
-          excludes: prerelease, draft
-
-      - run: tar -czvf gotrue-${{ steps.releases.outputs.release }}-x86.tar.gz gotrue migrations/
+      - run: tar -czvf gotrue-${{ needs.release.outputs.version }}-x86.tar.gz gotrue migrations/
       - run: mv gotrue-arm64 gotrue
-      - run: tar -czvf gotrue-${{ steps.releases.outputs.release }}-arm64.tar.gz gotrue migrations/
+      - run: tar -czvf gotrue-${{ needs.release.outputs.version }}-arm64.tar.gz gotrue migrations/
 
       - uses: AButler/upload-release-assets@v2.0
         with:
-          files: "gotrue-${{ steps.releases.outputs.release }}*.tar.gz"
-          release-tag: ${{ steps.releases.outputs.release }}
+          files: "gotrue-${{ needs.release.outputs.version }}*.tar.gz"
+          release-tag: ${{ needs.release.outputs.version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to ECR account - staging
-        uses: docker/login-action@v1
-        with:
-          registry: 436098097459.dkr.ecr.us-east-1.amazonaws.com
-          username: ${{ secrets.DEV_ACCESS_KEY_ID }}
-          password: ${{ secrets.DEV_SECRET_ACCESS_KEY }}
-
-      - name: Login to ECR account - prod
-        uses: docker/login-action@v1
-        with:
-          registry: 646182064048.dkr.ecr.us-east-1.amazonaws.com
-          username: ${{ secrets.PROD_ACCESS_KEY_ID }}
-          password: ${{ secrets.PROD_SECRET_ACCESS_KEY }}
-
-      - name: Upload image to ECR
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: |
-            436098097459.dkr.ecr.us-east-1.amazonaws.com/gotrue:${{ steps.releases.outputs.release }}
-            646182064048.dkr.ecr.us-east-1.amazonaws.com/gotrue:${{ steps.releases.outputs.release }}
-
-      - uses: docker/setup-qemu-action@v1
-        with:
-          platforms: amd64,arm64
-
-      - uses: docker/setup-buildx-action@v1
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Upload image to Docker Hub
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            supabase/gotrue:latest
-            supabase/gotrue:${{ steps.releases.outputs.release }}
+  publish:
+    needs:
+      - release
+    if: success() && needs.release.outputs.status == 'true'
+    # Call publish explicitly because events from actions cannot trigger more actions
+    uses: ./.github/workflows/publish.yml
+    with:
+      version: v${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci/cd workflow
patch release to trigger new workflow

## What is the current behavior?

some duplication in release job

## What is the new behavior?

- publish docker image in separate workflow
- runs deploy and publish in parallel
- mirrors to public ecr

## Additional context

Add any other context or screenshots.
