### PR TITLE
fix: Access to `req.Body` via `getBodyBytes`

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -50,10 +50,16 @@ func (a *API) loadUser(w http.ResponseWriter, r *http.Request) (context.Context,
 
 func (a *API) getAdminParams(r *http.Request) (*adminUserParams, error) {
 	params := adminUserParams{}
-	err := json.NewDecoder(r.Body).Decode(&params)
+
+	body, err := getBodyBytes(r)
 	if err != nil {
+		return nil, badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, &params); err != nil {
 		return nil, badRequestError("Could not decode admin user params: %v", err)
 	}
+
 	return &params, nil
 }
 

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptrace"
@@ -273,4 +275,23 @@ func isStringInSlice(checkValue string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// getBodyBytes returns a byte array of the request's Body.
+func getBodyBytes(req *http.Request) ([]byte, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil, nil
+	}
+
+	originalBody := req.Body
+	defer originalBody.Close()
+
+	buf, err := io.ReadAll(originalBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(buf))
+
+	return buf, nil
 }

--- a/api/invite.go
+++ b/api/invite.go
@@ -21,9 +21,12 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	adminUser := getAdminUser(ctx)
 	params := &InviteParams{}
 
-	jsonDecoder := json.NewDecoder(r.Body)
-	err := jsonDecoder.Decode(params)
+	body, err := getBodyBytes(r)
 	if err != nil {
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read Invite params: %v", err)
 	}
 

--- a/api/mail.go
+++ b/api/mail.go
@@ -38,10 +38,14 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 	adminUser := getAdminUser(ctx)
 
 	params := &GenerateLinkParams{}
-	jsonDecoder := json.NewDecoder(r.Body)
 
-	if err := jsonDecoder.Decode(params); err != nil {
-		return badRequestError("Could not read body: %v", err)
+	body, err := getBodyBytes(r)
+	if err != nil {
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
+		return badRequestError("Could not parse JSON: %v", err)
 	}
 
 	if err := a.validateEmail(ctx, params.Email); err != nil {

--- a/api/recover.go
+++ b/api/recover.go
@@ -19,9 +19,13 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.config
 	params := &RecoverParams{}
-	jsonDecoder := json.NewDecoder(r.Body)
-	err := jsonDecoder.Decode(params)
+
+	body, err := getBodyBytes(r)
 	if err != nil {
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read verification params: %v", err)
 	}
 

--- a/api/signup.go
+++ b/api/signup.go
@@ -35,9 +35,13 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	params := &SignupParams{}
-	jsonDecoder := json.NewDecoder(r.Body)
-	err := jsonDecoder.Decode(params)
+
+	body, err := getBodyBytes(r)
 	if err != nil {
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read Signup params: %v", err)
 	}
 

--- a/api/token.go
+++ b/api/token.go
@@ -165,8 +165,12 @@ func (a *API) Token(w http.ResponseWriter, r *http.Request) error {
 func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	params := &PasswordGrantParams{}
 
-	jsonDecoder := json.NewDecoder(r.Body)
-	if err := jsonDecoder.Decode(params); err != nil {
+	body, err := getBodyBytes(r)
+	if err != nil {
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read password grant params: %v", err)
 	}
 
@@ -178,7 +182,6 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	}
 	var user *models.User
 	var provider string
-	var err error
 	if params.Email != "" {
 		provider = "email"
 		if !config.External.Email.Enabled {
@@ -248,8 +251,12 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 
 	params := &RefreshTokenGrantParams{}
 
-	jsonDecoder := json.NewDecoder(r.Body)
-	if err := jsonDecoder.Decode(params); err != nil {
+	body, err := getBodyBytes(r)
+	if err != nil {
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read refresh token grant params: %v", err)
 	}
 
@@ -359,8 +366,12 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	params := &IdTokenGrantParams{}
 
-	jsonDecoder := json.NewDecoder(r.Body)
-	if err := jsonDecoder.Decode(params); err != nil {
+	body, err := getBodyBytes(r)
+	if err != nil {
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read id token grant params: %v", err)
 	}
 
@@ -373,7 +384,6 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 	}
 
 	var verifier *oidc.IDTokenVerifier
-	var err error
 	if params.Provider != "" {
 		verifier, err = params.getVerifier(ctx, a.config)
 	} else if params.ClientID != "" && params.Issuer != "" {

--- a/api/user.go
+++ b/api/user.go
@@ -56,9 +56,13 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	config := a.config
 
 	params := &UserUpdateParams{}
-	jsonDecoder := json.NewDecoder(r.Body)
-	err := jsonDecoder.Decode(params)
+
+	body, err := getBodyBytes(r)
 	if err != nil {
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read User Update params: %v", err)
 	}
 

--- a/api/verify.go
+++ b/api/verify.go
@@ -159,8 +159,13 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	config := a.config
 	params := &VerifyParams{}
-	jsonDecoder := json.NewDecoder(r.Body)
-	if err := jsonDecoder.Decode(params); err != nil {
+
+	body, err := getBodyBytes(r)
+	if err != nil {
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read verification params: %v", err)
 	}
 
@@ -178,7 +183,6 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
 
 	var (
 		user  *models.User
-		err   error
 		token *AccessTokenResponse
 	)
 


### PR DESCRIPTION
Fixes access to a request's `Body` via a common helper function `getBodyBytes(req)` which handles proper closing and re-setting of `req.Body`.