### PR TITLE
refactor: deprecate io/ioutil in favour of io

### DIFF
--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -36,7 +36,7 @@ func TestSignupHookSendInstanceID(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		defer squash(r.Body.Close)
-		raw, err := ioutil.ReadAll(r.Body)
+		raw, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		data := map[string]interface{}{}
@@ -77,7 +77,7 @@ func TestSignupHookFromClaims(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		defer squash(r.Body.Close)
-		raw, err := ioutil.ReadAll(r.Body)
+		raw, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		data := map[string]interface{}{}

--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -65,7 +65,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 			if err != nil {
 				return badRequestError("Could not parse metadata: %v", err)
 			}
-			r.Body = ioutil.NopCloser(strings.NewReader(string(newBodyContent)))
+			r.Body = io.NopCloser(strings.NewReader(string(newBodyContent)))
 			r.ContentLength = int64(len(string(newBodyContent)))
 
 			fakeResponse := &responseStub{}
@@ -82,7 +82,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 				if err != nil {
 					return badRequestError("Could not parse metadata: %v", err)
 				}
-				r.Body = ioutil.NopCloser(bytes.NewReader(metadata))
+				r.Body = io.NopCloser(bytes.NewReader(metadata))
 				return a.MagicLink(w, r)
 			}
 			// otherwise confirmation email already contains 'magic link'

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -89,7 +89,7 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaValid() {
 		afterCtx, err := ts.API.verifyCaptcha(w, req)
 		require.NoError(ts.T(), err)
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		require.NoError(ts.T(), err)
 
 		// re-initialize buffer

--- a/api/provider/notion.go
+++ b/api/provider/notion.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/netlify/gotrue/conf"
@@ -88,7 +88,7 @@ func (g notionProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 		return nil, fmt.Errorf("a %v error occurred with retrieving user from notion", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/api/provider/provider.go
+++ b/api/provider/provider.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -126,9 +126,9 @@ func makeRequest(ctx context.Context, tok *oauth2.Token, g *oauth2.Config, url s
 	}
 	defer res.Body.Close()
 
-	bodyBytes, _ := ioutil.ReadAll(res.Body)
+	bodyBytes, _ := io.ReadAll(res.Body)
 	defer res.Body.Close()
-	res.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+	res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		return httpError(res.StatusCode, string(bodyBytes))

--- a/api/provider/twitch.go
+++ b/api/provider/twitch.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -103,7 +103,7 @@ func (t twitchProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 		return nil, fmt.Errorf("a %v error occurred with retrieving user from twitch", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -84,7 +84,7 @@ func (t TwitterProvider) FetchUserData(ctx context.Context, tok *oauth.AccessTok
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return &UserProvidedData{}, fmt.Errorf("a %v error occurred with retrieving user from twitter", resp.StatusCode)
 	}
-	bits, err := ioutil.ReadAll(resp.Body)
+	bits, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -89,7 +89,7 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 		signature := r.Header.Get("x-webhook-signature")
 		p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}
 		claims := new(jwt.StandardClaims)
-		token, err := p.ParseWithClaims(signature, claims, func(token *jwt.Token) (interface{}, error) {
+		token, _ := p.ParseWithClaims(signature, claims, func(token *jwt.Token) (interface{}, error) {
 			return []byte(ts.Config.Webhook.Secret), nil
 		})
 		assert.True(token.Valid)
@@ -100,7 +100,7 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 		// verify the contents
 
 		defer squash(r.Body.Close)
-		raw, err := ioutil.ReadAll(r.Body)
+		raw, err := io.ReadAll(r.Body)
 		require.NoError(err)
 		data := map[string]interface{}{}
 		require.NoError(json.Unmarshal(raw, &data))

--- a/api/token.go
+++ b/api/token.go
@@ -445,7 +445,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 				if terr != nil {
 					return terr
 				}
-				if identity, terr = a.createNewIdentity(tx, user, params.Provider, claims); terr != nil {
+				if _, terr = a.createNewIdentity(tx, user, params.Provider, claims); terr != nil {
 					return terr
 				}
 			} else {

--- a/api/verify.go
+++ b/api/verify.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// indicates that a user should be redirected due to an error
-	redirectWithQueryError = errors.New("redirect user")
+	errRedirectWithQuery = errors.New("redirect user")
 )
 
 const (
@@ -426,13 +426,13 @@ func (a *API) verifyEmailLink(ctx context.Context, conn *storage.Connection, par
 
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			return nil, expiredTokenError("Email link is invalid or has expired").WithInternalError(redirectWithQueryError)
+			return nil, expiredTokenError("Email link is invalid or has expired").WithInternalError(errRedirectWithQuery)
 		}
 		return nil, internalServerError("Database error finding user from email link").WithInternalError(err)
 	}
 
 	if user.IsBanned() {
-		return nil, unauthorizedError("Error confirming user").WithInternalError(redirectWithQueryError)
+		return nil, unauthorizedError("Error confirming user").WithInternalError(errRedirectWithQuery)
 	}
 
 	var isExpired bool
@@ -446,7 +446,7 @@ func (a *API) verifyEmailLink(ctx context.Context, conn *storage.Connection, par
 	}
 
 	if isExpired {
-		return nil, expiredTokenError("Email link is invalid or has expired").WithInternalError(redirectWithQueryError)
+		return nil, expiredTokenError("Email link is invalid or has expired").WithInternalError(errRedirectWithQuery)
 	}
 	return user, nil
 }
@@ -489,13 +489,13 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			return nil, notFoundError(err.Error()).WithInternalError(redirectWithQueryError)
+			return nil, notFoundError(err.Error()).WithInternalError(errRedirectWithQuery)
 		}
 		return nil, internalServerError("Database error finding user").WithInternalError(err)
 	}
 
 	if user.IsBanned() {
-		return nil, unauthorizedError("Error confirming user").WithInternalError(redirectWithQueryError)
+		return nil, unauthorizedError("Error confirming user").WithInternalError(errRedirectWithQuery)
 	}
 
 	var isValid bool
@@ -536,7 +536,7 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 	}
 
 	if !isValid || err != nil {
-		return nil, expiredTokenError("Token has expired or is invalid").WithInternalError(redirectWithQueryError)
+		return nil, expiredTokenError("Token has expired or is invalid").WithInternalError(errRedirectWithQuery)
 	}
 	return user, nil
 }

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -274,7 +274,7 @@ func (ts *VerifyTestSuite) TestInvalidOtp() {
 			w := httptest.NewRecorder()
 			ts.API.handler.ServeHTTP(w, req)
 
-			b, err := ioutil.ReadAll(w.Body)
+			b, err := io.ReadAll(w.Body)
 			require.NoError(ts.T(), err)
 			var resp ResponseBody
 			err = json.Unmarshal(b, &resp)

--- a/security/hcaptcha.go
+++ b/security/hcaptcha.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -62,7 +62,7 @@ func VerifyRequest(r *http.Request, secretKey string) (VerificationResult, error
 		return SuccessfullyVerified, nil
 	}
 	res := GotrueRequest{}
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return UserRequestFailed, err
 	}
@@ -71,7 +71,7 @@ func VerifyRequest(r *http.Request, secretKey string) (VerificationResult, error
 	}
 
 	// re-init body so downstream route handlers don't get borked
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	jsonDecoder := json.NewDecoder(bytes.NewBuffer(bodyBytes))
 	err = jsonDecoder.Decode(&res)


### PR DESCRIPTION
## What kind of change does this PR introduce?
Patched some static check errors which came up while editing another branch.

We are now on Go 1.18  which is past Go 1.16 in which [`io/ioutil` has been deprecated](https://go.dev/doc/go1.16#ioutil)  -- the recommendation is that users use `io` instead. As such, this PR aims to patch this as per static check errors that were showing up.

Also took the recommendation to user `errFoo` instead of `redirectWithQueryError` and adjusted the error name accordingly. 

