### PR TITLE
feat: Remove remnants of `getInstanceID(ctx)`

### DIFF
--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
@@ -47,7 +46,7 @@ func (ts *AdminTestSuite) SetupTest() {
 }
 
 func (ts *AdminTestSuite) makeSuperAdmin(email string) string {
-	u, err := models.NewUser(uuid.Nil, "9123456", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
+	u, err := models.NewUser("9123456", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
 	require.NoError(ts.T(), err, "Error making new user")
 
 	u.Role = "supabase_admin"
@@ -90,11 +89,11 @@ func (ts *AdminTestSuite) TestAdminUsers() {
 
 // TestAdminUsers tests API /admin/users route
 func (ts *AdminTestSuite) TestAdminUsers_Pagination() {
-	u, err := models.NewUser(uuid.Nil, "12345678", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("12345678", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
-	u, err = models.NewUser(uuid.Nil, "987654321", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err = models.NewUser("987654321", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
@@ -119,12 +118,12 @@ func (ts *AdminTestSuite) TestAdminUsers_Pagination() {
 
 // TestAdminUsers tests API /admin/users route
 func (ts *AdminTestSuite) TestAdminUsers_SortAsc() {
-	u, err := models.NewUser(uuid.Nil, "", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	u.CreatedAt = time.Now().Add(-time.Minute)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
-	u, err = models.NewUser(uuid.Nil, "", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err = models.NewUser("", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
 	u.CreatedAt = time.Now()
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
@@ -154,12 +153,12 @@ func (ts *AdminTestSuite) TestAdminUsers_SortAsc() {
 
 // TestAdminUsers tests API /admin/users route
 func (ts *AdminTestSuite) TestAdminUsers_SortDesc() {
-	u, err := models.NewUser(uuid.Nil, "12345678", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("12345678", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	u.CreatedAt = time.Now().Add(-time.Minute)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
-	u, err = models.NewUser(uuid.Nil, "987654321", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err = models.NewUser("987654321", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
 	u.CreatedAt = time.Now()
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
@@ -186,7 +185,7 @@ func (ts *AdminTestSuite) TestAdminUsers_SortDesc() {
 
 // TestAdminUsers tests API /admin/users route
 func (ts *AdminTestSuite) TestAdminUsers_FilterEmail() {
-	u, err := models.NewUser(uuid.Nil, "", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
@@ -211,11 +210,11 @@ func (ts *AdminTestSuite) TestAdminUsers_FilterEmail() {
 
 // TestAdminUsers tests API /admin/users route
 func (ts *AdminTestSuite) TestAdminUsers_FilterName() {
-	u, err := models.NewUser(uuid.Nil, "", "test1@example.com", "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
+	u, err := models.NewUser("", "test1@example.com", "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
-	u, err = models.NewUser(uuid.Nil, "", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err = models.NewUser("", "test2@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
@@ -321,7 +320,7 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 			assert.Equal(ts.T(), "email", data.AppMetaData["provider"])
 			assert.Equal(ts.T(), []interface{}{"email"}, data.AppMetaData["providers"])
 
-			u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, data.GetEmail(), ts.Config.JWT.Aud)
+			u, err := models.FindUserByEmailAndAudience(ts.API.db, data.GetEmail(), ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 
 			var expectedPassword string
@@ -336,7 +335,7 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 
 // TestAdminUserGet tests API /admin/user route (GET)
 func (ts *AdminTestSuite) TestAdminUserGet() {
-	u, err := models.NewUser(uuid.Nil, "12345678", "test1@example.com", "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test Get User"})
+	u, err := models.NewUser("12345678", "test1@example.com", "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test Get User"})
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
@@ -362,7 +361,7 @@ func (ts *AdminTestSuite) TestAdminUserGet() {
 
 // TestAdminUserUpdate tests API /admin/user route (UPDATE)
 func (ts *AdminTestSuite) TestAdminUserUpdate() {
-	u, err := models.NewUser(uuid.Nil, "12345678", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("12345678", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
@@ -402,7 +401,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdate() {
 }
 
 func (ts *AdminTestSuite) TestAdminUserUpdatePasswordFailed() {
-	u, err := models.NewUser(uuid.Nil, "12345678", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("12345678", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
@@ -425,7 +424,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdatePasswordFailed() {
 }
 
 func (ts *AdminTestSuite) TestAdminUserUpdateBannedUntilFailed() {
-	u, err := models.NewUser(uuid.Nil, "", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("", "test1@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 
@@ -449,7 +448,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdateBannedUntilFailed() {
 
 // TestAdminUserDelete tests API /admin/user route (DELETE)
 func (ts *AdminTestSuite) TestAdminUserDelete() {
-	u, err := models.NewUser(uuid.Nil, "123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 

--- a/api/audit.go
+++ b/api/audit.go
@@ -14,8 +14,6 @@ var filterColumnMap = map[string][]string{
 }
 
 func (a *API) adminAuditLog(w http.ResponseWriter, r *http.Request) error {
-	ctx := r.Context()
-	instanceID := getInstanceID(ctx)
 	// aud := a.requestAud(ctx, r)
 	pageParams, err := paginate(r)
 	if err != nil {
@@ -35,7 +33,7 @@ func (a *API) adminAuditLog(w http.ResponseWriter, r *http.Request) error {
 		qval = qparts[1]
 	}
 
-	logs, err := models.FindAuditLogEntries(a.db, instanceID, col, qval, pageParams)
+	logs, err := models.FindAuditLogEntries(a.db, col, qval, pageParams)
 	if err != nil {
 		return internalServerError("Error searching for audit logs").WithInternalError(err)
 	}

--- a/api/audit_test.go
+++ b/api/audit_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
@@ -44,7 +43,7 @@ func (ts *AuditTestSuite) SetupTest() {
 }
 
 func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
-	u, err := models.NewUser(uuid.Nil, "", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
+	u, err := models.NewUser("", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
 	require.NoError(ts.T(), err, "Error making new user")
 
 	u.Role = "supabase_admin"
@@ -119,7 +118,7 @@ func (ts *AuditTestSuite) TestAuditFilters() {
 
 func (ts *AuditTestSuite) prepareDeleteEvent() {
 	// DELETE USER
-	u, err := models.NewUser(uuid.Nil, "12345678", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("12345678", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
 

--- a/api/context.go
+++ b/api/context.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 
-	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/models"
 )
@@ -64,12 +63,6 @@ func getRequestID(ctx context.Context) string {
 	}
 
 	return obj.(string)
-}
-
-// getInstanceID reads the instance id from the context.
-func getInstanceID(ctx context.Context) uuid.UUID {
-	// TODO: remove this method, it's deprecated
-	return uuid.Nil
 }
 
 // withUser adds the user id to the context.

--- a/api/external_github_test.go
+++ b/api/external_github_test.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
@@ -216,7 +215,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGitHubErrorWhenUserBanned() {
 	u := performAuthorization(ts, "github", code, "")
 	assertAuthorizationSuccess(ts, u, tokenCount, userCount, "github@example.com", "GitHub Test", "123", "http://example.com/avatar")
 
-	user, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "github@example.com", ts.Config.JWT.Aud)
+	user, err := models.FindUserByEmailAndAudience(ts.API.db, "github@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	t := time.Now().Add(24 * time.Hour)
 	user.BannedUntil = &t

--- a/api/external_test.go
+++ b/api/external_test.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
@@ -41,12 +40,12 @@ func (ts *ExternalTestSuite) SetupTest() {
 
 func (ts *ExternalTestSuite) createUser(providerId string, email string, name string, avatar string, confirmationToken string) (*models.User, error) {
 	// Cleanup existing user, if they already exist
-	if u, _ := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, email, ts.Config.JWT.Aud); u != nil {
+	if u, _ := models.FindUserByEmailAndAudience(ts.API.db, email, ts.Config.JWT.Aud); u != nil {
 		require.NoError(ts.T(), ts.API.db.Destroy(u), "Error deleting user")
 	}
 
 	// TODO: [Joel] -- refactor to take in phone
-	u, err := models.NewUser(uuid.Nil, "", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"provider_id": providerId, "full_name": name, "avatar_url": avatar})
+	u, err := models.NewUser("", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"provider_id": providerId, "full_name": name, "avatar_url": avatar})
 
 	if confirmationToken != "" {
 		u.ConfirmationToken = confirmationToken
@@ -115,7 +114,7 @@ func assertAuthorizationSuccess(ts *ExternalTestSuite, u *url.URL, tokenCount in
 	ts.Equal(1, userCount)
 
 	// ensure user has been created with metadata
-	user, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, email, ts.Config.JWT.Aud)
+	user, err := models.FindUserByEmailAndAudience(ts.API.db, email, ts.Config.JWT.Aud)
 	ts.Require().NoError(err)
 	ts.Equal(providerId, user.UserMetaData["provider_id"])
 	ts.Equal(name, user.UserMetaData["full_name"])
@@ -141,7 +140,7 @@ func assertAuthorizationFailure(ts *ExternalTestSuite, u *url.URL, errorDescript
 	ts.Empty(v.Get("token_type"))
 
 	// ensure user is nil
-	user, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, email, ts.Config.JWT.Aud)
+	user, err := models.FindUserByEmailAndAudience(ts.API.db, email, ts.Config.JWT.Aud)
 	ts.Require().Error(err, "User not found")
 	ts.Require().Nil(user)
 }

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -59,14 +59,11 @@ func getUserFromClaims(ctx context.Context, conn *storage.Connection) (*models.U
 		return nil, errors.New("Invalid claim: id")
 	}
 
-	// System User
-	instanceID := getInstanceID(ctx)
-
 	userID, err := uuid.FromString(claims.Subject)
 	if err != nil {
 		return nil, errors.New("Invalid user ID")
 	}
-	return models.FindUserByInstanceIDAndID(conn, instanceID, userID)
+	return models.FindUserByID(conn, userID)
 }
 
 func (a *API) isAdmin(ctx context.Context, u *models.User, aud string) bool {

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage/test"
@@ -25,8 +24,7 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 	conn, err := test.SetupDBConnection(globalConfig)
 	require.NoError(t, err)
 
-	iid := uuid.Must(uuid.NewV4())
-	user, err := models.NewUser(iid, "81234567", "test@truth.com", "thisisapassword", "", nil)
+	user, err := models.NewUser("81234567", "test@truth.com", "thisisapassword", "", nil)
 	require.NoError(t, err)
 
 	var callCount int
@@ -40,7 +38,6 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 		require.NoError(t, json.Unmarshal(raw, &data))
 
 		assert.Len(t, data, 3)
-		assert.Equal(t, iid.String(), data["instance_id"])
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer svr.Close()
@@ -56,7 +53,7 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, triggerEventHooks(context.Background(), conn, SignupEvent, user, iid, config))
+	require.NoError(t, triggerEventHooks(context.Background(), conn, SignupEvent, user, config))
 
 	assert.Equal(t, 1, callCount)
 }
@@ -68,8 +65,7 @@ func TestSignupHookFromClaims(t *testing.T) {
 	conn, err := test.SetupDBConnection(globalConfig)
 	require.NoError(t, err)
 
-	iid := uuid.Must(uuid.NewV4())
-	user, err := models.NewUser(iid, "", "test@truth.com", "thisisapassword", "", nil)
+	user, err := models.NewUser("", "test@truth.com", "thisisapassword", "", nil)
 	require.NoError(t, err)
 
 	var callCount int
@@ -83,7 +79,6 @@ func TestSignupHookFromClaims(t *testing.T) {
 		require.NoError(t, json.Unmarshal(raw, &data))
 
 		assert.Len(t, data, 3)
-		assert.Equal(t, iid.String(), data["instance_id"])
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer svr.Close()
@@ -103,7 +98,7 @@ func TestSignupHookFromClaims(t *testing.T) {
 		"signup": {svr.URL},
 	})
 
-	require.NoError(t, triggerEventHooks(ctx, conn, SignupEvent, user, iid, config))
+	require.NoError(t, triggerEventHooks(ctx, conn, SignupEvent, user, config))
 
 	assert.Equal(t, 1, callCount)
 }

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -45,11 +45,10 @@ type webhookClaims struct {
 type Webhook struct {
 	*conf.WebhookConfig
 
-	instanceID uuid.UUID
-	jwtSecret  string
-	claims     jwt.Claims
-	payload    []byte
-	headers    map[string]string
+	jwtSecret string
+	claims    jwt.Claims
+	payload   []byte
+	headers   map[string]string
 }
 
 type WebhookResponse struct {
@@ -71,7 +70,7 @@ func (w *Webhook) trigger() (io.ReadCloser, error) {
 		"component":   "webhook",
 		"url":         w.URL,
 		"signed":      w.jwtSecret != "",
-		"instance_id": w.instanceID,
+		"instance_id": uuid.Nil.String(),
 	})
 	client := http.Client{
 		Timeout: timeout,
@@ -153,7 +152,7 @@ func closeBody(rsp *http.Response) {
 	}
 }
 
-func triggerEventHooks(ctx context.Context, conn *storage.Connection, event HookEvent, user *models.User, instanceID uuid.UUID, config *conf.GlobalConfiguration) error {
+func triggerEventHooks(ctx context.Context, conn *storage.Connection, event HookEvent, user *models.User, config *conf.GlobalConfiguration) error {
 	if config.Webhook.URL != "" {
 		hookURL, err := url.Parse(config.Webhook.URL)
 		if err != nil {
@@ -162,7 +161,7 @@ func triggerEventHooks(ctx context.Context, conn *storage.Connection, event Hook
 		if !config.Webhook.HasEvent(string(event)) {
 			return nil
 		}
-		return triggerHook(ctx, hookURL, config.Webhook.Secret, conn, event, user, instanceID, config)
+		return triggerHook(ctx, hookURL, config.Webhook.Secret, conn, event, user, config)
 	}
 
 	fun := getFunctionHooks(ctx)
@@ -175,7 +174,7 @@ func triggerEventHooks(ctx context.Context, conn *storage.Connection, event Hook
 		if err != nil {
 			return errors.Wrapf(err, "Failed to parse Event Function Hook URL")
 		}
-		err = triggerHook(ctx, hookURL, config.JWT.Secret, conn, event, user, instanceID, config)
+		err = triggerHook(ctx, hookURL, config.JWT.Secret, conn, event, user, config)
 		if err != nil {
 			return err
 		}
@@ -183,7 +182,7 @@ func triggerEventHooks(ctx context.Context, conn *storage.Connection, event Hook
 	return nil
 }
 
-func triggerHook(ctx context.Context, hookURL *url.URL, secret string, conn *storage.Connection, event HookEvent, user *models.User, instanceID uuid.UUID, config *conf.GlobalConfiguration) error {
+func triggerHook(ctx context.Context, hookURL *url.URL, secret string, conn *storage.Connection, event HookEvent, user *models.User, config *conf.GlobalConfiguration) error {
 	if !hookURL.IsAbs() {
 		siteURL, err := url.Parse(config.SiteURL)
 		if err != nil {
@@ -200,7 +199,7 @@ func triggerHook(ctx context.Context, hookURL *url.URL, secret string, conn *sto
 		User       *models.User `json:"user"`
 	}{
 		Event:      event,
-		InstanceID: instanceID,
+		InstanceID: uuid.Nil,
 		User:       user,
 	}
 	data, err := json.Marshal(&payload)
@@ -216,7 +215,7 @@ func triggerHook(ctx context.Context, hookURL *url.URL, secret string, conn *sto
 	claims := webhookClaims{
 		StandardClaims: jwt.StandardClaims{
 			IssuedAt: time.Now().Unix(),
-			Subject:  instanceID.String(),
+			Subject:  uuid.Nil.String(),
 			Issuer:   gotrueIssuer,
 		},
 		SHA256: sha,
@@ -225,7 +224,6 @@ func triggerHook(ctx context.Context, hookURL *url.URL, secret string, conn *sto
 	w := Webhook{
 		WebhookConfig: &config.Webhook,
 		jwtSecret:     secret,
-		instanceID:    instanceID,
 		claims:        claims,
 		payload:       data,
 	}

--- a/api/invite.go
+++ b/api/invite.go
@@ -18,7 +18,6 @@ type InviteParams struct {
 func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.config
-	instanceID := getInstanceID(ctx)
 	adminUser := getAdminUser(ctx)
 	params := &InviteParams{}
 
@@ -33,7 +32,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	aud := a.requestAud(ctx, r)
-	user, err := models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
+	user, err := models.FindUserByEmailAndAudience(a.db, params.Email, aud)
 	if err != nil && !models.IsNotFoundError(err) {
 		return internalServerError("Database error finding user").WithInternalError(err)
 	}
@@ -56,7 +55,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		if terr := models.NewAuditLogEntry(r, tx, instanceID, adminUser, models.UserInvitedAction, "", map[string]interface{}{
+		if terr := models.NewAuditLogEntry(r, tx, adminUser, models.UserInvitedAction, "", map[string]interface{}{
 			"user_id":    user.ID,
 			"user_email": user.Email,
 		}); terr != nil {

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
@@ -50,11 +49,11 @@ func (ts *InviteTestSuite) SetupTest() {
 
 func (ts *InviteTestSuite) makeSuperAdmin(email string) string {
 	// Cleanup existing user, if they already exist
-	if u, _ := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, email, ts.Config.JWT.Aud); u != nil {
+	if u, _ := models.FindUserByEmailAndAudience(ts.API.db, email, ts.Config.JWT.Aud); u != nil {
 		require.NoError(ts.T(), ts.API.db.Destroy(u), "Error deleting user")
 	}
 
-	u, err := models.NewUser(uuid.Nil, "123456789", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
+	u, err := models.NewUser("123456789", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
 	require.NoError(ts.T(), err, "Error making new user")
 
 	u.Role = "supabase_admin"
@@ -146,7 +145,7 @@ func (ts *InviteTestSuite) TestVerifyInvite() {
 
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
-			user, err := models.NewUser(uuid.Nil, "", c.email, "", ts.Config.JWT.Aud, nil)
+			user, err := models.NewUser("", c.email, "", ts.Config.JWT.Aud, nil)
 			now := time.Now()
 			user.InvitedAt = &now
 			user.ConfirmationSentAt = &now
@@ -156,7 +155,7 @@ func (ts *InviteTestSuite) TestVerifyInvite() {
 			require.NoError(ts.T(), ts.API.db.Create(user))
 
 			// Find test user
-			_, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, c.email, ts.Config.JWT.Aud)
+			_, err = models.FindUserByEmailAndAudience(ts.API.db, c.email, ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 
 			// Request body
@@ -219,7 +218,7 @@ func (ts *InviteTestSuite) TestInviteExternalGitlab() {
 	ts.Require().Equal(http.StatusOK, w.Code)
 
 	// Find test user
-	user, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "gitlab@example.com", ts.Config.JWT.Aud)
+	user, err := models.FindUserByEmailAndAudience(ts.API.db, "gitlab@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
 	// get redirect url w/ state
@@ -261,7 +260,7 @@ func (ts *InviteTestSuite) TestInviteExternalGitlab() {
 	ts.Equal(1, userCount)
 
 	// ensure user has been created with metadata
-	user, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "gitlab@example.com", ts.Config.JWT.Aud)
+	user, err = models.FindUserByEmailAndAudience(ts.API.db, "gitlab@example.com", ts.Config.JWT.Aud)
 	ts.Require().NoError(err)
 	ts.Equal("Gitlab Test", user.UserMetaData["full_name"])
 	ts.Equal("http://example.com/avatar", user.UserMetaData["avatar_url"])
@@ -311,7 +310,7 @@ func (ts *InviteTestSuite) TestInviteExternalGitlab_MismatchedEmails() {
 	ts.Require().Equal(http.StatusOK, w.Code)
 
 	// Find test user
-	user, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "gitlab@example.com", ts.Config.JWT.Aud)
+	user, err := models.FindUserByEmailAndAudience(ts.API.db, "gitlab@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
 	// get redirect url w/ state

--- a/api/logout.go
+++ b/api/logout.go
@@ -10,7 +10,6 @@ import (
 // Logout is the endpoint for logging out a user and thereby revoking any refresh tokens
 func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	instanceID := getInstanceID(ctx)
 	config := a.config
 
 	a.clearCookieTokens(config, w)
@@ -21,10 +20,10 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(r, tx, instanceID, u, models.LogoutAction, "", nil); terr != nil {
+		if terr := models.NewAuditLogEntry(r, tx, u, models.LogoutAction, "", nil); terr != nil {
 			return terr
 		}
-		return models.Logout(tx, instanceID, u.ID)
+		return models.Logout(tx, u.ID)
 	})
 	if err != nil {
 		return internalServerError("Error logging out user").WithInternalError(err)

--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -28,7 +28,6 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Email logins are disabled")
 	}
 
-	instanceID := getInstanceID(ctx)
 	params := &MagicLinkParams{}
 	jsonDecoder := json.NewDecoder(r.Body)
 	err := jsonDecoder.Decode(params)
@@ -48,7 +47,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	aud := a.requestAud(ctx, r)
-	user, err := models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
+	user, err := models.FindUserByEmailAndAudience(a.db, params.Email, aud)
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			// User doesn't exist, sign them up with temporary password
@@ -97,7 +96,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(r, tx, instanceID, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
+		if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 			return terr
 		}
 

--- a/api/phone_test.go
+++ b/api/phone_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
@@ -51,7 +50,7 @@ func (ts *PhoneTestSuite) SetupTest() {
 	models.TruncateAll(ts.API.db)
 
 	// Create user
-	u, err := models.NewUser(uuid.Nil, "123456789", "", "password", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("123456789", "", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 }
@@ -67,7 +66,7 @@ func (ts *PhoneTestSuite) TestFormatPhoneNumber() {
 }
 
 func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
-	u, err := models.FindUserByPhoneAndAudience(ts.API.db, uuid.Nil, "123456789", ts.Config.JWT.Aud)
+	u, err := models.FindUserByPhoneAndAudience(ts.API.db, "123456789", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	ctx := context.Background()
 	cases := []struct {
@@ -101,7 +100,7 @@ func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
 		ts.Run(c.desc, func() {
 			err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, &TestSmsProvider{})
 			require.Equal(ts.T(), c.expected, err)
-			u, err = models.FindUserByPhoneAndAudience(ts.API.db, uuid.Nil, "123456789", ts.Config.JWT.Aud)
+			u, err = models.FindUserByPhoneAndAudience(ts.API.db, "123456789", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 
 			switch c.otpType {
@@ -121,7 +120,7 @@ func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
 }
 
 func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
-	u, err := models.FindUserByPhoneAndAudience(ts.API.db, uuid.Nil, "123456789", ts.Config.JWT.Aud)
+	u, err := models.FindUserByPhoneAndAudience(ts.API.db, "123456789", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	now := time.Now()
 	u.PhoneConfirmedAt = &now

--- a/api/reauthenticate.go
+++ b/api/reauthenticate.go
@@ -19,7 +19,6 @@ const InvalidNonceMessage = "Nonce has expired or is invalid"
 func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.config
-	instanceID := getInstanceID(ctx)
 
 	claims := getClaims(ctx)
 	userID, err := uuid.FromString(claims.Subject)
@@ -51,7 +50,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(r, tx, instanceID, user, models.UserReauthenticateAction, "", nil); terr != nil {
+		if terr := models.NewAuditLogEntry(r, tx, user, models.UserReauthenticateAction, "", nil); terr != nil {
 			return terr
 		}
 		if email != "" {

--- a/api/recover.go
+++ b/api/recover.go
@@ -18,7 +18,6 @@ type RecoverParams struct {
 func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.config
-	instanceID := getInstanceID(ctx)
 	params := &RecoverParams{}
 	jsonDecoder := json.NewDecoder(r.Body)
 	err := jsonDecoder.Decode(params)
@@ -36,7 +35,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	if err := a.validateEmail(ctx, params.Email); err != nil {
 		return err
 	}
-	user, err = models.FindUserByEmailAndAudience(a.db, instanceID, params.Email, aud)
+	user, err = models.FindUserByEmailAndAudience(a.db, params.Email, aud)
 
 	if err != nil {
 		if models.IsNotFoundError(err) {
@@ -46,7 +45,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
-		if terr := models.NewAuditLogEntry(r, tx, instanceID, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
+		if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 			return terr
 		}
 		mailer := a.Mailer(ctx)

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -107,7 +107,6 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 
 		assert.Equal(3, len(data))
 		assert.Equal("validate", data["event"])
-		assert.Equal(uuid.Nil.String(), data["instance_id"])
 
 		u, ok := data["user"].(map[string]interface{})
 		require.True(ok)
@@ -210,7 +209,7 @@ func (ts *SignupTestSuite) TestSignupTwice() {
 	y := httptest.NewRecorder()
 
 	ts.API.handler.ServeHTTP(y, req)
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test1@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test1@example.com", ts.Config.JWT.Aud)
 	if err == nil {
 		require.NoError(ts.T(), u.Confirm(ts.API.db))
 	}
@@ -232,7 +231,7 @@ func (ts *SignupTestSuite) TestSignupTwice() {
 }
 
 func (ts *SignupTestSuite) TestVerifySignup() {
-	user, err := models.NewUser(uuid.Nil, "123456789", "test@example.com", "testing", ts.Config.JWT.Aud, nil)
+	user, err := models.NewUser("123456789", "test@example.com", "testing", ts.Config.JWT.Aud, nil)
 	user.ConfirmationToken = "asdf3"
 	now := time.Now()
 	user.ConfirmationSentAt = &now
@@ -240,7 +239,7 @@ func (ts *SignupTestSuite) TestVerifySignup() {
 	require.NoError(ts.T(), ts.API.db.Create(user))
 
 	// Find test user
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
 	// Setup request

--- a/api/token_test.go
+++ b/api/token_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,7 @@ func (ts *TokenTestSuite) SetupTest() {
 	models.TruncateAll(ts.API.db)
 
 	// Create user & refresh token
-	u, err := models.NewUser(uuid.Nil, "12345678", "test@example.com", "password", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("12345678", "test@example.com", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	t := time.Now()
 	u.EmailConfirmedAt = &t
@@ -149,7 +148,7 @@ func (ts *TokenTestSuite) TestTokenRefreshTokenGrantFailure() {
 }
 
 func (ts *TokenTestSuite) TestTokenRefreshTokenRotation() {
-	u, err := models.NewUser(uuid.Nil, "", "foo@example.com", "password", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("", "foo@example.com", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	t := time.Now()
 	u.EmailConfirmedAt = &t
@@ -238,7 +237,7 @@ func (ts *TokenTestSuite) TestTokenRefreshTokenRotation() {
 }
 
 func (ts *TokenTestSuite) createBannedUser() *models.User {
-	u, err := models.NewUser(uuid.Nil, "", "banned@example.com", "password", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("", "banned@example.com", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	t := time.Now()
 	u.EmailConfirmedAt = &t

--- a/api/user.go
+++ b/api/user.go
@@ -54,7 +54,6 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.config
-	instanceID := getInstanceID(ctx)
 
 	params := &UserUpdateParams{}
 	jsonDecoder := json.NewDecoder(r.Body)
@@ -125,7 +124,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 
 			var exists bool
-			if exists, terr = models.IsDuplicatedEmail(tx, instanceID, params.Email, user.Aud); terr != nil {
+			if exists, terr = models.IsDuplicatedEmail(tx, params.Email, user.Aud); terr != nil {
 				return internalServerError("Database error checking email").WithInternalError(terr)
 			} else if exists {
 				return unprocessableEntityError(DuplicateEmailMsg)
@@ -144,7 +143,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				return err
 			}
 			var exists bool
-			if exists, terr = models.IsDuplicatedPhone(tx, instanceID, params.Phone, user.Aud); terr != nil {
+			if exists, terr = models.IsDuplicatedPhone(tx, params.Phone, user.Aud); terr != nil {
 				return internalServerError("Database error checking phone").WithInternalError(terr)
 			} else if exists {
 				return unprocessableEntityError(DuplicatePhoneMsg)
@@ -162,7 +161,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		if terr = models.NewAuditLogEntry(r, tx, instanceID, user, models.UserModifiedAction, "", nil); terr != nil {
+		if terr = models.NewAuditLogEntry(r, tx, user, models.UserModifiedAction, "", nil); terr != nil {
 			return internalServerError("Error recording audit log entry").WithInternalError(terr)
 		}
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
@@ -40,13 +39,13 @@ func (ts *UserTestSuite) SetupTest() {
 	models.TruncateAll(ts.API.db)
 
 	// Create user
-	u, err := models.NewUser(uuid.Nil, "123456789", "test@example.com", "password", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("123456789", "test@example.com", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 }
 
 func (ts *UserTestSuite) TestUserGet() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err, "Error finding user")
 	token, err := generateAccessToken(u, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 	require.NoError(ts.T(), err, "Error generating access token")
@@ -106,7 +105,7 @@ func (ts *UserTestSuite) TestUserUpdateEmail() {
 
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
-			u, err := models.NewUser(uuid.Nil, "", "", "", ts.Config.JWT.Aud, nil)
+			u, err := models.NewUser("", "", "", ts.Config.JWT.Aud, nil)
 			require.NoError(ts.T(), err, "Error creating test user model")
 			require.NoError(ts.T(), u.SetEmail(ts.API.db, c.userData["email"]), "Error setting user email")
 			require.NoError(ts.T(), u.SetPhone(ts.API.db, c.userData["phone"]), "Error setting user phone")
@@ -132,10 +131,10 @@ func (ts *UserTestSuite) TestUserUpdateEmail() {
 
 }
 func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
-	existingUser, err := models.NewUser(uuid.Nil, "22222222", "", "", ts.Config.JWT.Aud, nil)
+	existingUser, err := models.NewUser("22222222", "", "", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), ts.API.db.Create(existingUser))
 
@@ -191,7 +190,7 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 }
 
 func (ts *UserTestSuite) TestUserUpdatePassword() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
 	type expected struct {
@@ -255,7 +254,7 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 			require.Equal(ts.T(), c.expected.code, w.Code)
 
 			// Request body
-			u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+			u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 
 			require.Equal(ts.T(), c.expected.isAuthenticated, u.Authenticate(c.newPassword))
@@ -267,7 +266,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	ts.Config.Security.UpdatePasswordRequireReauthentication = true
 
 	// create a confirmed user
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	now := time.Now()
 	u.EmailConfirmedAt = &now
@@ -284,7 +283,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	ts.API.handler.ServeHTTP(w, req)
 	require.Equal(ts.T(), w.Code, http.StatusOK)
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	require.NotEmpty(ts.T(), u.ReauthenticationToken)
 	require.NotEmpty(ts.T(), u.ReauthenticationSentAt)
@@ -310,7 +309,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	require.Equal(ts.T(), w.Code, http.StatusOK)
 
 	// Request body
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
 	require.True(ts.T(), u.Authenticate("newpass"))

--- a/api/verify.go
+++ b/api/verify.go
@@ -231,7 +231,6 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
 }
 
 func (a *API) signupVerify(r *http.Request, ctx context.Context, conn *storage.Connection, user *models.User) (*models.User, error) {
-	instanceID := getInstanceID(ctx)
 	config := a.config
 
 	err := conn.Transaction(func(tx *storage.Connection) error {
@@ -250,11 +249,11 @@ func (a *API) signupVerify(r *http.Request, ctx context.Context, conn *storage.C
 			}
 		}
 
-		if terr = models.NewAuditLogEntry(r, tx, instanceID, user, models.UserSignedUpAction, "", nil); terr != nil {
+		if terr = models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", nil); terr != nil {
 			return terr
 		}
 
-		if terr = triggerEventHooks(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
+		if terr = triggerEventHooks(ctx, tx, SignupEvent, user, config); terr != nil {
 			return terr
 		}
 
@@ -270,7 +269,6 @@ func (a *API) signupVerify(r *http.Request, ctx context.Context, conn *storage.C
 }
 
 func (a *API) recoverVerify(r *http.Request, ctx context.Context, conn *storage.Connection, user *models.User) (*models.User, error) {
-	instanceID := getInstanceID(ctx)
 	config := a.config
 
 	err := conn.Transaction(func(tx *storage.Connection) error {
@@ -279,21 +277,21 @@ func (a *API) recoverVerify(r *http.Request, ctx context.Context, conn *storage.
 			return terr
 		}
 		if !user.IsConfirmed() {
-			if terr = models.NewAuditLogEntry(r, tx, instanceID, user, models.UserSignedUpAction, "", nil); terr != nil {
+			if terr = models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", nil); terr != nil {
 				return terr
 			}
 
-			if terr = triggerEventHooks(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
+			if terr = triggerEventHooks(ctx, tx, SignupEvent, user, config); terr != nil {
 				return terr
 			}
 			if terr = user.Confirm(tx); terr != nil {
 				return terr
 			}
 		} else {
-			if terr = models.NewAuditLogEntry(r, tx, instanceID, user, models.LoginAction, "", nil); terr != nil {
+			if terr = models.NewAuditLogEntry(r, tx, user, models.LoginAction, "", nil); terr != nil {
 				return terr
 			}
-			if terr = triggerEventHooks(ctx, tx, LoginEvent, user, instanceID, config); terr != nil {
+			if terr = triggerEventHooks(ctx, tx, LoginEvent, user, config); terr != nil {
 				return terr
 			}
 		}
@@ -307,16 +305,15 @@ func (a *API) recoverVerify(r *http.Request, ctx context.Context, conn *storage.
 }
 
 func (a *API) smsVerify(r *http.Request, ctx context.Context, conn *storage.Connection, user *models.User, otpType string) (*models.User, error) {
-	instanceID := getInstanceID(ctx)
 	config := a.config
 
 	err := conn.Transaction(func(tx *storage.Connection) error {
 		var terr error
-		if terr = models.NewAuditLogEntry(r, tx, instanceID, user, models.UserSignedUpAction, "", nil); terr != nil {
+		if terr = models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", nil); terr != nil {
 			return terr
 		}
 
-		if terr = triggerEventHooks(ctx, tx, SignupEvent, user, instanceID, config); terr != nil {
+		if terr = triggerEventHooks(ctx, tx, SignupEvent, user, config); terr != nil {
 			return terr
 		}
 
@@ -358,7 +355,6 @@ func (a *API) prepRedirectURL(message string, rurl string) string {
 }
 
 func (a *API) emailChangeVerify(r *http.Request, ctx context.Context, conn *storage.Connection, params *VerifyParams, user *models.User) (*models.User, error) {
-	instanceID := getInstanceID(ctx)
 	config := a.config
 
 	if config.Mailer.SecureEmailChangeEnabled && user.EmailChangeConfirmStatus == zeroConfirmation && user.GetEmail() != "" {
@@ -384,11 +380,11 @@ func (a *API) emailChangeVerify(r *http.Request, ctx context.Context, conn *stor
 	err := conn.Transaction(func(tx *storage.Connection) error {
 		var terr error
 
-		if terr = models.NewAuditLogEntry(r, tx, instanceID, user, models.UserModifiedAction, "", nil); terr != nil {
+		if terr = models.NewAuditLogEntry(r, tx, user, models.UserModifiedAction, "", nil); terr != nil {
 			return terr
 		}
 
-		if terr = triggerEventHooks(ctx, tx, EmailChangeEvent, user, instanceID, config); terr != nil {
+		if terr = triggerEventHooks(ctx, tx, EmailChangeEvent, user, config); terr != nil {
 			return terr
 		}
 
@@ -451,7 +447,6 @@ func (a *API) verifyEmailLink(ctx context.Context, conn *storage.Connection, par
 
 // verifyUserAndToken verifies the token associated to the user based on the verify type
 func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, params *VerifyParams, aud string) (*models.User, error) {
-	instanceID := getInstanceID(ctx)
 	config := a.config
 
 	var user *models.User
@@ -465,9 +460,9 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 		tokenHash = fmt.Sprintf("%x", sha256.Sum224([]byte(string(params.Phone)+params.Token)))
 		switch params.Type {
 		case phoneChangeVerification:
-			user, err = models.FindUserByPhoneChangeAndAudience(conn, instanceID, params.Phone, aud)
+			user, err = models.FindUserByPhoneChangeAndAudience(conn, params.Phone, aud)
 		case smsVerification:
-			user, err = models.FindUserByPhoneAndAudience(conn, instanceID, params.Phone, aud)
+			user, err = models.FindUserByPhoneAndAudience(conn, params.Phone, aud)
 		default:
 			return nil, badRequestError("Invalid sms verification type")
 		}
@@ -478,9 +473,9 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 		tokenHash = fmt.Sprintf("%x", sha256.Sum224([]byte(string(params.Email)+params.Token)))
 		switch params.Type {
 		case emailChangeVerification:
-			user, err = models.FindUserForEmailChange(conn, instanceID, params.Email, tokenHash, aud, config.Mailer.SecureEmailChangeEnabled)
+			user, err = models.FindUserForEmailChange(conn, params.Email, tokenHash, aud, config.Mailer.SecureEmailChangeEnabled)
 		default:
-			user, err = models.FindUserByEmailAndAudience(conn, instanceID, params.Email, aud)
+			user, err = models.FindUserByEmailAndAudience(conn, params.Email, aud)
 		}
 	} else {
 		return nil, badRequestError("Only an email address or phone number should be provided on verify")

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
@@ -43,13 +42,13 @@ func (ts *VerifyTestSuite) SetupTest() {
 	models.TruncateAll(ts.API.db)
 
 	// Create user
-	u, err := models.NewUser(uuid.Nil, "12345678", "test@example.com", "password", ts.Config.JWT.Aud, nil)
+	u, err := models.NewUser("12345678", "test@example.com", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 }
 
 func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.RecoverySentAt = &time.Time{}
 	require.NoError(ts.T(), ts.API.db.Update(u))
@@ -69,7 +68,7 @@ func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
 	ts.API.handler.ServeHTTP(w, req)
 	assert.Equal(ts.T(), http.StatusOK, w.Code)
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
 	assert.WithinDuration(ts.T(), time.Now(), *u.RecoverySentAt, 1*time.Second)
@@ -82,13 +81,13 @@ func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
 	ts.API.handler.ServeHTTP(w, req)
 	assert.Equal(ts.T(), http.StatusSeeOther, w.Code)
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	assert.True(ts.T(), u.IsConfirmed())
 }
 
 func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.EmailChangeSentAt = &time.Time{}
 	require.NoError(ts.T(), ts.API.db.Update(u))
@@ -113,7 +112,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 	ts.API.handler.ServeHTTP(w, req)
 	assert.Equal(ts.T(), http.StatusOK, w.Code)
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
 	assert.WithinDuration(ts.T(), time.Now(), *u.EmailChangeSentAt, 1*time.Second)
@@ -133,7 +132,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 	ts.Require().NoError(err)
 	ts.Require().NotEmpty(v.Get("message"))
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	assert.Equal(ts.T(), singleConfirmation, u.EmailChangeConfirmStatus)
 
@@ -154,13 +153,13 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 	ts.Require().NotEmpty(v.Get("refresh_token"))
 
 	// user's email should've been updated to new@example.com
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "new@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "new@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), zeroConfirmation, u.EmailChangeConfirmStatus)
 }
 
 func (ts *VerifyTestSuite) TestExpiredConfirmationToken() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.ConfirmationToken = "asdf3"
 	sentTime := time.Now().Add(-48 * time.Hour)
@@ -189,7 +188,7 @@ func (ts *VerifyTestSuite) TestExpiredConfirmationToken() {
 }
 
 func (ts *VerifyTestSuite) TestInvalidOtp() {
-	u, err := models.FindUserByPhoneAndAudience(ts.API.db, uuid.Nil, "12345678", ts.Config.JWT.Aud)
+	u, err := models.FindUserByPhoneAndAudience(ts.API.db, "12345678", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	sentTime := time.Now().Add(-48 * time.Hour)
 	u.ConfirmationToken = "123456"
@@ -288,7 +287,7 @@ func (ts *VerifyTestSuite) TestInvalidOtp() {
 }
 
 func (ts *VerifyTestSuite) TestExpiredRecoveryToken() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.RecoveryToken = "asdf3"
 	sentTime := time.Now().Add(-48 * time.Hour)
@@ -308,7 +307,7 @@ func (ts *VerifyTestSuite) TestExpiredRecoveryToken() {
 }
 
 func (ts *VerifyTestSuite) TestVerifyPermitedCustomUri() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.RecoverySentAt = &time.Time{}
 	require.NoError(ts.T(), ts.API.db.Update(u))
@@ -328,7 +327,7 @@ func (ts *VerifyTestSuite) TestVerifyPermitedCustomUri() {
 	ts.API.handler.ServeHTTP(w, req)
 	assert.Equal(ts.T(), http.StatusOK, w.Code)
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
 	assert.WithinDuration(ts.T(), time.Now(), *u.RecoverySentAt, 1*time.Second)
@@ -345,13 +344,13 @@ func (ts *VerifyTestSuite) TestVerifyPermitedCustomUri() {
 	rURL, _ := w.Result().Location()
 	assert.Equal(ts.T(), redirectURL.Hostname(), rURL.Hostname())
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	assert.True(ts.T(), u.IsConfirmed())
 }
 
 func (ts *VerifyTestSuite) TestVerifyNotPermitedCustomUri() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.RecoverySentAt = &time.Time{}
 	require.NoError(ts.T(), ts.API.db.Update(u))
@@ -371,7 +370,7 @@ func (ts *VerifyTestSuite) TestVerifyNotPermitedCustomUri() {
 	ts.API.handler.ServeHTTP(w, req)
 	assert.Equal(ts.T(), http.StatusOK, w.Code)
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
 	assert.WithinDuration(ts.T(), time.Now(), *u.RecoverySentAt, 1*time.Second)
@@ -389,7 +388,7 @@ func (ts *VerifyTestSuite) TestVerifyNotPermitedCustomUri() {
 	rURL, _ := w.Result().Location()
 	assert.Equal(ts.T(), siteURL.Hostname(), rURL.Hostname())
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	assert.True(ts.T(), u.IsConfirmed())
 }
@@ -497,7 +496,7 @@ func (ts *VerifyTestSuite) TestVerifySignupWithredirectURLContainedPath() {
 			ts.Config.ApplyDefaults()
 
 			// set verify token to user as it actual do in magic link method
-			u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+			u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 			u.ConfirmationToken = "someToken"
 			sendTime := time.Now().Add(time.Hour)
@@ -513,7 +512,7 @@ func (ts *VerifyTestSuite) TestVerifySignupWithredirectURLContainedPath() {
 			rURL, _ := w.Result().Location()
 			assert.Contains(ts.T(), rURL.String(), tC.expectedredirectURL) // redirected url starts with per test value
 
-			u, err = models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+			u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 			assert.True(ts.T(), u.IsConfirmed())
 		})
@@ -521,7 +520,7 @@ func (ts *VerifyTestSuite) TestVerifySignupWithredirectURLContainedPath() {
 }
 
 func (ts *VerifyTestSuite) TestVerifyBannedUser() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.ConfirmationToken = "confirmation_token"
 	u.RecoveryToken = "recovery_token"
@@ -601,7 +600,7 @@ func (ts *VerifyTestSuite) TestVerifyBannedUser() {
 }
 
 func (ts *VerifyTestSuite) TestVerifyValidOtp() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, uuid.Nil, "test@example.com", ts.Config.JWT.Aud)
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	u.EmailChange = "new@example.com"
 	u.Phone = "12345678"

--- a/metering/record.go
+++ b/metering/record.go
@@ -7,11 +7,11 @@ import (
 
 var logger = logrus.StandardLogger().WithField("metering", true)
 
-func RecordLogin(loginType string, userID, instanceID uuid.UUID) {
+func RecordLogin(loginType string, userID uuid.UUID) {
 	logger.WithFields(logrus.Fields{
 		"action":       "login",
 		"login_method": loginType,
-		"instance_id":  instanceID.String(),
+		"instance_id":  uuid.Nil.String(),
 		"user_id":      userID.String(),
 	}).Info("Login")
 }

--- a/models/identity_test.go
+++ b/models/identity_test.go
@@ -61,7 +61,7 @@ func (ts *IdentityTestSuite) TestFindUserIdentities() {
 }
 
 func (ts *IdentityTestSuite) createUserWithEmail(email string) *User {
-	user, err := NewUser(uuid.Nil, "", email, "secret", "test", nil)
+	user, err := NewUser("", email, "secret", "test", nil)
 	require.NoError(ts.T(), err)
 
 	err = ts.db.Create(user)
@@ -71,7 +71,7 @@ func (ts *IdentityTestSuite) createUserWithEmail(email string) *User {
 }
 
 func (ts *IdentityTestSuite) createUserWithIdentity(email string) *User {
-	user, err := NewUser(uuid.Nil, "", email, "secret", "test", nil)
+	user, err := NewUser("", email, "secret", "test", nil)
 	require.NoError(ts.T(), err)
 
 	err = ts.db.Create(user)

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -14,8 +14,7 @@ import (
 
 // RefreshToken is the database model for refresh tokens.
 type RefreshToken struct {
-	InstanceID uuid.UUID `json:"-" db:"instance_id"`
-	ID         int64     `db:"id"`
+	ID int64 `db:"id"`
 
 	Token string `db:"token"`
 
@@ -26,6 +25,8 @@ type RefreshToken struct {
 	Revoked   bool      `db:"revoked"`
 	CreatedAt time.Time `db:"created_at"`
 	UpdatedAt time.Time `db:"updated_at"`
+
+	DONTUSEINSTANCEID uuid.UUID `json:"-" db:"instance_id"`
 }
 
 func (RefreshToken) TableName() string {
@@ -43,7 +44,7 @@ func GrantRefreshTokenSwap(r *http.Request, tx *storage.Connection, user *User, 
 	var newToken *RefreshToken
 	err := tx.Transaction(func(rtx *storage.Connection) error {
 		var terr error
-		if terr = NewAuditLogEntry(r, tx, user.InstanceID, user, TokenRevokedAction, "", nil); terr != nil {
+		if terr = NewAuditLogEntry(r, tx, user, TokenRevokedAction, "", nil); terr != nil {
 			return errors.Wrap(terr, "error creating audit log entry")
 		}
 
@@ -87,16 +88,15 @@ func GetValidChildToken(tx *storage.Connection, token *RefreshToken) (*RefreshTo
 }
 
 // Logout deletes all refresh tokens for a user.
-func Logout(tx *storage.Connection, instanceID uuid.UUID, id uuid.UUID) error {
-	return tx.RawQuery("DELETE FROM "+(&pop.Model{Value: RefreshToken{}}).TableName()+" WHERE instance_id = ? AND user_id = ?", instanceID, id).Exec()
+func Logout(tx *storage.Connection, id uuid.UUID) error {
+	return tx.RawQuery("DELETE FROM "+(&pop.Model{Value: RefreshToken{}}).TableName()+" WHERE instance_id = ? AND user_id = ?", uuid.Nil, id).Exec()
 }
 
 func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshToken) (*RefreshToken, error) {
 	token := &RefreshToken{
-		InstanceID: user.InstanceID,
-		UserID:     user.ID,
-		Token:      crypto.SecureToken(),
-		Parent:     "",
+		UserID: user.ID,
+		Token:  crypto.SecureToken(),
+		Parent: "",
 	}
 	if oldToken != nil {
 		token.Parent = storage.NullString(oldToken.Token)

--- a/models/refresh_token_test.go
+++ b/models/refresh_token_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
@@ -68,7 +67,7 @@ func (ts *RefreshTokenTestSuite) TestLogout() {
 	r, err := GrantAuthenticatedUser(ts.db, u)
 	require.NoError(ts.T(), err)
 
-	require.NoError(ts.T(), Logout(ts.db, uuid.Nil, u.ID))
+	require.NoError(ts.T(), Logout(ts.db, u.ID))
 	u, r, err = FindUserWithRefreshToken(ts.db, r.Token)
 	require.Errorf(ts.T(), err, "expected error when there are no refresh tokens to authenticate. user: %v token: %v", u, r)
 
@@ -80,7 +79,7 @@ func (ts *RefreshTokenTestSuite) createUser() *User {
 }
 
 func (ts *RefreshTokenTestSuite) createUserWithEmail(email string) *User {
-	user, err := NewUser(uuid.Nil, "", email, "secret", "test", nil)
+	user, err := NewUser("", email, "secret", "test", nil)
 	require.NoError(ts.T(), err)
 
 	err = ts.db.Create(user)

--- a/models/user.go
+++ b/models/user.go
@@ -17,8 +17,7 @@ var PasswordHashCost = bcrypt.DefaultCost
 
 // User respresents a registered user with email/password authentication
 type User struct {
-	InstanceID uuid.UUID `json:"-" db:"instance_id"`
-	ID         uuid.UUID `json:"id" db:"id"`
+	ID uuid.UUID `json:"id" db:"id"`
 
 	Aud               string             `json:"aud" db:"aud"`
 	Role              string             `json:"role" db:"role"`
@@ -63,10 +62,12 @@ type User struct {
 	CreatedAt   time.Time  `json:"created_at" db:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at" db:"updated_at"`
 	BannedUntil *time.Time `json:"banned_until,omitempty" db:"banned_until"`
+
+	DONTUSEINSTANCEID uuid.UUID `json:"-" db:"instance_id"`
 }
 
 // NewUser initializes a new user from an email, password and user data.
-func NewUser(instanceID uuid.UUID, phone, email, password, aud string, userData map[string]interface{}) (*User, error) {
+func NewUser(phone, email, password, aud string, userData map[string]interface{}) (*User, error) {
 	id, err := uuid.NewV4()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error generating unique id")
@@ -79,7 +80,6 @@ func NewUser(instanceID uuid.UUID, phone, email, password, aud string, userData 
 		userData = make(map[string]interface{})
 	}
 	user := &User{
-		InstanceID:        instanceID,
 		ID:                id,
 		Aud:               aud,
 		Email:             storage.NullString(strings.ToLower(email)),
@@ -313,8 +313,8 @@ func (u *User) Recover(tx *storage.Connection) error {
 }
 
 // CountOtherUsers counts how many other users exist besides the one provided
-func CountOtherUsers(tx *storage.Connection, instanceID, id uuid.UUID) (int, error) {
-	userCount, err := tx.Q().Where("instance_id = ? and id != ?", instanceID, id).Count(&User{})
+func CountOtherUsers(tx *storage.Connection, id uuid.UUID) (int, error) {
+	userCount, err := tx.Q().Where("instance_id = ? and id != ?", uuid.Nil, id).Count(&User{})
 	return userCount, errors.Wrap(err, "error finding registered users")
 }
 
@@ -340,23 +340,18 @@ func FindUserByConfirmationToken(tx *storage.Connection, token string) (*User, e
 }
 
 // FindUserByEmailAndAudience finds a user with the matching email and audience.
-func FindUserByEmailAndAudience(tx *storage.Connection, instanceID uuid.UUID, email, aud string) (*User, error) {
-	return findUser(tx, "instance_id = ? and LOWER(email) = ? and aud = ?", instanceID, strings.ToLower(email), aud)
+func FindUserByEmailAndAudience(tx *storage.Connection, email, aud string) (*User, error) {
+	return findUser(tx, "instance_id = ? and LOWER(email) = ? and aud = ?", uuid.Nil, strings.ToLower(email), aud)
 }
 
 // FindUserByPhoneAndAudience finds a user with the matching email and audience.
-func FindUserByPhoneAndAudience(tx *storage.Connection, instanceID uuid.UUID, phone, aud string) (*User, error) {
-	return findUser(tx, "instance_id = ? and phone = ? and aud = ?", instanceID, phone, aud)
+func FindUserByPhoneAndAudience(tx *storage.Connection, phone, aud string) (*User, error) {
+	return findUser(tx, "instance_id = ? and phone = ? and aud = ?", uuid.Nil, phone, aud)
 }
 
 // FindUserByID finds a user matching the provided ID.
 func FindUserByID(tx *storage.Connection, id uuid.UUID) (*User, error) {
-	return findUser(tx, "id = ?", id)
-}
-
-// FindUserByInstanceIDAndID finds a user matching the provided ID.
-func FindUserByInstanceIDAndID(tx *storage.Connection, instanceID, id uuid.UUID) (*User, error) {
-	return findUser(tx, "instance_id = ? and id = ?", instanceID, id)
+	return findUser(tx, "instance_id = ? and id = ?", uuid.Nil, id)
 }
 
 // FindUserByRecoveryToken finds a user with the matching recovery token.
@@ -394,9 +389,9 @@ func FindUserWithRefreshToken(tx *storage.Connection, token string) (*User, *Ref
 }
 
 // FindUsersInAudience finds users with the matching audience.
-func FindUsersInAudience(tx *storage.Connection, instanceID uuid.UUID, aud string, pageParams *Pagination, sortParams *SortParams, filter string) ([]*User, error) {
+func FindUsersInAudience(tx *storage.Connection, aud string, pageParams *Pagination, sortParams *SortParams, filter string) ([]*User, error) {
 	users := []*User{}
-	q := tx.Q().Where("instance_id = ? and aud = ?", instanceID, aud)
+	q := tx.Q().Where("instance_id = ? and aud = ?", uuid.Nil, aud)
 
 	if filter != "" {
 		lf := "%" + filter + "%"
@@ -422,43 +417,43 @@ func FindUsersInAudience(tx *storage.Connection, instanceID uuid.UUID, aud strin
 }
 
 // FindUserByEmailChangeCurrentAndAudience finds a user with the matching email change and audience.
-func FindUserByEmailChangeCurrentAndAudience(tx *storage.Connection, instanceID uuid.UUID, email, token, aud string) (*User, error) {
+func FindUserByEmailChangeCurrentAndAudience(tx *storage.Connection, email, token, aud string) (*User, error) {
 	return findUser(
 		tx,
 		"instance_id = ? and LOWER(email) = ? and email_change_token_current = ? and aud = ?",
-		instanceID, strings.ToLower(email), token, aud,
+		uuid.Nil, strings.ToLower(email), token, aud,
 	)
 }
 
 // FindUserByEmailChangeNewAndAudience finds a user with the matching email change and audience.
-func FindUserByEmailChangeNewAndAudience(tx *storage.Connection, instanceID uuid.UUID, email, token, aud string) (*User, error) {
+func FindUserByEmailChangeNewAndAudience(tx *storage.Connection, email, token, aud string) (*User, error) {
 	return findUser(
 		tx,
 		"instance_id = ? and LOWER(email_change) = ? and email_change_token_new = ? and aud = ?",
-		instanceID, strings.ToLower(email), token, aud,
+		uuid.Nil, strings.ToLower(email), token, aud,
 	)
 }
 
 // FindUserForEmailChange finds a user requesting for an email change
-func FindUserForEmailChange(tx *storage.Connection, instanceID uuid.UUID, email, token, aud string, secureEmailChangeEnabled bool) (*User, error) {
+func FindUserForEmailChange(tx *storage.Connection, email, token, aud string, secureEmailChangeEnabled bool) (*User, error) {
 	if secureEmailChangeEnabled {
-		if user, err := FindUserByEmailChangeCurrentAndAudience(tx, instanceID, email, token, aud); err == nil {
+		if user, err := FindUserByEmailChangeCurrentAndAudience(tx, email, token, aud); err == nil {
 			return user, err
 		} else if !IsNotFoundError(err) {
 			return nil, err
 		}
 	}
-	return FindUserByEmailChangeNewAndAudience(tx, instanceID, email, token, aud)
+	return FindUserByEmailChangeNewAndAudience(tx, email, token, aud)
 }
 
 // FindUserByPhoneChangeAndAudience finds a user with the matching phone change and audience.
-func FindUserByPhoneChangeAndAudience(tx *storage.Connection, instanceID uuid.UUID, phone, aud string) (*User, error) {
-	return findUser(tx, "instance_id = ? and phone_change = ? and aud = ?", instanceID, phone, aud)
+func FindUserByPhoneChangeAndAudience(tx *storage.Connection, phone, aud string) (*User, error) {
+	return findUser(tx, "instance_id = ? and phone_change = ? and aud = ?", uuid.Nil, phone, aud)
 }
 
 // IsDuplicatedEmail returns whether a user exists with a matching email and audience.
-func IsDuplicatedEmail(tx *storage.Connection, instanceID uuid.UUID, email, aud string) (bool, error) {
-	_, err := FindUserByEmailAndAudience(tx, instanceID, email, aud)
+func IsDuplicatedEmail(tx *storage.Connection, email, aud string) (bool, error) {
+	_, err := FindUserByEmailAndAudience(tx, email, aud)
 	if err != nil {
 		if IsNotFoundError(err) {
 			return false, nil
@@ -469,8 +464,8 @@ func IsDuplicatedEmail(tx *storage.Connection, instanceID uuid.UUID, email, aud 
 }
 
 // IsDuplicatedPhone checks if the phone number already exists in the users table
-func IsDuplicatedPhone(tx *storage.Connection, instanceID uuid.UUID, phone, aud string) (bool, error) {
-	_, err := FindUserByPhoneAndAudience(tx, instanceID, phone, aud)
+func IsDuplicatedPhone(tx *storage.Connection, phone, aud string) (bool, error) {
+	_, err := FindUserByPhoneAndAudience(tx, phone, aud)
 	if err != nil {
 		if IsNotFoundError(err) {
 			return false, nil

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -3,7 +3,6 @@ package models
 import (
 	"testing"
 
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
@@ -44,7 +43,7 @@ func TestUser(t *testing.T) {
 }
 
 func (ts *UserTestSuite) TestUpdateAppMetadata() {
-	u, err := NewUser(uuid.Nil, "", "", "", "", nil)
+	u, err := NewUser("", "", "", "", nil)
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), u.UpdateAppMetaData(ts.db, make(map[string]interface{})))
 
@@ -63,7 +62,7 @@ func (ts *UserTestSuite) TestUpdateAppMetadata() {
 }
 
 func (ts *UserTestSuite) TestUpdateUserMetadata() {
-	u, err := NewUser(uuid.Nil, "", "", "", "", nil)
+	u, err := NewUser("", "", "", "", nil)
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), u.UpdateUserMetaData(ts.db, make(map[string]interface{})))
 
@@ -92,18 +91,18 @@ func (ts *UserTestSuite) TestFindUserByConfirmationToken() {
 func (ts *UserTestSuite) TestFindUserByEmailAndAudience() {
 	u := ts.createUser()
 
-	n, err := FindUserByEmailAndAudience(ts.db, uuid.Nil, u.GetEmail(), "test")
+	n, err := FindUserByEmailAndAudience(ts.db, u.GetEmail(), "test")
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), u.ID, n.ID)
 
-	_, err = FindUserByEmailAndAudience(ts.db, uuid.Nil, u.GetEmail(), "invalid")
+	_, err = FindUserByEmailAndAudience(ts.db, u.GetEmail(), "invalid")
 	require.EqualError(ts.T(), err, UserNotFoundError{}.Error())
 }
 
 func (ts *UserTestSuite) TestFindUsersInAudience() {
 	u := ts.createUser()
 
-	n, err := FindUsersInAudience(ts.db, uuid.Nil, u.Aud, nil, nil, "")
+	n, err := FindUsersInAudience(ts.db, u.Aud, nil, nil, "")
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 1)
 
@@ -111,7 +110,7 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 		Page:    1,
 		PerPage: 50,
 	}
-	n, err = FindUsersInAudience(ts.db, uuid.Nil, u.Aud, &p, nil, "")
+	n, err = FindUsersInAudience(ts.db, u.Aud, &p, nil, "")
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 1)
 	assert.Equal(ts.T(), uint64(1), p.Count)
@@ -121,7 +120,7 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 			{Name: "created_at", Dir: Descending},
 		},
 	}
-	n, err = FindUsersInAudience(ts.db, uuid.Nil, u.Aud, nil, sp, "")
+	n, err = FindUsersInAudience(ts.db, u.Aud, nil, sp, "")
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 1)
 }
@@ -130,14 +129,6 @@ func (ts *UserTestSuite) TestFindUserByID() {
 	u := ts.createUser()
 
 	n, err := FindUserByID(ts.db, u.ID)
-	require.NoError(ts.T(), err)
-	require.Equal(ts.T(), u.ID, n.ID)
-}
-
-func (ts *UserTestSuite) TestFindUserByInstanceIDAndID() {
-	u := ts.createUser()
-
-	n, err := FindUserByInstanceIDAndID(ts.db, uuid.Nil, u.ID)
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), u.ID, n.ID)
 }
@@ -169,19 +160,19 @@ func (ts *UserTestSuite) TestFindUserWithRefreshToken() {
 func (ts *UserTestSuite) TestIsDuplicatedEmail() {
 	_ = ts.createUserWithEmail("david.calavera@netlify.com")
 
-	e, err := IsDuplicatedEmail(ts.db, uuid.Nil, "david.calavera@netlify.com", "test")
+	e, err := IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "test")
 	require.NoError(ts.T(), err)
 	require.True(ts.T(), e, "expected email to be duplicated")
 
-	e, err = IsDuplicatedEmail(ts.db, uuid.Nil, "davidcalavera@netlify.com", "test")
+	e, err = IsDuplicatedEmail(ts.db, "davidcalavera@netlify.com", "test")
 	require.NoError(ts.T(), err)
 	require.False(ts.T(), e, "expected email to not be duplicated")
 
-	e, err = IsDuplicatedEmail(ts.db, uuid.Nil, "david@netlify.com", "test")
+	e, err = IsDuplicatedEmail(ts.db, "david@netlify.com", "test")
 	require.NoError(ts.T(), err)
 	require.False(ts.T(), e, "expected same email to not be duplicated")
 
-	e, err = IsDuplicatedEmail(ts.db, uuid.Nil, "david.calavera@netlify.com", "other-aud")
+	e, err = IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "other-aud")
 	require.NoError(ts.T(), err)
 	require.False(ts.T(), e, "expected same email to not be duplicated")
 }
@@ -191,7 +182,7 @@ func (ts *UserTestSuite) createUser() *User {
 }
 
 func (ts *UserTestSuite) createUserWithEmail(email string) *User {
-	user, err := NewUser(uuid.Nil, "", email, "secret", "test", nil)
+	user, err := NewUser("", email, "secret", "test", nil)
 	require.NoError(ts.T(), err)
 
 	err = ts.db.Create(user)
@@ -201,10 +192,7 @@ func (ts *UserTestSuite) createUserWithEmail(email string) *User {
 }
 
 func (ts *UserTestSuite) TestRemoveUnconfirmedIdentities() {
-	uid, err := uuid.NewV4()
-	require.NoError(ts.T(), err)
-
-	user, err := NewUser(uid, "+29382983298", "someone@example.com", "abcdefgh", "test", nil)
+	user, err := NewUser("+29382983298", "someone@example.com", "abcdefgh", "authenticated", nil)
 	require.NoError(ts.T(), err)
 
 	user.AppMetaData = map[string]interface{}{


### PR DESCRIPTION
Removes all remnants of `getInstanceID(ctx)`. The only exception is that the `InstanceID` field in some models (`User`, `RefreshToken`, `AuditLogEntry`) can't be removed (because `pop` uses the zero value when creating a model). This has been renamed to `DONTUSEINSTANCEID` and should be removed once the `instance_id` column is removed from the database.

Note that database queries have not removed the `instance_id = ?` conditionals, and instead use `uuid.Nil` for the value; this is because some users of GoTrue may have entries in the database with a non-0 UUID `instance_id`.