### PR TITLE
feat: Add provider_refresh_token query fragment

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -291,6 +291,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 		q := url.Values{}
 		q.Set("provider_token", providerAccessToken)
 		// Because not all providers give out a refresh token
+		// See corresponding OAuth2 spec: <https://www.rfc-editor.org/rfc/rfc6749.html#section-5.1>
 		if providerRefreshToken != "" {
 			q.Set("provider_refresh_token", providerRefreshToken)
 		}

--- a/api/external.go
+++ b/api/external.go
@@ -110,7 +110,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	providerType := getExternalProviderType(ctx)
 	var userData *provider.UserProvidedData
 	var providerAccessToken string
-	var providerRefreshToken string
+	var providerRefreshToken string = ""
 	if providerType == "twitter" {
 		// future OAuth1.0 providers will use this method
 		oAuthResponseData, err := a.oAuth1Callback(ctx, r, providerType)
@@ -119,7 +119,6 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 		}
 		userData = oAuthResponseData.userData
 		providerAccessToken = oAuthResponseData.token
-		providerRefreshToken = oAuthResponseData.refreshToken
 	} else {
 		oAuthResponseData, err := a.oAuthCallback(ctx, r, providerType)
 		if err != nil {

--- a/api/external_oauth.go
+++ b/api/external_oauth.go
@@ -14,8 +14,9 @@ import (
 
 // OAuthProviderData contains the userData and token returned by the oauth provider
 type OAuthProviderData struct {
-	userData *provider.UserProvidedData
-	token    string
+	userData     *provider.UserProvidedData
+	token        string
+	refreshToken string
 }
 
 // loadOAuthState parses the `state` query parameter as a JWS payload,
@@ -96,8 +97,9 @@ func (a *API) oAuthCallback(ctx context.Context, r *http.Request, providerType s
 	}
 
 	return &OAuthProviderData{
-		userData: userData,
-		token:    token.AccessToken,
+		userData:     userData,
+		token:        token.AccessToken,
+		refreshToken: token.RefreshToken,
 	}, nil
 }
 
@@ -134,8 +136,9 @@ func (a *API) oAuth1Callback(ctx context.Context, r *http.Request, providerType 
 	}
 
 	return &OAuthProviderData{
-		userData: userData,
-		token:    accessToken.Token,
+		userData:     userData,
+		token:        accessToken.Token,
+		refreshToken: "",
 	}, nil
 
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Retrieves the `ProviderRefreshToken` from the provider's OAuth response
* Pass the `ProviderRefreshToken` as `provider_refresh_token` in the query fragments when redirecting to SITE_URL

## What is the current behavior?

Currently the provider's refresh token is completely ignored and never passed to the client.

## What is the new behavior?

The provider's refresh token is now passed, **when it exists**, to the client as `provider_refresh_token` along the `provider_token`.

## Additional context

This feature should be backwards compatible, for a more coherent approach it could be possible to rename the current `provider_token` to `provider_access_token` but it would probably break current integrations.

Some of the OAuth providers have an expiry date on the access token they provide (e.g: Twitch). By passing the provider refresh token it allows developers to renew the provider token and build more easily and seamlessly on top of the provider's API.

This is a feature that has been requested last year already : https://github.com/supabase/gotrue-js/issues/131

Some of the providers don't pass a refresh_token because their access_token doesn't expire (example: Github Apps have a refresh token but Github OAuth apps don't). In this case I have added an if condition to not pass the refresh_token.
