### PR TITLE
feat: Remove `IsSuperAdmin`

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -71,7 +71,7 @@ func (a *API) isAdmin(ctx context.Context, u *models.User, aud string) bool {
 	if aud == "" {
 		aud = config.JWT.Aud
 	}
-	return u.IsSuperAdmin || (aud == u.Aud && u.HasRole(config.JWT.AdminGroupName))
+	return aud == u.Aud && u.HasRole(config.JWT.AdminGroupName)
 }
 
 func (a *API) requestAud(ctx context.Context, r *http.Request) string {

--- a/cmd/admin_cmd.go
+++ b/cmd/admin_cmd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var autoconfirm, isSuperAdmin, isAdmin bool
+var autoconfirm, isAdmin bool
 var audience string
 
 func getAudience(c *conf.GlobalConfiguration) string {
@@ -29,7 +29,6 @@ func adminCmd() *cobra.Command {
 	adminCmd.PersistentFlags().StringVarP(&audience, "aud", "a", "", "Set the new user's audience")
 
 	adminCreateUserCmd.Flags().BoolVar(&autoconfirm, "confirm", false, "Automatically confirm user without sending an email")
-	adminCreateUserCmd.Flags().BoolVar(&isSuperAdmin, "superadmin", false, "Create user with superadmin privileges")
 	adminCreateUserCmd.Flags().BoolVar(&isAdmin, "admin", false, "Create user with admin privileges")
 
 	return adminCmd
@@ -84,7 +83,6 @@ func adminCreateUser(config *conf.GlobalConfiguration, args []string) {
 	if err != nil {
 		logrus.Fatalf("Error creating new user: %+v", err)
 	}
-	user.IsSuperAdmin = isSuperAdmin
 
 	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
@@ -154,8 +152,6 @@ func adminEditRole(config *conf.GlobalConfiguration, args []string) {
 			logrus.Fatalf("Error finding user (%s): %+v", userID, err)
 		}
 	}
-
-	user.IsSuperAdmin = isSuperAdmin
 
 	if len(args) > 0 {
 		user.Role = args[0]

--- a/models/user.go
+++ b/models/user.go
@@ -56,8 +56,7 @@ type User struct {
 	AppMetaData  JSONMap `json:"app_metadata" db:"raw_app_meta_data"`
 	UserMetaData JSONMap `json:"user_metadata" db:"raw_user_meta_data"`
 
-	IsSuperAdmin bool       `json:"-" db:"is_super_admin"`
-	Identities   []Identity `json:"identities" has_many:"identities"`
+	Identities []Identity `json:"identities" has_many:"identities"`
 
 	CreatedAt   time.Time  `json:"created_at" db:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at" db:"updated_at"`


### PR DESCRIPTION
Removes the `IsSuperAdmin` field from the `User` model, as this is not used nor supported by Supabase.