### PR TITLE
refactor: params.Metadata -> params.Data

### DIFF
--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -15,8 +15,8 @@ import (
 
 // MagicLinkParams holds the parameters for a magic link request
 type MagicLinkParams struct {
-	Email    string                 `json:"email"`
-	Metadata map[string]interface{} `json:"metadata"`
+	Email string                 `json:"email"`
+	Data  map[string]interface{} `json:"metadata"`
 }
 
 // MagicLink sends a recovery email
@@ -35,8 +35,8 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read verification params: %v", err)
 	}
 
-	if params.Metadata == nil {
-		params.Metadata = make(map[string]interface{})
+	if params.Data == nil {
+		params.Data = make(map[string]interface{})
 	}
 
 	if params.Email == "" {
@@ -59,7 +59,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 			signUpParams := &SignupParams{
 				Email:    params.Email,
 				Password: password,
-				Data:     params.Metadata,
+				Data:     params.Data,
 			}
 			newBodyContent, err := json.Marshal(signUpParams)
 			if err != nil {
@@ -76,7 +76,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 				}
 				newBodyContent := &SignupParams{
 					Email: params.Email,
-					Data:  params.Metadata,
+					Data:  params.Data,
 				}
 				metadata, err := json.Marshal(newBodyContent)
 				if err != nil {

--- a/api/otp.go
+++ b/api/otp.go
@@ -17,13 +17,13 @@ type OtpParams struct {
 	Email      string                 `json:"email"`
 	Phone      string                 `json:"phone"`
 	CreateUser bool                   `json:"create_user"`
-	Metadata   map[string]interface{} `json:"metadata"`
+	Data   map[string]interface{} `json:"data"`
 }
 
 // SmsParams contains the request body params for sms otp
 type SmsParams struct {
 	Phone    string                 `json:"phone"`
-	Metadata map[string]interface{} `json:"metadata"`
+	Data map[string]interface{} `json:"data"`
 }
 
 // Otp returns the MagicLink or SmsOtp handler based on the request body params
@@ -31,8 +31,8 @@ func (a *API) Otp(w http.ResponseWriter, r *http.Request) error {
 	params := &OtpParams{
 		CreateUser: true,
 	}
-	if params.Metadata == nil {
-		params.Metadata = make(map[string]interface{})
+	if params.Data == nil {
+		params.Data = make(map[string]interface{})
 	}
 
 	body, err := getBodyBytes(r)
@@ -82,8 +82,8 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read sms otp params: %v", err)
 	}
-	if params.Metadata == nil {
-		params.Metadata = make(map[string]interface{})
+	if params.Data == nil {
+		params.Data = make(map[string]interface{})
 	}
 
 	params.Phone, err = a.validatePhone(params.Phone)
@@ -105,7 +105,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 			signUpParams := &SignupParams{
 				Phone:    params.Phone,
 				Password: password,
-				Data:     params.Metadata,
+				Data:     params.Data,
 			}
 			newBodyContent, err := json.Marshal(signUpParams)
 			if err != nil {

--- a/api/otp.go
+++ b/api/otp.go
@@ -17,13 +17,13 @@ type OtpParams struct {
 	Email      string                 `json:"email"`
 	Phone      string                 `json:"phone"`
 	CreateUser bool                   `json:"create_user"`
-	Data   map[string]interface{} `json:"data"`
+	Data       map[string]interface{} `json:"data"`
 }
 
 // SmsParams contains the request body params for sms otp
 type SmsParams struct {
-	Phone    string                 `json:"phone"`
-	Data map[string]interface{} `json:"data"`
+	Phone string                 `json:"phone"`
+	Data  map[string]interface{} `json:"data"`
 }
 
 // Otp returns the MagicLink or SmsOtp handler based on the request body params

--- a/api/otp_test.go
+++ b/api/otp_test.go
@@ -51,7 +51,7 @@ func (ts *OtpTestSuite) TestOtp() {
 			OtpParams{
 				Email:      "test@example.com",
 				CreateUser: true,
-				Metadata: map[string]interface{}{
+				Data: map[string]interface{}{
 					"somedata": "metadata",
 				},
 			},


### PR DESCRIPTION
Renames the OTP param from Metadata to Data to be consistent with the `/signup` route.

TODOs: 
- [ ] Check and update corresponding GoTrue-js bindings 
- [ ] Check and update corresponding GoTrue-js types