### PR TITLE
refactor: split observability config and enablement

### DIFF
--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gobuffalo/pop/v5/logging"
-	"github.com/netlify/gotrue/conf"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -20,10 +19,8 @@ var migrateCmd = cobra.Command{
 }
 
 func migrate(cmd *cobra.Command, args []string) {
-	globalConfig, err := conf.LoadGlobal(configFile)
-	if err != nil {
-		logrus.Fatalf("Failed to load configuration: %+v", err)
-	}
+	globalConfig := loadGlobalConfig()
+
 	if globalConfig.DB.Driver == "" && globalConfig.DB.URL != "" {
 		u, err := url.Parse(globalConfig.DB.URL)
 		if err != nil {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -259,15 +259,9 @@ func LoadGlobal(filename string) (*GlobalConfiguration, error) {
 		return nil, err
 	}
 
-	if err := ConfigureLogging(&config.Logging); err != nil {
-		return nil, err
-	}
-
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
-
-	ConfigureTracing(&config.Tracing)
 
 	return config, nil
 }

--- a/conf/logging.go
+++ b/conf/logging.go
@@ -1,19 +1,5 @@
 package conf
 
-import (
-	"os"
-
-	"github.com/gobuffalo/pop/v5"
-	"github.com/gobuffalo/pop/v5/logging"
-	"github.com/sirupsen/logrus"
-)
-
-const (
-	LOG_SQL_ALL       = "all"
-	LOG_SQL_NONE      = "none"
-	LOG_SQL_STATEMENT = "statement"
-)
-
 type LoggingConfig struct {
 	Level            string                 `mapstructure:"log_level" json:"log_level"`
 	File             string                 `mapstructure:"log_file" json:"log_file"`
@@ -22,77 +8,4 @@ type LoggingConfig struct {
 	TSFormat         string                 `mapstructure:"ts_format" json:"ts_format"`
 	Fields           map[string]interface{} `mapstructure:"fields" json:"fields"`
 	SQL              string                 `mapstructure:"sql" json:"sql"`
-}
-
-func ConfigureLogging(config *LoggingConfig) error {
-	logrus.SetFormatter(&logrus.JSONFormatter{})
-
-	// use a file if you want
-	if config.File != "" {
-		f, errOpen := os.OpenFile(config.File, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0660) //#nosec G302 -- Log files should be rw-rw-r--
-		if errOpen != nil {
-			return errOpen
-		}
-		logrus.SetOutput(f)
-		logrus.Infof("Set output file to %s", config.File)
-	}
-
-	if config.Level != "" {
-		level, err := logrus.ParseLevel(config.Level)
-		if err != nil {
-			return err
-		}
-		logrus.SetLevel(level)
-		logrus.Debug("Set log level to: " + logrus.GetLevel().String())
-	}
-
-	f := logrus.Fields{}
-	for k, v := range config.Fields {
-		f[k] = v
-	}
-	logrus.WithFields(f)
-
-	setPopLogger(config.SQL)
-
-	return nil
-}
-
-func setPopLogger(sql string) {
-	popLog := logrus.WithField("component", "pop")
-	sqlLog := logrus.WithField("component", "sql")
-
-	shouldLogSQL := sql == LOG_SQL_STATEMENT || sql == LOG_SQL_ALL
-	shouldLogSQLArgs := sql == LOG_SQL_ALL
-
-	pop.SetLogger(func(lvl logging.Level, s string, args ...interface{}) {
-		// Special case SQL logging since we have 2 extra flags to check
-		if lvl == logging.SQL {
-			if !shouldLogSQL {
-				return
-			}
-
-			if shouldLogSQLArgs && len(args) > 0 {
-				sqlLog.WithField("args", args).Info(s)
-			} else {
-				sqlLog.Info(s)
-			}
-			return
-		}
-
-		l := popLog
-		if len(args) > 0 {
-			l = l.WithField("args", args)
-		}
-
-		switch lvl {
-		case logging.Debug:
-			l.Debug(s)
-		case logging.Info:
-			l.Info(s)
-		case logging.Warn:
-			l.Warn(s)
-		case logging.Error:
-			l.Error(s)
-		}
-	})
 }

--- a/conf/tracing.go
+++ b/conf/tracing.go
@@ -1,13 +1,5 @@
 package conf
 
-import (
-	"fmt"
-
-	"github.com/opentracing/opentracing-go"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-)
-
 type TracingConfig struct {
 	Enabled     bool `default:"false"`
 	Host        string
@@ -18,25 +10,4 @@ type TracingConfig struct {
 
 func (tc *TracingConfig) Validate() error {
 	return nil
-}
-
-func (tc *TracingConfig) tracingAddr() string {
-	return fmt.Sprintf("%s:%s", tc.Host, tc.Port)
-}
-
-func ConfigureTracing(tc *TracingConfig) {
-	var t opentracing.Tracer = opentracing.NoopTracer{}
-	if tc.Enabled {
-		tracerOps := []tracer.StartOption{
-			tracer.WithServiceName(tc.ServiceName),
-			tracer.WithAgentAddr(tc.tracingAddr()),
-		}
-
-		for k, v := range tc.Tags {
-			tracerOps = append(tracerOps, tracer.WithGlobalTag(k, v))
-		}
-
-		t = opentracer.New(tracerOps...)
-	}
-	opentracing.SetGlobalTracer(t)
 }

--- a/observability/logging.go
+++ b/observability/logging.go
@@ -1,0 +1,100 @@
+package observability
+
+import (
+	"os"
+	"sync"
+
+	"github.com/gobuffalo/pop/v5"
+	"github.com/gobuffalo/pop/v5/logging"
+	"github.com/netlify/gotrue/conf"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	LOG_SQL_ALL       = "all"
+	LOG_SQL_NONE      = "none"
+	LOG_SQL_STATEMENT = "statement"
+)
+
+var (
+	loggingOnce sync.Once
+)
+
+func ConfigureLogging(config *conf.LoggingConfig) error {
+	var err error
+
+	loggingOnce.Do(func() {
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+
+		// use a file if you want
+		if config.File != "" {
+			f, errOpen := os.OpenFile(config.File, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0660) //#nosec G302 -- Log files should be rw-rw-r--
+			if errOpen != nil {
+				err = errOpen
+				return
+			}
+			logrus.SetOutput(f)
+			logrus.Infof("Set output file to %s", config.File)
+		}
+
+		if config.Level != "" {
+			level, errParse := logrus.ParseLevel(config.Level)
+			if err != nil {
+				err = errParse
+				return
+			}
+			logrus.SetLevel(level)
+			logrus.Debug("Set log level to: " + logrus.GetLevel().String())
+		}
+
+		f := logrus.Fields{}
+		for k, v := range config.Fields {
+			f[k] = v
+		}
+		logrus.WithFields(f)
+
+		setPopLogger(config.SQL)
+	})
+
+	return err
+}
+
+func setPopLogger(sql string) {
+	popLog := logrus.WithField("component", "pop")
+	sqlLog := logrus.WithField("component", "sql")
+
+	shouldLogSQL := sql == LOG_SQL_STATEMENT || sql == LOG_SQL_ALL
+	shouldLogSQLArgs := sql == LOG_SQL_ALL
+
+	pop.SetLogger(func(lvl logging.Level, s string, args ...interface{}) {
+		// Special case SQL logging since we have 2 extra flags to check
+		if lvl == logging.SQL {
+			if !shouldLogSQL {
+				return
+			}
+
+			if shouldLogSQLArgs && len(args) > 0 {
+				sqlLog.WithField("args", args).Info(s)
+			} else {
+				sqlLog.Info(s)
+			}
+			return
+		}
+
+		l := popLog
+		if len(args) > 0 {
+			l = l.WithField("args", args)
+		}
+
+		switch lvl {
+		case logging.Debug:
+			l.Debug(s)
+		case logging.Info:
+			l.Info(s)
+		case logging.Warn:
+			l.Warn(s)
+		case logging.Error:
+			l.Error(s)
+		}
+	})
+}

--- a/observability/tracing.go
+++ b/observability/tracing.go
@@ -1,0 +1,38 @@
+package observability
+
+import (
+	"net"
+	"sync"
+
+	"github.com/netlify/gotrue/conf"
+	"github.com/opentracing/opentracing-go"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+var (
+	tracingOnce sync.Once
+)
+
+func ConfigureTracing(tc *conf.TracingConfig) error {
+	tracingOnce.Do(func() {
+		var t opentracing.Tracer = opentracing.NoopTracer{}
+
+		if tc.Enabled {
+			tracerOps := []tracer.StartOption{
+				tracer.WithServiceName(tc.ServiceName),
+				tracer.WithAgentAddr(net.JoinHostPort(tc.Host, tc.Port)),
+			}
+
+			for k, v := range tc.Tags {
+				tracerOps = append(tracerOps, tracer.WithGlobalTag(k, v))
+			}
+
+			t = opentracer.New(tracerOps...)
+		}
+
+		opentracing.SetGlobalTracer(t)
+	})
+
+	return nil
+}


### PR DESCRIPTION
Splits the configuration and enablement of observability settings such as tracing and logging. A tracer, metrics collector or logger should only be configured once per process. This also allows for future additions of OpenTelemetry metrics and tracing.

Part of #679. 