### PR TITLE
refactor: remove auth schema prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The following are some basic commands. A full and up to date list of commands ca
 
 Start the containers as described above in an attached state with log output.
 
-``` bash
+```bash
 make dev
 ```
 
@@ -29,7 +29,7 @@ make dev
 
 Start the containers with a fresh database and run the project's tests.
 
-``` bash
+```bash
 make docker-test
 ```
 
@@ -37,7 +37,7 @@ make docker-test
 
 Remove both containers and their volumes. This removes any data associated with the containers.
 
-``` bash
+```bash
 make docker-clean
 ```
 
@@ -45,7 +45,7 @@ make docker-clean
 
 Fully rebuild the containers without using any cached layers.
 
-``` bash
+```bash
 make docker-build
 ```
 
@@ -118,7 +118,11 @@ To complete installation, you will:
 2. To install the PostgreSQL Docker image, run:
 
 ```
-./hack/postgresd.sh
+# Builds the postgres image
+docker-compose -f docker-compose-dev.yml build postgres
+
+# Runs the postgres container
+docker-compose -f docker-compose-dev.yml up postgres
 ```
 
 You may see a message like:
@@ -433,7 +437,7 @@ The following commands should help in setting up a database and running the test
 
 ```sh
 # Runs the database in a docker container
-$ ./hack/postgresd.sh
+$ docker-compose -f docker-compose-dev.yml up postgres
 
 # Applies the migrations to the database (requires soda cli)
 $ make migrate_test
@@ -452,9 +456,9 @@ In these examples, we change the port from 5432 to 7432.
 > Note: This is not recommended, but if you do, please do not check in changes.
 
 ```
-// file: postgresd.sh
-docker run --name gotrue_postgresql
--p 7432:5432 \ 👈 set the first value to your external facing port
+// file: docker-compose-dev.yml
+ports:
+  - 7432:5432 \ 👈 set the first value to your external facing port
 ```
 
 The port you customize here can them be used in the subsequent configuration:

--- a/Dockerfile.postgres.dev
+++ b/Dockerfile.postgres.dev
@@ -1,0 +1,8 @@
+FROM postgres:13
+WORKDIR /
+RUN pwd
+COPY init_postgres.sh /docker-entrypoint-initdb.d/init.sh
+RUN chmod +x /docker-entrypoint-initdb.d/init.sh
+EXPOSE 5432
+
+CMD ["postgres"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ features and capabilities.
 
 Create a `.env` file to store your own custom env vars. See [`example.env`](example.env)
 
-1. Start the local postgres database in a postgres container: `./hack/postgresd.sh`
+1. Start the local postgres database in a postgres container: `docker-compose -f docker-compose-dev.yml up postgres`
 2. Build the gotrue binary: `make build` . You should see an output like this:
 
 ```

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -67,6 +67,7 @@ func migrate(cmd *cobra.Command, args []string) {
 	}
 	deets.Options = map[string]string{
 		"migration_table_name": "schema_migrations",
+		"Namespace":            globalConfig.DB.Namespace,
 	}
 
 	db, err := pop.NewConnection(deets)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -29,9 +29,9 @@ type EmailProviderConfiguration struct {
 
 // DBConfiguration holds all the database related configuration.
 type DBConfiguration struct {
-	Driver string `json:"driver" required:"true"`
-	URL    string `json:"url" envconfig:"DATABASE_URL" required:"true"`
-
+	Driver    string `json:"driver" required:"true"`
+	URL       string `json:"url" envconfig:"DATABASE_URL" required:"true"`
+	Namespace string `json:"namespace" envconfig:"NAMESPACE" default:"auth"`
 	// MaxPoolSize defaults to 0 (unlimited).
 	MaxPoolSize    int    `json:"max_pool_size" split_words:"true"`
 	MigrationsPath string `json:"migrations_path" split_words:"true" default:"./migrations"`

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -31,7 +31,7 @@ type EmailProviderConfiguration struct {
 type DBConfiguration struct {
 	Driver    string `json:"driver" required:"true"`
 	URL       string `json:"url" envconfig:"DATABASE_URL" required:"true"`
-	Namespace string `json:"namespace" envconfig:"NAMESPACE" default:"auth"`
+	Namespace string `json:"namespace" envconfig:"DB_NAMESPACE" default:"auth"`
 	// MaxPoolSize defaults to 0 (unlimited).
 	MaxPoolSize    int    `json:"max_pool_size" split_words:"true"`
 	MigrationsPath string `json:"migrations_path" split_words:"true" default:"./migrations"`

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -28,6 +28,6 @@ services:
       - POSTGRES_PASSWORD=root
       - POSTGRES_DB=postgres
       # sets the schema name, this should match the `NAMESPACE` env var set in your .env file
-      - NAMESPACE=auth 
+      - DB_NAMESPACE=auth 
 volumes:
   postgres_data:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,17 +15,19 @@ services:
       - ./:/go/src/github.com/netlify/gotrue
     command: CompileDaemon --build="make build" --directory=/go/src/github.com/netlify/gotrue --recursive=true -pattern="(.+\.go|.+\.env)" -exclude=gotrue -exclude=gotrue-arm64 -exclude=.env --command="/go/src/github.com/netlify/gotrue/gotrue -c=.env.docker"
   postgres:
-    image: postgres:13
-    container_name: postgres
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres.dev
+    container_name: gotrue_postgres
     ports:
       - '5432:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ${PWD}/hack/init_postgres.sql:/docker-entrypoint-initdb.d/init.sql
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=root
       - POSTGRES_DB=postgres
-
+      # sets the schema name, this should match the `NAMESPACE` env var set in your .env file
+      - NAMESPACE=auth 
 volumes:
   postgres_data:

--- a/init_postgres.sh
+++ b/init_postgres.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+	CREATE USER supabase_admin LOGIN CREATEROLE CREATEDB REPLICATION BYPASSRLS;
+
+    -- Supabase super admin
+    CREATE USER supabase_auth_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION PASSWORD 'root';
+    CREATE SCHEMA IF NOT EXISTS $NAMESPACE AUTHORIZATION supabase_auth_admin;
+    GRANT CREATE ON DATABASE postgres TO supabase_auth_admin;
+    ALTER USER supabase_auth_admin SET search_path = '$NAMESPACE';
+EOSQL

--- a/init_postgres.sh
+++ b/init_postgres.sh
@@ -6,7 +6,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
 
     -- Supabase super admin
     CREATE USER supabase_auth_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION PASSWORD 'root';
-    CREATE SCHEMA IF NOT EXISTS $NAMESPACE AUTHORIZATION supabase_auth_admin;
+    CREATE SCHEMA IF NOT EXISTS $DB_NAMESPACE AUTHORIZATION supabase_auth_admin;
     GRANT CREATE ON DATABASE postgres TO supabase_auth_admin;
-    ALTER USER supabase_auth_admin SET search_path = '$NAMESPACE';
+    ALTER USER supabase_auth_admin SET search_path = '$DB_NAMESPACE';
 EOSQL

--- a/migrations/00_init_auth_schema.up.sql
+++ b/migrations/00_init_auth_schema.up.sql
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS {{ index .Options "Namespace" }}.audit_log_entries (
 	created_at timestamptz NULL,
 	CONSTRAINT audit_log_entries_pkey PRIMARY KEY (id)
 );
-CREATE INDEX IF NOT EXISTS audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
+CREATE INDEX IF NOT EXISTS audit_logs_instance_id_idx ON {{ index .Options "Namespace" }}.audit_log_entries USING btree (instance_id);
 comment on table {{ index .Options "Namespace" }}.audit_log_entries is 'Auth: Audit trail for user actions.';
 
 -- auth.schema_migrations definition

--- a/migrations/00_init_auth_schema.up.sql
+++ b/migrations/00_init_auth_schema.up.sql
@@ -1,6 +1,6 @@
 -- auth.users definition
 
-CREATE TABLE IF NOT EXISTS auth.users (
+CREATE TABLE IF NOT EXISTS {{ index .Options "Namespace" }}.users (
 	instance_id uuid NULL,
 	id uuid NOT NULL UNIQUE,
 	aud varchar(255) NULL,
@@ -24,13 +24,13 @@ CREATE TABLE IF NOT EXISTS auth.users (
 	updated_at timestamptz NULL,
 	CONSTRAINT users_pkey PRIMARY KEY (id)
 );
-CREATE INDEX IF NOT EXISTS users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
-CREATE INDEX IF NOT EXISTS users_instance_id_idx ON auth.users USING btree (instance_id);
-comment on table auth.users is 'Auth: Stores user login data within a secure schema.';
+CREATE INDEX IF NOT EXISTS users_instance_id_email_idx ON {{ index .Options "Namespace" }}.users USING btree (instance_id, email);
+CREATE INDEX IF NOT EXISTS users_instance_id_idx ON {{ index .Options "Namespace" }}.users USING btree (instance_id);
+comment on table {{ index .Options "Namespace" }}.users is 'Auth: Stores user login data within a secure schema.';
 
 -- auth.refresh_tokens definition
 
-CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
+CREATE TABLE IF NOT EXISTS {{ index .Options "Namespace" }}.refresh_tokens (
 	instance_id uuid NULL,
 	id bigserial NOT NULL,
 	"token" varchar(255) NULL,
@@ -40,14 +40,14 @@ CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
 	updated_at timestamptz NULL,
 	CONSTRAINT refresh_tokens_pkey PRIMARY KEY (id)
 );
-CREATE INDEX IF NOT EXISTS refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
-CREATE INDEX IF NOT EXISTS refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
-CREATE INDEX IF NOT EXISTS refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
-comment on table auth.refresh_tokens is 'Auth: Store of tokens used to refresh JWT tokens once they expire.';
+CREATE INDEX IF NOT EXISTS refresh_tokens_instance_id_idx ON {{ index .Options "Namespace" }}.refresh_tokens USING btree (instance_id);
+CREATE INDEX IF NOT EXISTS refresh_tokens_instance_id_user_id_idx ON {{ index .Options "Namespace" }}.refresh_tokens USING btree (instance_id, user_id);
+CREATE INDEX IF NOT EXISTS refresh_tokens_token_idx ON {{ index .Options "Namespace" }}.refresh_tokens USING btree (token);
+comment on table {{ index .Options "Namespace" }}.refresh_tokens is 'Auth: Store of tokens used to refresh JWT tokens once they expire.';
 
 -- auth.instances definition
 
-CREATE TABLE IF NOT EXISTS auth.instances (
+CREATE TABLE IF NOT EXISTS {{ index .Options "Namespace" }}.instances (
 	id uuid NOT NULL,
 	uuid uuid NULL,
 	raw_base_config text NULL,
@@ -55,11 +55,11 @@ CREATE TABLE IF NOT EXISTS auth.instances (
 	updated_at timestamptz NULL,
 	CONSTRAINT instances_pkey PRIMARY KEY (id)
 );
-comment on table auth.instances is 'Auth: Manages users across multiple sites.';
+comment on table {{ index .Options "Namespace" }}.instances is 'Auth: Manages users across multiple sites.';
 
 -- auth.audit_log_entries definition
 
-CREATE TABLE IF NOT EXISTS auth.audit_log_entries (
+CREATE TABLE IF NOT EXISTS {{ index .Options "Namespace" }}.audit_log_entries (
 	instance_id uuid NULL,
 	id uuid NOT NULL,
 	payload json NULL,
@@ -67,22 +67,22 @@ CREATE TABLE IF NOT EXISTS auth.audit_log_entries (
 	CONSTRAINT audit_log_entries_pkey PRIMARY KEY (id)
 );
 CREATE INDEX IF NOT EXISTS audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
-comment on table auth.audit_log_entries is 'Auth: Audit trail for user actions.';
+comment on table {{ index .Options "Namespace" }}.audit_log_entries is 'Auth: Audit trail for user actions.';
 
 -- auth.schema_migrations definition
 
-CREATE TABLE IF NOT EXISTS auth.schema_migrations (
+CREATE TABLE IF NOT EXISTS {{ index .Options "Namespace" }}.schema_migrations (
 	"version" varchar(255) NOT NULL,
 	CONSTRAINT schema_migrations_pkey PRIMARY KEY ("version")
 );
 comment on table auth.schema_migrations is 'Auth: Manages updates to the auth system.';
 		
 -- Gets the User ID from the request cookie
-create or replace function auth.uid() returns uuid as $$
+create or replace function {{ index .Options "Namespace" }}.uid() returns uuid as $$
   select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
 $$ language sql stable;
 
 -- Gets the User ID from the request cookie
-create or replace function auth.role() returns text as $$
+create or replace function {{ index .Options "Namespace" }}.role() returns text as $$
   select nullif(current_setting('request.jwt.claim.role', true), '')::text;
 $$ language sql stable;

--- a/migrations/20210710035447_alter_users.up.sql
+++ b/migrations/20210710035447_alter_users.up.sql
@@ -1,6 +1,6 @@
 -- alter user schema
 
-ALTER TABLE auth.users 
+ALTER TABLE {{ index .Options "Namespace" }}.users 
 ADD COLUMN IF NOT EXISTS phone VARCHAR(15) NULL UNIQUE DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS phone_confirmed_at timestamptz NULL DEFAULT NULL,
 ADD COLUMN IF NOT EXISTS phone_change VARCHAR(15) NULL DEFAULT '',
@@ -11,9 +11,9 @@ DO $$
 BEGIN
   IF NOT EXISTS(SELECT *
     FROM information_schema.columns
-    WHERE table_schema = 'auth' and table_name='users' and column_name='email_confirmed_at')
+    WHERE table_schema = '{{ index .Options "Namespace" }}' and table_name='users' and column_name='email_confirmed_at')
   THEN
-      ALTER TABLE "auth"."users" RENAME COLUMN "confirmed_at" TO "email_confirmed_at";
+      ALTER TABLE "{{ index .Options "Namespace" }}"."users" RENAME COLUMN "confirmed_at" TO "email_confirmed_at";
   END IF;
 END $$;
 

--- a/migrations/20210722035447_adds_confirmed_at.up.sql
+++ b/migrations/20210722035447_adds_confirmed_at.up.sql
@@ -1,4 +1,4 @@
 -- adds confirmed at
 
-ALTER TABLE auth.users
+ALTER TABLE {{ index .Options "Namespace" }}.users
 ADD COLUMN IF NOT EXISTS confirmed_at timestamptz GENERATED ALWAYS AS (LEAST (users.email_confirmed_at, users.phone_confirmed_at)) STORED;

--- a/migrations/20210730183235_add_email_change_confirmed.up.sql
+++ b/migrations/20210730183235_add_email_change_confirmed.up.sql
@@ -1,6 +1,6 @@
 -- adds email_change_confirmed
 
-ALTER TABLE auth.users
+ALTER TABLE {{ index .Options "Namespace" }}.users
 ADD COLUMN IF NOT EXISTS email_change_token_current varchar(255) null DEFAULT '', 
 ADD COLUMN IF NOT EXISTS email_change_confirm_status smallint DEFAULT 0 CHECK (email_change_confirm_status >= 0 AND email_change_confirm_status <= 2);
 
@@ -8,8 +8,8 @@ DO $$
 BEGIN
   IF NOT EXISTS(SELECT *
     FROM information_schema.columns
-    WHERE table_schema = 'auth' and table_name='users' and column_name='email_change_token_new')
+    WHERE table_schema = '{{ index .Options "Namespace" }}' and table_name='users' and column_name='email_change_token_new')
   THEN
-      ALTER TABLE "auth"."users" RENAME COLUMN "email_change_token" TO "email_change_token_new";
+      ALTER TABLE "{{ index .Options "Namespace" }}"."users" RENAME COLUMN "email_change_token" TO "email_change_token_new";
   END IF;
 END $$;

--- a/migrations/20210909172000_create_identities_table.up.sql
+++ b/migrations/20210909172000_create_identities_table.up.sql
@@ -1,6 +1,6 @@
 -- adds identities table 
 
-CREATE TABLE IF NOT EXISTS auth.identities (
+CREATE TABLE IF NOT EXISTS {{ index .Options "Namespace" }}.identities (
     id text NOT NULL,
     user_id uuid NOT NULL,
     identity_data JSONB NOT NULL,
@@ -9,6 +9,6 @@ CREATE TABLE IF NOT EXISTS auth.identities (
     created_at timestamptz NULL,
     updated_at timestamptz NULL,
     CONSTRAINT identities_pkey PRIMARY KEY (provider, id),
-    CONSTRAINT identities_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE
+    CONSTRAINT identities_user_id_fkey FOREIGN KEY (user_id) REFERENCES {{ index .Options "Namespace" }}.users(id) ON DELETE CASCADE
 );
-COMMENT ON TABLE auth.identities is 'Auth: Stores identities associated to a user.';
+COMMENT ON TABLE {{ index .Options "Namespace" }}.identities is 'Auth: Stores identities associated to a user.';

--- a/migrations/20210927181326_add_refresh_token_parent.up.sql
+++ b/migrations/20210927181326_add_refresh_token_parent.up.sql
@@ -1,22 +1,22 @@
 -- adds parent column
 
-ALTER TABLE auth.refresh_tokens
+ALTER TABLE {{ index .Options "Namespace" }}.refresh_tokens
 ADD COLUMN IF NOT EXISTS parent varchar(255) NULL;
 
 DO $$
 BEGIN
   IF NOT EXISTS(SELECT *
     FROM information_schema.constraint_column_usage
-    WHERE table_schema = 'auth' and table_name='refresh_tokens' and constraint_name='refresh_tokens_token_unique')
+    WHERE table_schema = '{{ index .Options "Namespace" }}' and table_name='refresh_tokens' and constraint_name='refresh_tokens_token_unique')
   THEN
-      ALTER TABLE "auth"."refresh_tokens" ADD CONSTRAINT refresh_tokens_token_unique UNIQUE ("token");
+      ALTER TABLE "{{ index .Options "Namespace" }}"."refresh_tokens" ADD CONSTRAINT refresh_tokens_token_unique UNIQUE ("token");
   END IF;
 
   IF NOT EXISTS(SELECT *
     FROM information_schema.constraint_column_usage
-    WHERE table_schema = 'auth' and table_name='refresh_tokens' and constraint_name='refresh_tokens_parent_fkey')
+    WHERE table_schema = '{{ index .Options "Namespace" }}' and table_name='refresh_tokens' and constraint_name='refresh_tokens_parent_fkey')
   THEN
-      ALTER TABLE "auth"."refresh_tokens" ADD CONSTRAINT refresh_tokens_parent_fkey FOREIGN KEY (parent) REFERENCES auth.refresh_tokens("token");
+      ALTER TABLE "{{ index .Options "Namespace" }}"."refresh_tokens" ADD CONSTRAINT refresh_tokens_parent_fkey FOREIGN KEY (parent) REFERENCES {{ index .Options "Namespace" }}.refresh_tokens("token");
   END IF;
 
   CREATE INDEX IF NOT EXISTS refresh_tokens_parent_idx ON refresh_tokens USING btree (parent);

--- a/migrations/20211124214934_update_auth_functions.up.sql
+++ b/migrations/20211124214934_update_auth_functions.up.sql
@@ -1,6 +1,6 @@
 -- update auth functions
 
-create or replace function auth.uid() 
+create or replace function {{ index .Options "Namespace" }}.uid() 
 returns uuid 
 language sql stable
 as $$
@@ -11,7 +11,7 @@ as $$
 	)::uuid
 $$;
 
-create or replace function auth.role() 
+create or replace function {{ index .Options "Namespace" }}.role() 
 returns text 
 language sql stable
 as $$
@@ -22,7 +22,7 @@ as $$
 	)::text
 $$;
 
-create or replace function auth.email() 
+create or replace function {{ index .Options "Namespace" }}.email() 
 returns text 
 language sql stable
 as $$

--- a/migrations/20211202183645_update_auth_uid.up.sql
+++ b/migrations/20211202183645_update_auth_uid.up.sql
@@ -1,6 +1,6 @@
 -- update auth.uid()
 
-create or replace function auth.uid()
+create or replace function {{ index .Options "Namespace" }}.uid()
 returns uuid
 language sql stable
 as $$

--- a/migrations/20220114185340_add_banned_until.up.sql
+++ b/migrations/20220114185340_add_banned_until.up.sql
@@ -1,4 +1,4 @@
 -- adds banned_until column
 
-ALTER TABLE auth.users
+ALTER TABLE {{ index .Options "Namespace" }}.users
 ADD COLUMN IF NOT EXISTS banned_until timestamptz NULL;

--- a/migrations/20220224000811_update_auth_functions.up.sql
+++ b/migrations/20220224000811_update_auth_functions.up.sql
@@ -1,6 +1,6 @@
 -- update auth functions
 
-create or replace function auth.uid() 
+create or replace function {{ index .Options "Namespace" }}.uid() 
 returns uuid 
 language sql stable
 as $$
@@ -11,7 +11,7 @@ as $$
 	)::uuid
 $$;
 
-create or replace function auth.role() 
+create or replace function {{ index .Options "Namespace" }}.role() 
 returns text 
 language sql stable
 as $$
@@ -22,7 +22,7 @@ as $$
 	)::text
 $$;
 
-create or replace function auth.email() 
+create or replace function {{ index .Options "Namespace" }}.email() 
 returns text 
 language sql stable
 as $$

--- a/migrations/20220323170000_add_user_reauthentication.up.sql
+++ b/migrations/20220323170000_add_user_reauthentication.up.sql
@@ -1,5 +1,5 @@
 -- adds reauthentication_token and reauthentication_sent_at 
 
-ALTER TABLE auth.users
+ALTER TABLE {{ index .Options "Namespace" }}.users
 ADD COLUMN IF NOT EXISTS reauthentication_token varchar(255) null default '',
 ADD COLUMN IF NOT EXISTS reauthentication_sent_at timestamptz null default null;

--- a/migrations/20220429102000_add_unique_idx.up.sql
+++ b/migrations/20220429102000_add_unique_idx.up.sql
@@ -7,8 +7,8 @@ DROP INDEX IF EXISTS email_change_token_current_idx;
 DROP INDEX IF EXISTS email_change_token_new_idx;
 DROP INDEX IF EXISTS reauthentication_token_idx;
 
-CREATE UNIQUE INDEX IF NOT EXISTS confirmation_token_idx ON auth.users USING btree (confirmation_token) WHERE confirmation_token !~ '^[0-9 ]*$';
-CREATE UNIQUE INDEX IF NOT EXISTS recovery_token_idx ON auth.users USING btree (recovery_token) WHERE recovery_token !~ '^[0-9 ]*$';
-CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_current_idx ON auth.users USING btree (email_change_token_current) WHERE email_change_token_current !~ '^[0-9 ]*$';
-CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_new_idx ON auth.users USING btree (email_change_token_new) WHERE email_change_token_new !~ '^[0-9 ]*$';
-CREATE UNIQUE INDEX IF NOT EXISTS reauthentication_token_idx ON auth.users USING btree (reauthentication_token) WHERE reauthentication_token !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS confirmation_token_idx ON {{ index .Options "Namespace" }}.users USING btree (confirmation_token) WHERE confirmation_token !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS recovery_token_idx ON {{ index .Options "Namespace" }}.users USING btree (recovery_token) WHERE recovery_token !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_current_idx ON {{ index .Options "Namespace" }}.users USING btree (email_change_token_current) WHERE email_change_token_current !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS email_change_token_new_idx ON {{ index .Options "Namespace" }}.users USING btree (email_change_token_new) WHERE email_change_token_new !~ '^[0-9 ]*$';
+CREATE UNIQUE INDEX IF NOT EXISTS reauthentication_token_idx ON {{ index .Options "Namespace" }}.users USING btree (reauthentication_token) WHERE reauthentication_token !~ '^[0-9 ]*$';

--- a/migrations/20220531120530_add_auth_jwt_function.up.sql
+++ b/migrations/20220531120530_add_auth_jwt_function.up.sql
@@ -1,10 +1,10 @@
 -- add auth.jwt function
 
-comment on function auth.uid() is 'Deprecated. Use auth.jwt() -> ''sub'' instead.';
-comment on function auth.role() is 'Deprecated. Use auth.jwt() -> ''role'' instead.';
-comment on function auth.email() is 'Deprecated. Use auth.jwt() -> ''email'' instead.';
+comment on function {{ index .Options "Namespace" }}.uid() is 'Deprecated. Use auth.jwt() -> ''sub'' instead.';
+comment on function {{ index .Options "Namespace" }}.role() is 'Deprecated. Use auth.jwt() -> ''role'' instead.';
+comment on function {{ index .Options "Namespace" }}.email() is 'Deprecated. Use auth.jwt() -> ''email'' instead.';
 
-create or replace function auth.jwt()
+create or replace function {{ index .Options "Namespace" }}.jwt()
 returns jsonb
 language sql stable
 as $$

--- a/migrations/20220614074223_add_ip_address_to_audit_log.postgres.up.sql
+++ b/migrations/20220614074223_add_ip_address_to_audit_log.postgres.up.sql
@@ -1,3 +1,3 @@
 -- Add IP Address to audit log
-ALTER TABLE auth.audit_log_entries
+ALTER TABLE {{ index .Options "Namespace" }}.audit_log_entries
 ADD COLUMN IF NOT EXISTS ip_address VARCHAR(64) NOT NULL DEFAULT '';

--- a/migrations/20220811173540_add_sessions_table.up.sql
+++ b/migrations/20220811173540_add_sessions_table.up.sql
@@ -1,23 +1,23 @@
 -- Add session_id column to refresh_tokens table
-create table if not exists auth.sessions (
+create table if not exists {{ index .Options "Namespace" }}.sessions (
     id uuid not null,
     user_id uuid not null,
     created_at timestamptz null,
     updated_at timestamptz null,
     constraint sessions_pkey primary key (id),
-    constraint sessions_user_id_fkey foreign key (user_id) references auth.users(id) on delete cascade
+    constraint sessions_user_id_fkey foreign key (user_id) references {{ index .Options "Namespace" }}.users(id) on delete cascade
 );
-comment on table auth.sessions is 'Auth: Stores session data associated to a user.';
+comment on table {{ index .Options "Namespace" }}.sessions is 'Auth: Stores session data associated to a user.';
 
-alter table auth.refresh_tokens
+alter table {{ index .Options "Namespace" }}.refresh_tokens
 add column if not exists session_id uuid null;
 
 do $$
 begin
   if not exists(select *
     from information_schema.constraint_column_usage
-    where table_schema = 'auth' and table_name='sessions' and constraint_name='refresh_tokens_session_id_fkey')
+    where table_schema = '{{ index .Options "Namespace" }}' and table_name='sessions' and constraint_name='refresh_tokens_session_id_fkey')
   then
-      alter table "auth"."refresh_tokens" add constraint refresh_tokens_session_id_fkey foreign key (session_id) references auth.sessions(id) on delete cascade;
+      alter table "{{ index .Options "Namespace" }}"."refresh_tokens" add constraint refresh_tokens_session_id_fkey foreign key (session_id) references {{ index .Options "Namespace" }}.sessions(id) on delete cascade;
   end if;
 END $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Supersedes #553 without relying on postgres search path, fixes #185
* This change allows us to move away from hardcoding the auth schema prefix in the migrations and instead defer to use the `NAMESPACE` env var
* Since pop allows for go template strings in `.sql` files when running migrations, we can use `{{ index .Options "Namespace" }}` to specify the schema name in the migration file
