### PR TITLE
fix: admin user create should respect `app_metadata`

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -255,6 +255,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return internalServerError("Error creating user").WithInternalError(err)
 	}
+
 	if user.AppMetaData == nil {
 		user.AppMetaData = make(map[string]interface{})
 	}
@@ -289,6 +290,12 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 		}
 		if terr := user.SetRole(tx, role); terr != nil {
 			return terr
+		}
+
+		if params.AppMetaData != nil {
+			if terr := user.UpdateAppMetaData(tx, params.AppMetaData); terr != nil {
+				return terr
+			}
 		}
 
 		if params.EmailConfirm {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes the bug described in https://github.com/supabase/gotrue/issues/629 where `app_metadata` field was not being respected when a user is created via the admin endpoint

