### PR TITLE
feat: use proper ip address

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	chimiddleware "github.com/go-chi/chi/middleware"
+	"github.com/netlify/gotrue/utilities"
 	"github.com/sirupsen/logrus"
 )
 
@@ -26,7 +27,7 @@ func (l *structuredLogger) NewLogEntry(r *http.Request) chimiddleware.LogEntry {
 		"component":   "api",
 		"method":      r.Method,
 		"path":        r.URL.Path,
-		"remote_addr": r.RemoteAddr,
+		"remote_addr": utilities.GetIPAddress(r),
 		"referer":     r.Referer(),
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
 	}

--- a/security/hcaptcha.go
+++ b/security/hcaptcha.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/netlify/gotrue/utilities"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -77,7 +78,7 @@ func VerifyRequest(r *http.Request, secretKey string) (VerificationResult, error
 	if err != nil || strings.TrimSpace(res.Security.Token) == "" {
 		return UserRequestFailed, errors.Wrap(err, "couldn't decode captcha info")
 	}
-	clientIP := strings.Split(r.RemoteAddr, ":")[0]
+	clientIP := utilities.GetIPAddress(r)
 	return verifyCaptchaCode(res.Security.Token, secretKey, clientIP)
 }
 

--- a/utilities/request.go
+++ b/utilities/request.go
@@ -1,0 +1,35 @@
+package utilities
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// GetIPAddress returns the real IP address of the HTTP request. It parses the
+// X-Forwarded-For header.
+func GetIPAddress(r *http.Request) string {
+	if r.Header != nil {
+		xForwardedFor := r.Header.Get("X-Forwarded-For")
+		if xForwardedFor != "" {
+			ips := strings.Split(xForwardedFor, ",")
+			for i := range ips {
+				ips[i] = strings.TrimSpace(ips[i])
+			}
+
+			for _, ip := range ips {
+				if ip != "" {
+					return ip
+				}
+			}
+		}
+	}
+
+	ipPort := r.RemoteAddr
+	ip, _, err := net.SplitHostPort(ipPort)
+	if err != nil {
+		return ipPort
+	}
+
+	return ip
+}

--- a/utilities/request_test.go
+++ b/utilities/request_test.go
@@ -1,0 +1,87 @@
+package utilities
+
+import (
+	"net/http"
+	tst "testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetIPAddress(t *tst.T) {
+	examples := []func(r *http.Request) string{
+		func(r *http.Request) string {
+			r.Header = nil
+			r.RemoteAddr = "127.0.0.1:8080"
+
+			return "127.0.0.1"
+		},
+
+		func(r *http.Request) string {
+			r.Header = nil
+			r.RemoteAddr = "incorrect"
+
+			return "incorrect"
+		},
+
+		func(r *http.Request) string {
+			r.Header = make(http.Header)
+			r.RemoteAddr = "127.0.0.1:8080"
+
+			return "127.0.0.1"
+		},
+
+		func(r *http.Request) string {
+			r.Header = make(http.Header)
+			r.RemoteAddr = "[::1]:8080"
+
+			return "::1"
+		},
+
+		func(r *http.Request) string {
+			r.Header = make(http.Header)
+			r.RemoteAddr = "127.0.0.1:8080"
+			r.Header.Add("X-Forwarded-For", "127.0.0.2")
+
+			return "127.0.0.2"
+		},
+
+		func(r *http.Request) string {
+			r.Header = make(http.Header)
+			r.RemoteAddr = "127.0.0.1:8080"
+			r.Header.Add("X-Forwarded-For", "127.0.0.2")
+
+			return "127.0.0.2"
+		},
+
+		func(r *http.Request) string {
+			r.Header = make(http.Header)
+			r.RemoteAddr = "127.0.0.1:8080"
+			r.Header.Add("X-Forwarded-For", "127.0.0.2,")
+
+			return "127.0.0.2"
+		},
+
+		func(r *http.Request) string {
+			r.Header = make(http.Header)
+			r.RemoteAddr = "127.0.0.1:8080"
+			r.Header.Add("X-Forwarded-For", "127.0.0.2,127.0.0.3")
+
+			return "127.0.0.2"
+		},
+
+		func(r *http.Request) string {
+			r.Header = make(http.Header)
+			r.RemoteAddr = "127.0.0.1:8080"
+			r.Header.Add("X-Forwarded-For", "::1,127.0.0.2")
+
+			return "::1"
+		},
+	}
+
+	for _, example := range examples {
+		req := &http.Request{}
+		expected := example(req)
+
+		require.Equal(t, GetIPAddress(req), expected)
+	}
+}


### PR DESCRIPTION
Uses the [`X-Forwarded-For`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) header to determine the proper origin of the HTTP request. Comes out of #582.