### PR TITLE
Add MFA Sessions Fields

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -49,8 +49,7 @@ type JWTConfiguration struct {
 
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
-	Enabled                 bool    `json:"mfa_enabled" default:"false"`
-	ChallengeExpiryDuration float64 `json:"challenge_expiry_duration" default:"300"`
+	ChallengeExpiryDuration float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 }
 
 // GlobalConfiguration holds all the configuration that applies to all instances.

--- a/migrations/20220811173540_add_sessions_table.up.sql
+++ b/migrations/20220811173540_add_sessions_table.up.sql
@@ -4,6 +4,9 @@ create table if not exists auth.sessions (
     user_id uuid not null,
     created_at timestamptz null,
     updated_at timestamptz null,
+    factor_id  text null,
+    amr_claims text [] null,
+
     constraint sessions_pkey primary key (id),
     constraint sessions_user_id_fkey foreign key (user_id) references auth.users(id) on delete cascade
 );

--- a/models/challenge.go
+++ b/models/challenge.go
@@ -54,7 +54,7 @@ func FindChallengesByFactorID(tx *storage.Connection, factorID string) ([]*Chall
 func (f *Challenge) Verify(tx *storage.Connection) error {
 	now := time.Now()
 	f.VerifiedAt = &now
-	return tx.UpdateOnly(f, "verifiedAt")
+	return tx.UpdateOnly(f, "verified_at")
 }
 
 func findChallenge(tx *storage.Connection, query string, args ...interface{}) (*Challenge, error) {
@@ -65,6 +65,5 @@ func findChallenge(tx *storage.Connection, query string, args ...interface{}) (*
 		}
 		return nil, errors.Wrap(err, "error finding challenge")
 	}
-
 	return obj, nil
 }

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -15,6 +15,8 @@ type Session struct {
 	UserID    uuid.UUID `json:"user_id" db:"user_id"`
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
+	FactorID  string `json:"factor_id" db:"factor_id"`
+	AMRClaims []string `json:"amr_claims" db:"amr_claims"`
 }
 
 func (Session) TableName() string {

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -15,8 +15,8 @@ type Session struct {
 	UserID    uuid.UUID `json:"user_id" db:"user_id"`
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
-	FactorID  string `json:"factor_id" db:"factor_id"`
-	AMRClaims []string `json:"amr_claims" db:"amr_claims"`
+	FactorID  string    `json:"factor_id" db:"factor_id"`
+	AMRClaims []string  `json:"amr_claims" db:"amr_claims"`
 }
 
 func (Session) TableName() string {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds `factor_id` and `amr_claims` to session. Also adds fixes suggested  by @kangmingtay.

Briefly, the changes are:

1. Remove MFA Enabled. Looks like I  actually didn't remove `MFA_Enabled`  -- this can be reintroduced in V2 since there's no need to explicitly enable.
2.  Move TOTP validation logic to be before the check for challenge expiry
3. Catches errors when saving factors


## What is the new behavior?

Error in saving factors/Challenges should show up

## Additional context

Random: Looks like someone filed a PR for [Global `split_words`](https://github.com/kelseyhightower/envconfig/pull/191) on envconfig. Don't think it's getting merged anytime soon though