### PR TITLE
fix: skip capcha if admin jwt in header 

### DIFF
--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -42,25 +42,12 @@ func TestAdmin(t *testing.T) {
 func (ts *AdminTestSuite) SetupTest() {
 	models.TruncateAll(ts.API.db)
 	ts.Config.External.Email.Enabled = true
-	ts.token = ts.makeSuperAdmin("")
-}
-
-func (ts *AdminTestSuite) makeSuperAdmin(email string) string {
-	u, err := models.NewUser("9123456", email, "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test User"})
-	require.NoError(ts.T(), err, "Error making new user")
-
-	u.Role = "supabase_admin"
-
-	token, err := generateAccessToken(u, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
-	require.NoError(ts.T(), err, "Error generating access token")
-
-	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
-	_, err = p.Parse(token, func(token *jwt.Token) (interface{}, error) {
-		return []byte(ts.Config.JWT.Secret), nil
-	})
-	require.NoError(ts.T(), err, "Error parsing token")
-
-	return token
+	claims := &GoTrueClaims{
+		Role: "supabase_admin",
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(ts.Config.JWT.Secret))
+	require.NoError(ts.T(), err, "Error generating admin jwt")
+	ts.token = token
 }
 
 // TestAdminUsersUnauthorized tests API /admin/users route without authentication

--- a/api/auth.go
+++ b/api/auth.go
@@ -44,10 +44,6 @@ func (a *API) requireAdmin(ctx context.Context, w http.ResponseWriter, r *http.R
 
 func (a *API) extractBearerToken(w http.ResponseWriter, r *http.Request) (string, error) {
 	authHeader := r.Header.Get("Authorization")
-	if authHeader == "" {
-		return "", unauthorizedError("This endpoint requires a Bearer token")
-	}
-
 	matches := bearerRegexp.FindStringSubmatch(authHeader)
 	if len(matches) != 2 {
 		return "", unauthorizedError("This endpoint requires a Bearer token")

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -131,7 +131,7 @@ func (a *API) verifyCaptcha(w http.ResponseWriter, req *http.Request) (context.C
 	if !config.Security.Captcha.Enabled {
 		return ctx, nil
 	}
-	if ctx, err := a.requireAdminCredentials(w, req); err == nil {
+	if _, err := a.requireAdminCredentials(w, req); err == nil {
 		// skip captcha validation if authorization header contains an admin role
 		return ctx, nil
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Allows a user to skip captcha validation if an admin JWT is present in the header
* Allows one to bypass captcha validation on a trusted client (e.g. supabase's user management dashboard)
* Add test for bypassing captcha with admin jwt