### PR TITLE
chore: Remove unused `addGetBody` middleware

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -51,26 +50,6 @@ func (f *FunctionHooks) UnmarshalJSON(b []byte) error {
 		(*f)[event] = []string{hook}
 	}
 	return nil
-}
-
-func addGetBody(w http.ResponseWriter, req *http.Request) (context.Context, error) {
-	if req.Method == http.MethodGet {
-		return req.Context(), nil
-	}
-
-	if req.Body == nil || req.Body == http.NoBody {
-		return nil, badRequestError("request must provide a body")
-	}
-
-	buf, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		return nil, internalServerError("Error reading body").WithInternalError(err)
-	}
-	req.GetBody = func() (io.ReadCloser, error) {
-		return ioutil.NopCloser(bytes.NewReader(buf)), nil
-	}
-	req.Body, _ = req.GetBody()
-	return req.Context(), nil
 }
 
 func (a *API) loadJWSSignatureHeader(w http.ResponseWriter, r *http.Request) (context.Context, error) {


### PR DESCRIPTION
The function is not used -- probably added to populate the `GetBody` function on requests, but it's not used.