### PR TITLE
style: move test-only code under _test files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,11 @@ jobs:
         run: |
           set -x
           go vet ./...
+      - name: Check for unused code
+        run: |
+          set -x
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          make unused
       - name: Check gosec
         run: |
           set -x

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build: deps ## Build the binary.
 dev-deps: deps ## Install developer dependencies
 	@go install github.com/gobuffalo/pop/soda@latest
 	@go install github.com/securego/gosec/v2/cmd/gosec@latest
+	@go install honnef.co/go/tools/cmd/staticcheck@latest
 
 deps: ## Install dependencies.
 	@go mod download
@@ -35,6 +36,15 @@ vet: # Vet the code
 sec: # Check for security vulnerabilities
 	gosec -quiet $(CHECK_FILES)
 	gosec -quiet -tests -exclude=G104 $(CHECK_FILES)
+
+unused: # Look for unused code
+	@echo "Unused code:"
+	staticcheck -checks U1000 $(CHECK_FILES)
+	
+	@echo
+	
+	@echo "Code used only in _test.go (do move it in those files):"
+	staticcheck -checks U1000 -tests=false $(CHECK_FILES)
 
 dev: ## Run the development containers
 	docker-compose -f $(DEV_DOCKER_COMPOSE) up

--- a/api/context.go
+++ b/api/context.go
@@ -140,11 +140,6 @@ func getExternalReferrer(ctx context.Context) string {
 	return obj.(string)
 }
 
-// withFunctionHooks adds the provided function hooks to the context.
-func withFunctionHooks(ctx context.Context, hooks map[string][]string) context.Context {
-	return context.WithValue(ctx, functionHooksKey, hooks)
-}
-
 // getFunctionHooks reads the request ID from the context.
 func getFunctionHooks(ctx context.Context) map[string][]string {
 	obj := ctx.Value(functionHooksKey)

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -176,24 +176,6 @@ func isPrivateIP(ip net.IP) bool {
 	return false
 }
 
-func removeLocalhostFromPrivateIPBlock() *net.IPNet {
-	_, localhost, _ := net.ParseCIDR("127.0.0.0/8")
-
-	var localhostIndex int
-	for i := 0; i < len(privateIPBlocks); i++ {
-		if privateIPBlocks[i] == localhost {
-			localhostIndex = i
-		}
-	}
-	privateIPBlocks = append(privateIPBlocks[:localhostIndex], privateIPBlocks[localhostIndex+1:]...)
-
-	return localhost
-}
-
-func unshiftPrivateIPBlock(address *net.IPNet) {
-	privateIPBlocks = append([]*net.IPNet{address}, privateIPBlocks...)
-}
-
 type noLocalTransport struct {
 	inner  http.RoundTripper
 	errlog logrus.FieldLogger

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"net"
+)
+
+func removeLocalhostFromPrivateIPBlock() *net.IPNet {
+	_, localhost, _ := net.ParseCIDR("127.0.0.0/8")
+
+	var localhostIndex int
+	for i := 0; i < len(privateIPBlocks); i++ {
+		if privateIPBlocks[i] == localhost {
+			localhostIndex = i
+		}
+	}
+	privateIPBlocks = append(privateIPBlocks[:localhostIndex], privateIPBlocks[localhostIndex+1:]...)
+
+	return localhost
+}
+
+func unshiftPrivateIPBlock(address *net.IPNet) {
+	privateIPBlocks = append([]*net.IPNet{address}, privateIPBlocks...)
+}

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// withFunctionHooks adds the provided function hooks to the context.
+func withFunctionHooks(ctx context.Context, hooks map[string][]string) context.Context {
+	return context.WithValue(ctx, functionHooksKey, hooks)
+}
+
 func TestSignupHookSendInstanceID(t *testing.T) {
 	globalConfig, err := conf.LoadGlobal(apiTestConfig)
 	require.NoError(t, err)

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -2,7 +2,6 @@ package mailer
 
 import (
 	"net/url"
-	"regexp"
 
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
@@ -78,10 +77,4 @@ func getSiteURL(referrerURL, siteURL, filepath, fragment string) (string, error)
 	}
 	site.RawQuery = fragment
 	return site.String(), nil
-}
-
-var urlRegexp = regexp.MustCompile(`^https?://[^/]+`)
-
-func enforceRelativeURL(url string) string {
-	return urlRegexp.ReplaceAllString(url, "")
 }

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -1,10 +1,17 @@
 package mailer
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var urlRegexp = regexp.MustCompile(`^https?://[^/]+`)
+
+func enforceRelativeURL(url string) string {
+	return urlRegexp.ReplaceAllString(url, "")
+}
 
 func TestGetSiteURL(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Moves code used only in `_test.go` files, into such files, so they don't pollute the main binary.

Depends on: #637.