### PR TITLE
refactor: requireAuthentication should store user and session in context

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -152,13 +152,11 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 		r.With(api.requireAuthentication).Post("/logout", api.Logout)
 
-		r.Route("/reauthenticate", func(r *router) {
-			r.Use(api.requireAuthentication)
+		r.With(api.requireAuthentication).Route("/reauthenticate", func(r *router) {
 			r.Get("/", api.Reauthenticate)
 		})
 
-		r.Route("/user", func(r *router) {
-			r.Use(api.requireAuthentication)
+		r.With(api.requireAuthentication).Route("/user", func(r *router) {
 			r.Get("/", api.UserGet)
 			r.With(sharedLimiter).Put("/", api.UserUpdate)
 		})

--- a/api/auth.go
+++ b/api/auth.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
@@ -20,7 +22,16 @@ func (a *API) requireAuthentication(w http.ResponseWriter, r *http.Request) (con
 		return nil, err
 	}
 
-	return a.parseJWTClaims(token, r, w)
+	ctx, err := a.parseJWTClaims(token, r, w)
+	if err != nil {
+		return ctx, err
+	}
+
+	ctx, err = a.maybeLoadUserOrSession(ctx)
+	if err != nil {
+		return ctx, err
+	}
+	return ctx, err
 }
 
 func (a *API) requireAdmin(ctx context.Context, w http.ResponseWriter, r *http.Request) (context.Context, error) {
@@ -70,4 +81,42 @@ func (a *API) parseJWTClaims(bearer string, r *http.Request, w http.ResponseWrit
 	}
 
 	return withToken(ctx, token), nil
+}
+
+func (a *API) maybeLoadUserOrSession(ctx context.Context) (context.Context, error) {
+	claims := getClaims(ctx)
+	if claims == nil {
+		return ctx, errors.New("invalid token")
+	}
+
+	if claims.Subject == "" {
+		return nil, errors.New("invalid claim: subject missing")
+	}
+
+	var user *models.User
+	if claims.Subject != "" {
+		userId, err := uuid.FromString(claims.Subject)
+		if err != nil {
+			return ctx, err
+		}
+		user, err = models.FindUserByID(a.db, userId)
+		if err != nil {
+			return ctx, err
+		}
+		ctx = withUser(ctx, user)
+	}
+
+	var session *models.Session
+	if claims.SessionId != "" {
+		sessionId, err := uuid.FromString(claims.SessionId)
+		if err != nil {
+			return ctx, err
+		}
+		session, err = models.FindSessionById(a.db, sessionId)
+		if err != nil {
+			return ctx, err
+		}
+		ctx = withSession(ctx, session)
+	}
+	return ctx, nil
 }

--- a/api/context.go
+++ b/api/context.go
@@ -20,6 +20,7 @@ const (
 	signatureKey            = contextKey("signature")
 	externalProviderTypeKey = contextKey("external_provider_type")
 	userKey                 = contextKey("user")
+	sessionKey              = contextKey("session")
 	externalReferrerKey     = contextKey("external_referrer")
 	functionHooksKey        = contextKey("function_hooks")
 	adminUserKey            = contextKey("admin_user")
@@ -65,18 +66,32 @@ func getRequestID(ctx context.Context) string {
 	return obj.(string)
 }
 
-// withUser adds the user id to the context.
+// withUser adds the user to the context.
 func withUser(ctx context.Context, u *models.User) context.Context {
 	return context.WithValue(ctx, userKey, u)
 }
 
-// getUser reads the user id from the context.
+// getUser reads the user from the context.
 func getUser(ctx context.Context) *models.User {
 	obj := ctx.Value(userKey)
 	if obj == nil {
 		return nil
 	}
 	return obj.(*models.User)
+}
+
+// withSession adds the session to the context.
+func withSession(ctx context.Context, s *models.Session) context.Context {
+	return context.WithValue(ctx, sessionKey, s)
+}
+
+// getSession reads the session from the context.
+func getSession(ctx context.Context) *models.Session {
+	obj := ctx.Value(sessionKey)
+	if obj == nil {
+		return nil
+	}
+	return obj.(*models.Session)
 }
 
 // withSignature adds the provided request ID to the context.

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -47,40 +46,6 @@ func sendJSON(w http.ResponseWriter, status int, obj interface{}) error {
 	w.WriteHeader(status)
 	_, err = w.Write(b)
 	return err
-}
-
-func getSessionFromClaims(ctx context.Context, conn *storage.Connection) (*models.Session, error) {
-	claims := getClaims(ctx)
-	if claims == nil {
-		return nil, errors.New("Invalid token")
-	}
-
-	if claims.SessionId == "" {
-		return nil, nil
-	}
-
-	sessionId, err := uuid.FromString(claims.SessionId)
-	if err != nil {
-		return nil, errors.New("Invalid session ID")
-	}
-	return models.FindSessionById(conn, sessionId)
-}
-
-func getUserFromClaims(ctx context.Context, conn *storage.Connection) (*models.User, error) {
-	claims := getClaims(ctx)
-	if claims == nil {
-		return nil, errors.New("Invalid token")
-	}
-
-	if claims.Subject == "" {
-		return nil, errors.New("Invalid claim: id")
-	}
-
-	userID, err := uuid.FromString(claims.Subject)
-	if err != nil {
-		return nil, errors.New("Invalid user ID")
-	}
-	return models.FindUserByID(conn, userID)
 }
 
 func (a *API) isAdmin(ctx context.Context, u *models.User, aud string) bool {

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -120,3 +120,9 @@ func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshTok
 	}
 	return token, nil
 }
+
+// Deprecated. For backward compatibility, some access tokens may not have a sessionId. Use models.Logout instead.
+// LogoutAllRefreshTokens deletes all sessions for a user.
+func LogoutAllRefreshTokens(tx *storage.Connection, userId uuid.UUID) error {
+	return tx.RawQuery("DELETE FROM "+(&pop.Model{Value: RefreshToken{}}).TableName()+" WHERE user_id = ?", userId).Exec()
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `requireAuthentication` middleware should handle storing the user and session in the request context since the user is always needed downstream
* `/logout` should maintain backward compatibility for access_tokens that do not have a `session_id` claim in them and delete all the refresh tokens associated to a user
* `/logout` should delete all sessions associated to a user if the `session_id` claim exists in the access_token. Since the delete is cascaded, the refresh_tokens associated to each session will also be deleted
* replace `getUserFromClaims` and `getSessionFromClaims` with `maybeLoadUserOrSession` 