### PR TITLE
ci: add release for mfa_v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
     types: [completed]
     branches:
       - master
-      - mfa
+      - mfa_v1
       - zerosessionidfix
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - mfa
+      - mfa_v1
       - saml
       - zerosessionidfix
     tags: ['*']

--- a/.releaserc
+++ b/.releaserc
@@ -2,7 +2,7 @@
   "branches": [
     "master",
     {
-        "name": "mfa",
+        "name": "mfa_v1",
         "prerelease": true
     },
     {


### PR DESCRIPTION
We will be using the `mfa_v1` branch instead of the `mfa` branch. The `mfa_v1` only contains the vanilla enroll and verify flow and does not include recovery codes