### PR TITLE
feat: support docker file-based secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ COPY --from=build /go/src/github.com/netlify/gotrue/migrations /usr/local/etc/go
 ENV GOTRUE_DB_MIGRATIONS_PATH /usr/local/etc/gotrue/migrations
 
 USER netlify
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["gotrue"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# load secrets either from environment variables or files
+file_env 'DATABASE_URL'
+file_env 'GOTRUE_JWT_SECRET'
+file_env 'GOTRUE_SMTP_PASS'
+
+exec "${@}"
+


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gotrue/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
This PR is to add an entry point file `docker-entrypoint.sh` to Docker image, which will enable use of Docker file-based secrets as mentioned in https://github.com/supabase/supabase/issues/6014.

Currently this Docker image only supports environment variable based secrets, file-based secrets `*_FILE` are not supported but is suggested by Docker in https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
```
make build
make dev
```

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
add support for docker file-based secrets

