### PR TITLE
refactor: patch static check errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,11 @@ jobs:
         run: |
           set -x
           go vet ./...
-      - name: Check for unused code
+      - name: Run static check
         run: |
           set -x
           go install honnef.co/go/tools/cmd/staticcheck@latest
-          make unused
+          make static
       - name: Check gosec
         run: |
           set -x

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DEV_DOCKER_COMPOSE:=docker-compose-dev.yml
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-all: vet sec unused build ## Run the tests and build the binary.
+all: vet sec static build ## Run the tests and build the binary.
 
 build: deps ## Build the binary.
 	go build $(FLAGS)
@@ -45,6 +45,8 @@ unused: dev-deps # Look for unused code
 	
 	@echo "Code used only in _test.go (do move it in those files):"
 	staticcheck -checks U1000 -tests=false $(CHECK_FILES)
+static: dev-deps
+	staticcheck ./...
 
 dev: ## Run the development containers
 	docker-compose -f $(DEV_DOCKER_COMPOSE) up

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -70,8 +70,8 @@ func (ts *AdminTestSuite) TestAdminUsers() {
 	ts.API.handler.ServeHTTP(w, req)
 	require.Equal(ts.T(), http.StatusOK, w.Code)
 
-	assert.Equal(ts.T(), "</admin/users?page=0>; rel=\"last\"", w.HeaderMap.Get("Link"))
-	assert.Equal(ts.T(), "0", w.HeaderMap.Get("X-Total-Count"))
+	assert.Equal(ts.T(), "</admin/users?page=0>; rel=\"last\"", w.Header().Get("Link"))
+	assert.Equal(ts.T(), "0", w.Header().Get("X-Total-Count"))
 }
 
 // TestAdminUsers tests API /admin/users route
@@ -93,8 +93,8 @@ func (ts *AdminTestSuite) TestAdminUsers_Pagination() {
 	ts.API.handler.ServeHTTP(w, req)
 	require.Equal(ts.T(), http.StatusOK, w.Code)
 
-	assert.Equal(ts.T(), "</admin/users?page=2&per_page=1>; rel=\"next\", </admin/users?page=2&per_page=1>; rel=\"last\"", w.HeaderMap.Get("Link"))
-	assert.Equal(ts.T(), "2", w.HeaderMap.Get("X-Total-Count"))
+	assert.Equal(ts.T(), "</admin/users?page=2&per_page=1>; rel=\"next\", </admin/users?page=2&per_page=1>; rel=\"last\"", w.Header().Get("Link"))
+	assert.Equal(ts.T(), "2", w.Header().Get("X-Total-Count"))
 
 	data := make(map[string]interface{})
 	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))

--- a/api/audit_test.go
+++ b/api/audit_test.go
@@ -71,8 +71,8 @@ func (ts *AuditTestSuite) TestAuditGet() {
 	ts.API.handler.ServeHTTP(w, req)
 	require.Equal(ts.T(), http.StatusOK, w.Code)
 
-	assert.Equal(ts.T(), "</admin/audit?page=1>; rel=\"last\"", w.HeaderMap.Get("Link"))
-	assert.Equal(ts.T(), "1", w.HeaderMap.Get("X-Total-Count"))
+	assert.Equal(ts.T(), "</admin/audit?page=1>; rel=\"last\"", w.Header().Get("Link"))
+	assert.Equal(ts.T(), "1", w.Header().Get("X-Total-Count"))
 
 	logs := []models.AuditLogEntry{}
 	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&logs))

--- a/api/errors.go
+++ b/api/errors.go
@@ -17,7 +17,7 @@ import (
 var (
 	DuplicateEmailMsg       = "A user with this email address has already been registered"
 	DuplicatePhoneMsg       = "A user with this phone number has already been registered"
-	UserExistsError   error = errors.New("User already exists")
+	UserExistsError   error = errors.New("user already exists")
 )
 
 var oauthErrorMap = map[int]string{

--- a/api/mail.go
+++ b/api/mail.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	MaxFrequencyLimitError error = errors.New("Frequency limit reached")
+	MaxFrequencyLimitError error = errors.New("frequency limit reached")
 )
 
 type GenerateLinkParams struct {

--- a/api/provider/apple.go
+++ b/api/provider/apple.go
@@ -86,7 +86,7 @@ func (p AppleProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
 		oauth2.SetAuthURLParam("client_id", p.ClientID),
 		oauth2.SetAuthURLParam("secret", p.ClientSecret),
 	}
-	return p.Exchange(oauth2.NoContext, code, opts...)
+	return p.Exchange(context.Background(), code, opts...)
 }
 
 func (p AppleProvider) AuthCodeURL(state string, args ...oauth2.AuthCodeOption) string {

--- a/api/provider/azure.go
+++ b/api/provider/azure.go
@@ -66,7 +66,7 @@ func (g azureProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 	}
 
 	if u.Email == "" {
-		return nil, errors.New("Unable to find email with Azure provider")
+		return nil, errors.New("unable to find email with Azure provider")
 	}
 
 	return &UserProvidedData{

--- a/api/provider/azure.go
+++ b/api/provider/azure.go
@@ -56,7 +56,7 @@ func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 }
 
 func (g azureProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g azureProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/bitbucket.go
+++ b/api/provider/bitbucket.go
@@ -90,7 +90,7 @@ func (g bitbucketProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (
 	}
 
 	if len(data.Emails) <= 0 {
-		return nil, errors.New("Unable to find email with Bitbucket provider")
+		return nil, errors.New("unable to find email with Bitbucket provider")
 	}
 
 	data.Metadata = &Claims{

--- a/api/provider/bitbucket.go
+++ b/api/provider/bitbucket.go
@@ -61,7 +61,7 @@ func NewBitbucketProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, e
 }
 
 func (g bitbucketProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g bitbucketProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/discord.go
+++ b/api/provider/discord.go
@@ -62,7 +62,7 @@ func NewDiscordProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAu
 }
 
 func (g discordProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g discordProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/discord.go
+++ b/api/provider/discord.go
@@ -72,7 +72,7 @@ func (g discordProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*U
 	}
 
 	if u.Email == "" {
-		return nil, errors.New("Unable to find email with Discord provider")
+		return nil, errors.New("unable to find email with Discord provider")
 	}
 
 	var avatarURL string

--- a/api/provider/facebook.go
+++ b/api/provider/facebook.go
@@ -85,7 +85,7 @@ func (p facebookProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 	}
 
 	if u.Email == "" {
-		return nil, errors.New("Unable to find email with Facebook provider")
+		return nil, errors.New("unable to find email with Facebook provider")
 	}
 
 	return &UserProvidedData{

--- a/api/provider/facebook.go
+++ b/api/provider/facebook.go
@@ -70,7 +70,7 @@ func NewFacebookProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 }
 
 func (p facebookProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return p.Exchange(oauth2.NoContext, code)
+	return p.Exchange(context.Background(), code)
 }
 
 func (p facebookProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/github.go
+++ b/api/provider/github.go
@@ -113,7 +113,7 @@ func (g githubProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 	}
 
 	if len(data.Emails) <= 0 {
-		return nil, errors.New("Unable to find email with GitHub provider")
+		return nil, errors.New("unable to find email with GitHub provider")
 	}
 
 	return data, nil

--- a/api/provider/github.go
+++ b/api/provider/github.go
@@ -72,7 +72,7 @@ func NewGithubProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 }
 
 func (g githubProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g githubProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/gitlab.go
+++ b/api/provider/gitlab.go
@@ -63,7 +63,7 @@ func NewGitlabProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 }
 
 func (g gitlabProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g gitlabProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/gitlab.go
+++ b/api/provider/gitlab.go
@@ -93,7 +93,7 @@ func (g gitlabProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 	}
 
 	if len(data.Emails) <= 0 {
-		return nil, errors.New("Unable to find email with GitLab provider")
+		return nil, errors.New("unable to find email with GitLab provider")
 	}
 
 	data.Metadata = &Claims{

--- a/api/provider/google.go
+++ b/api/provider/google.go
@@ -81,7 +81,7 @@ func (g googleProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 	}
 
 	if len(data.Emails) <= 0 {
-		return nil, errors.New("Unable to find email with Google provider")
+		return nil, errors.New("unable to find email with Google provider")
 	}
 
 	data.Metadata = &Claims{

--- a/api/provider/google.go
+++ b/api/provider/google.go
@@ -61,7 +61,7 @@ func NewGoogleProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAut
 }
 
 func (g googleProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g googleProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/keycloak.go
+++ b/api/provider/keycloak.go
@@ -62,7 +62,7 @@ func NewKeycloakProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 }
 
 func (g keycloakProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g keycloakProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/keycloak.go
+++ b/api/provider/keycloak.go
@@ -38,7 +38,7 @@ func NewKeycloakProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 	}
 
 	if ext.URL == "" {
-		return nil, errors.New("Unable to find URL for the Keycloak provider")
+		return nil, errors.New("unable to find URL for the Keycloak provider")
 	}
 
 	extURLlen := len(ext.URL)
@@ -73,7 +73,7 @@ func (g keycloakProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 	}
 
 	if u.Email == "" {
-		return nil, errors.New("Unable to find email with Keycloak provider")
+		return nil, errors.New("unable to find email with Keycloak provider")
 	}
 
 	return &UserProvidedData{

--- a/api/provider/linkedin.go
+++ b/api/provider/linkedin.go
@@ -91,7 +91,7 @@ func NewLinkedinProvider(ext conf.OAuthProviderConfiguration, scopes string) (OA
 }
 
 func (g linkedinProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func GetName(name linkedinName) string {

--- a/api/provider/linkedin.go
+++ b/api/provider/linkedin.go
@@ -113,7 +113,7 @@ func (g linkedinProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 	}
 
 	if len(e.Elements) <= 0 {
-		return nil, errors.New("Unable to find email with Linkedin provider")
+		return nil, errors.New("unable to find email with Linkedin provider")
 	}
 
 	emails := []Email{}

--- a/api/provider/notion.go
+++ b/api/provider/notion.go
@@ -60,7 +60,7 @@ func NewNotionProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, erro
 }
 
 func (g notionProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g notionProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/slack.go
+++ b/api/provider/slack.go
@@ -59,7 +59,7 @@ func NewSlackProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 }
 
 func (g slackProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g slackProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/slack.go
+++ b/api/provider/slack.go
@@ -69,7 +69,7 @@ func (g slackProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 	}
 
 	if u.Email == "" {
-		return nil, errors.New("Unable to find email with Slack provider")
+		return nil, errors.New("unable to find email with Slack provider")
 	}
 
 	return &UserProvidedData{

--- a/api/provider/spotify.go
+++ b/api/provider/spotify.go
@@ -65,7 +65,7 @@ func NewSpotifyProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAu
 }
 
 func (g spotifyProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g spotifyProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/spotify.go
+++ b/api/provider/spotify.go
@@ -75,7 +75,7 @@ func (g spotifyProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*U
 	}
 
 	if u.Email == "" {
-		return nil, errors.New("Unable to find email with Spotify provider")
+		return nil, errors.New("unable to find email with Spotify provider")
 	}
 
 	var avatarURL string

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -88,7 +88,7 @@ func (t TwitterProvider) FetchUserData(ctx context.Context, tok *oauth.AccessTok
 	if err != nil {
 		return nil, err
 	}
-	err = json.NewDecoder(bytes.NewReader(bits)).Decode(&u)
+	_ = json.NewDecoder(bytes.NewReader(bits)).Decode(&u)
 
 	if u.Email == "" {
 		return nil, errors.New("unable to find email with Twitter provider")

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -91,7 +91,7 @@ func (t TwitterProvider) FetchUserData(ctx context.Context, tok *oauth.AccessTok
 	err = json.NewDecoder(bytes.NewReader(bits)).Decode(&u)
 
 	if u.Email == "" {
-		return nil, errors.New("Unable to find email with Twitter provider")
+		return nil, errors.New("unable to find email with Twitter provider")
 	}
 
 	data := &UserProvidedData{

--- a/api/provider/workos.go
+++ b/api/provider/workos.go
@@ -80,7 +80,7 @@ func (g workosProvider) AuthCodeURL(state string, args ...oauth2.AuthCodeOption)
 }
 
 func (g workosProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g workosProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {

--- a/api/provider/workos.go
+++ b/api/provider/workos.go
@@ -98,7 +98,7 @@ func (g workosProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 	}
 
 	if u.Email == "" {
-		return nil, errors.New("Unable to find email with WorkOS provider")
+		return nil, errors.New("unable to find email with WorkOS provider")
 	}
 
 	return &UserProvidedData{

--- a/api/provider/zoom.go
+++ b/api/provider/zoom.go
@@ -53,7 +53,7 @@ func NewZoomProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error)
 }
 
 func (g zoomProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(oauth2.NoContext, code)
+	return g.Exchange(context.Background(), code)
 }
 
 func (g zoomProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
@@ -63,7 +63,7 @@ func (g zoomProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*User
 	}
 
 	if u.Email == "" {
-		return nil, errors.New("Unable to find email with Zoom provider")
+		return nil, errors.New("unable to find email with Zoom provider")
 	}
 
 	verified := true

--- a/api/sms_provider/messagebird.go
+++ b/api/sms_provider/messagebird.go
@@ -93,7 +93,7 @@ func (t *MessagebirdProvider) SendSms(phone string, message string) error {
 	}
 
 	if resp.Recipients.TotalSentCount == 0 {
-		return fmt.Errorf("Messagebird error: total sent count is 0")
+		return fmt.Errorf("messagebird error: total sent count is 0")
 	}
 
 	return nil

--- a/api/sms_provider/sms_provider.go
+++ b/api/sms_provider/sms_provider.go
@@ -37,6 +37,6 @@ func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {
 	case "vonage":
 		return NewVonageProvider(config.Sms.Vonage)
 	default:
-		return nil, fmt.Errorf("Sms Provider %s could not be found", name)
+		return nil, fmt.Errorf("sms Provider %s could not be found", name)
 	}
 }

--- a/api/sms_provider/textlocal.go
+++ b/api/sms_provider/textlocal.go
@@ -72,11 +72,11 @@ func (t *TextlocalProvider) SendSms(phone string, message string) error {
 	}
 
 	if len(resp.Errors) == 0 {
-		return errors.New("Textlocal error: Internal Error")
+		return errors.New("textlocal error: Internal Error")
 	}
 
 	if resp.Status != "success" {
-		return fmt.Errorf("Textlocal error: %v (code: %v)", resp.Errors[0].Message, resp.Errors[0].Code)
+		return fmt.Errorf("textlocal error: %v (code: %v)", resp.Errors[0].Message, resp.Errors[0].Code)
 	}
 
 	return nil

--- a/api/sms_provider/twilio.go
+++ b/api/sms_provider/twilio.go
@@ -90,7 +90,7 @@ func (t *TwilioProvider) SendSms(phone string, message string) error {
 	}
 
 	if resp.Status == "failed" || resp.Status == "undelivered" {
-		return fmt.Errorf("Twilio error: %v %v", resp.ErrorMessage, resp.ErrorCode)
+		return fmt.Errorf("twilio error: %v %v", resp.ErrorMessage, resp.ErrorCode)
 	}
 
 	return nil

--- a/api/sms_provider/vonage.go
+++ b/api/sms_provider/vonage.go
@@ -72,12 +72,12 @@ func (t *VonageProvider) SendSms(phone string, message string) error {
 	}
 
 	if len(resp.Messages) <= 0 {
-		return errors.New("Vonage error: Internal Error")
+		return errors.New("vonage error: Internal Error")
 	}
 
 	// A status of zero indicates success; a non-zero value means something went wrong.
 	if resp.Messages[0].Status != "0" {
-		return fmt.Errorf("Vonage error: %v (status: %v)", resp.Messages[0].ErrorText, resp.Messages[0].Status)
+		return fmt.Errorf("vonage error: %v (status: %v)", resp.Messages[0].ErrorText, resp.Messages[0].Status)
 	}
 
 	return nil

--- a/api/token.go
+++ b/api/token.go
@@ -597,7 +597,7 @@ func (a *API) setCookieTokens(config *conf.GlobalConfiguration, token *AccessTok
 
 func (a *API) setCookieToken(config *conf.GlobalConfiguration, name string, tokenString string, session bool, w http.ResponseWriter) error {
 	if name == "" {
-		return errors.New("Failed to set cookie, invalid name")
+		return errors.New("failed to set cookie, invalid name")
 	}
 	cookieName := config.Cookie.Key + "-" + name
 	exp := time.Second * time.Duration(config.Cookie.Duration)

--- a/api/token.go
+++ b/api/token.go
@@ -113,7 +113,7 @@ func (p *IdTokenGrantParams) getVerifierFromClientIDandIssuer(ctx context.Contex
 	var err error
 	provider, err = oidc.NewProvider(ctx, p.Issuer)
 	if err != nil {
-		return nil, fmt.Errorf("Issuer %s doesn't support the id_token grant flow", p.Issuer)
+		return nil, fmt.Errorf("issuer %s doesn't support the id_token grant flow", p.Issuer)
 	}
 	return provider.Verifier(&oidc.Config{ClientID: p.ClientID}), nil
 }

--- a/api/token.go
+++ b/api/token.go
@@ -121,11 +121,11 @@ func (p *IdTokenGrantParams) getVerifierFromClientIDandIssuer(ctx context.Contex
 func getEmailVerified(v interface{}) bool {
 	var emailVerified bool
 	var err error
-	switch v.(type) {
+	switch v := v.(type) {
 	case string:
-		emailVerified, err = strconv.ParseBool(v.(string))
+		emailVerified, err = strconv.ParseBool(v)
 	case bool:
-		emailVerified = v.(bool)
+		emailVerified = v
 	default:
 		emailVerified = false
 	}

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -47,14 +47,13 @@ func migrate(cmd *cobra.Command, args []string) {
 		}
 		if level != logrus.DebugLevel {
 			var noopLogger = func(lvl logging.Level, s string, args ...interface{}) {
-				return
 			}
 			// Hide pop migration logging
 			pop.SetLogger(noopLogger)
 		}
 	}
 
-	u, err := url.Parse(globalConfig.DB.URL)
+	u, _ := url.Parse(globalConfig.DB.URL)
 	processedUrl := globalConfig.DB.URL
 	if len(u.Query()) != 0 {
 		processedUrl = fmt.Sprintf("%s&application_name=gotrue_migrations", processedUrl)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -385,62 +385,62 @@ func (c *GlobalConfiguration) Validate() error {
 
 func (o *OAuthProviderConfiguration) Validate() error {
 	if !o.Enabled {
-		return errors.New("Provider is not enabled")
+		return errors.New("provider is not enabled")
 	}
 	if o.ClientID == "" {
-		return errors.New("Missing Oauth client ID")
+		return errors.New("missing Oauth client ID")
 	}
 	if o.Secret == "" {
-		return errors.New("Missing Oauth secret")
+		return errors.New("missing Oauth secret")
 	}
 	if o.RedirectURI == "" {
-		return errors.New("Missing redirect URI")
+		return errors.New("missing redirect URI")
 	}
 	return nil
 }
 
 func (t *TwilioProviderConfiguration) Validate() error {
 	if t.AccountSid == "" {
-		return errors.New("Missing Twilio account SID")
+		return errors.New("missing Twilio account SID")
 	}
 	if t.AuthToken == "" {
-		return errors.New("Missing Twilio auth token")
+		return errors.New("missing Twilio auth token")
 	}
 	if t.MessageServiceSid == "" {
-		return errors.New("Missing Twilio message service SID or Twilio phone number")
+		return errors.New("missing Twilio message service SID or Twilio phone number")
 	}
 	return nil
 }
 
 func (t *MessagebirdProviderConfiguration) Validate() error {
 	if t.AccessKey == "" {
-		return errors.New("Missing Messagebird access key")
+		return errors.New("missing Messagebird access key")
 	}
 	if t.Originator == "" {
-		return errors.New("Missing Messagebird originator")
+		return errors.New("missing Messagebird originator")
 	}
 	return nil
 }
 
 func (t *TextlocalProviderConfiguration) Validate() error {
 	if t.ApiKey == "" {
-		return errors.New("Missing Textlocal API key")
+		return errors.New("missing Textlocal API key")
 	}
 	if t.Sender == "" {
-		return errors.New("Missing Textlocal sender")
+		return errors.New("missing Textlocal sender")
 	}
 	return nil
 }
 
 func (t *VonageProviderConfiguration) Validate() error {
 	if t.ApiKey == "" {
-		return errors.New("Missing Vonage API key")
+		return errors.New("missing Vonage API key")
 	}
 	if t.ApiSecret == "" {
-		return errors.New("Missing Vonage API secret")
+		return errors.New("missing Vonage API secret")
 	}
 	if t.From == "" {
-		return errors.New("Missing Vonage 'from' parameter")
+		return errors.New("missing Vonage 'from' parameter")
 	}
 	return nil
 }

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -321,7 +321,7 @@ func (m TemplateMailer) GetEmailActionLink(user *models.User, actionType, referr
 	case "email_change_new":
 		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.EmailChange, "token="+user.EmailChangeTokenNew+"&type=email_change"+redirectParam)
 	default:
-		return "", fmt.Errorf("Invalid email action link type: %s", actionType)
+		return "", fmt.Errorf("invalid email action link type: %s", actionType)
 	}
 	if err != nil {
 		return "", err

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -300,6 +300,9 @@ func (m TemplateMailer) Send(user *models.User, subject, body string, data map[s
 // GetEmailActionLink returns a magiclink, recovery or invite link based on the actionType passed.
 func (m TemplateMailer) GetEmailActionLink(user *models.User, actionType, referrerURL string) (string, error) {
 	globalConfig, err := conf.LoadGlobal(configFile)
+	if err != nil {
+		return "", err
+	}
 
 	redirectParam := ""
 	if len(referrerURL) > 0 {

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -64,7 +64,7 @@ func (m TemplateMailer) ValidateEmail(email string) error {
 
 // InviteMail sends a invite mail to a new user
 func (m *TemplateMailer) InviteMail(user *models.User, otp, referrerURL string) error {
-	globalConfig, err := conf.LoadGlobal(configFile)
+	globalConfig, _ := conf.LoadGlobal(configFile)
 
 	redirectParam := ""
 	if len(referrerURL) > 0 {

--- a/models/identity.go
+++ b/models/identity.go
@@ -30,7 +30,7 @@ func (Identity) TableName() string {
 func NewIdentity(user *User, provider string, identityData map[string]interface{}) (*Identity, error) {
 	id, ok := identityData["sub"]
 	if !ok {
-		return nil, errors.New("Error missing provider id")
+		return nil, errors.New("error missing provider id")
 	}
 	now := time.Now()
 

--- a/models/json_map.go
+++ b/models/json_map.go
@@ -26,7 +26,7 @@ func (j JSONMap) Scan(src interface{}) error {
 	case nil:
 		source = []byte("")
 	default:
-		return errors.New("Invalid data type for JSONMap")
+		return errors.New("invalid data type for JSONMap")
 	}
 
 	if len(source) == 0 {

--- a/models/user.go
+++ b/models/user.go
@@ -169,7 +169,7 @@ func (u *User) GetPhone() string {
 func (u *User) UpdateUserMetaData(tx *storage.Connection, updates map[string]interface{}) error {
 	if u.UserMetaData == nil {
 		u.UserMetaData = updates
-	} else if updates != nil {
+	} else {
 		for key, value := range updates {
 			if value != nil {
 				u.UserMetaData[key] = value
@@ -185,7 +185,7 @@ func (u *User) UpdateUserMetaData(tx *storage.Connection, updates map[string]int
 func (u *User) UpdateAppMetaData(tx *storage.Connection, updates map[string]interface{}) error {
 	if u.AppMetaData == nil {
 		u.AppMetaData = updates
-	} else if updates != nil {
+	} else {
 		for key, value := range updates {
 			if value != nil {
 				u.AppMetaData[key] = value

--- a/storage/dial.go
+++ b/storage/dial.go
@@ -57,7 +57,7 @@ func getExcludedColumns(model interface{}, includeColumns ...string) ([]string, 
 	sm := &pop.Model{Value: model}
 	st := reflect.TypeOf(model)
 	if st.Kind() == reflect.Ptr {
-		st = st.Elem()
+		_ = st.Elem()
 	}
 
 	// get all columns and remove included to get excluded set

--- a/storage/helper.go
+++ b/storage/helper.go
@@ -14,7 +14,7 @@ func (s *NullString) Scan(value interface{}) error {
 	}
 	strVal, ok := value.(string)
 	if !ok {
-		return errors.New("Column is not a string")
+		return errors.New("column is not a string")
 	}
 	*s = NullString(strVal)
 	return nil


### PR DESCRIPTION
## What kind of change does this PR introduce?



- deprecate oauth2.NoContext in favour of context.Background() and replace it with  `context.Background()` instead
- Lowercase error messages

Relevant links:
[OAuth2.NoContext is deprecated](https://github.com/golang/oauth2/blob/master/oauth2.go#L26) Replacing it with 

