### PR TITLE
style: remove old `.github/CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @netlify/opensource @netlify/backend


### PR DESCRIPTION
Inherited from Netlify, also the reason why code owners are not showing up in new PRs.