### PR TITLE
ci: add temp. manual run for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Build and Release on Push to Master
 
 on:
+  workflow_dispatch:
+
   workflow_run:
     workflows: [Test]
     types: [completed]


### PR DESCRIPTION
For some reason the existing workflows are not running one after the other. This will allow us to manually dispatch a release on the `zerosessionidfix` branch.