### PR TITLE
fix: Add full `gosec` support (w/o tests)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           set -x
           go install github.com/securego/gosec/v2/cmd/gosec@latest
-          gosec -tests -exclude=G104 ./... # exclude unhandled errors for the time being
+          make sec
       - name: Init Database
         run: psql -f hack/init_postgres.sql postgresql://postgres:root@localhost:5432/postgres
       - name: Run migrations

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ vet: # Vet the code
 	go vet $(CHECK_FILES)
 
 sec: # Check for security vulnerabilities
-	gosec -tests -exclude=G104 $(CHECK_FILES)
+	gosec -quiet $(CHECK_FILES)
+	gosec -quiet -tests -exclude=G104 $(CHECK_FILES)
 
 dev: ## Run the development containers
 	docker-compose -f $(DEV_DOCKER_COMPOSE) up

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -148,7 +148,9 @@ func (w *Webhook) generateSignature() (string, error) {
 
 func closeBody(rsp *http.Response) {
 	if rsp != nil && rsp.Body != nil {
-		rsp.Body.Close()
+		if err := rsp.Body.Close(); err != nil {
+			logrus.WithError(err).Warn("body close in hooks failed")
+		}
 	}
 }
 
@@ -231,11 +233,9 @@ func triggerHook(ctx context.Context, hookURL *url.URL, secret string, conn *sto
 	w.URL = hookURL.String()
 
 	body, err := w.trigger()
-	defer func() {
-		if body != nil {
-			body.Close()
-		}
-	}()
+	if body != nil {
+		defer body.Close()
+	}
 	if err == nil && body != nil {
 		webhookRsp := &WebhookResponse{}
 		decoder := json.NewDecoder(body)

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,10 +1,8 @@
 package api
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -74,15 +72,13 @@ func (a *API) limitEmailSentHandler() middlewareHandler {
 		if config.External.Email.Enabled && !config.Mailer.Autoconfirm {
 			if req.Method == "PUT" || req.Method == "POST" {
 				res := make(map[string]interface{})
-				bodyBytes, err := ioutil.ReadAll(req.Body)
+
+				bodyBytes, err := getBodyBytes(req)
 				if err != nil {
 					return c, internalServerError("Error invalid request body").WithInternalError(err)
 				}
-				req.Body.Close()
-				req.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
 
-				jsonDecoder := json.NewDecoder(bytes.NewBuffer(bodyBytes))
-				if err := jsonDecoder.Decode(&res); err != nil {
+				if err := json.Unmarshal(bodyBytes, &res); err != nil {
 					return c, badRequestError("Error invalid request body").WithInternalError(err)
 				}
 

--- a/api/provider/notion.go
+++ b/api/provider/notion.go
@@ -79,18 +79,23 @@ func (g notionProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 
 	client := &http.Client{Timeout: defaultTimeout}
 	resp, err := client.Do(req)
-
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("a %v error occurred with retrieving user from notion", resp.StatusCode)
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
-	json.Unmarshal(body, &u)
-	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(body, &u)
+	if err != nil {
+		return nil, err
+	}
 
 	if u.Bot.Owner.User.Person.Email == "" {
 		return nil, errors.New("unable to find email with notion provider")

--- a/api/provider/twitch.go
+++ b/api/provider/twitch.go
@@ -94,18 +94,24 @@ func (t twitchProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 
 	client := &http.Client{Timeout: defaultTimeout}
 	resp, err := client.Do(req)
-
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("a %v error occurred with retrieving user from twitch", resp.StatusCode)
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
-	json.Unmarshal(body, &u)
-	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, &u)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(u.Data) == 0 {
 		return nil, errors.New("unable to find user with twitch provider")

--- a/security/hcaptcha.go
+++ b/security/hcaptcha.go
@@ -65,7 +65,10 @@ func VerifyRequest(r *http.Request, secretKey string) (VerificationResult, error
 	if err != nil {
 		return UserRequestFailed, err
 	}
-	r.Body.Close()
+	if err := r.Body.Close(); err != nil {
+		return UserRequestFailed, err
+	}
+
 	// re-init body so downstream route handlers don't get borked
 	r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
 


### PR DESCRIPTION
Fixes some remaining `G104: Audit errors not checked` errors in the main codebase. The tests codebase has a ton of these, which should be OK when used in tests, so keeping G104 excluded there.