### PR TITLE
refactor: remove LoadGlobal calls from mailer

### DIFF
--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -24,29 +24,29 @@ type Mailer interface {
 }
 
 // NewMailer returns a new gotrue mailer
-func NewMailer(instanceConfig *conf.GlobalConfiguration) Mailer {
+func NewMailer(globalConfig *conf.GlobalConfiguration) Mailer {
 	mail := gomail.NewMessage()
-	from := mail.FormatAddress(instanceConfig.SMTP.AdminEmail, instanceConfig.SMTP.SenderName)
+	from := mail.FormatAddress(globalConfig.SMTP.AdminEmail, globalConfig.SMTP.SenderName)
 
 	var mailClient MailClient
-	if instanceConfig.SMTP.Host == "" {
-		logrus.Infof("Noop mail client being used for %v", instanceConfig.SiteURL)
+	if globalConfig.SMTP.Host == "" {
+		logrus.Infof("Noop mail client being used for %v", globalConfig.SiteURL)
 		mailClient = &noopMailClient{}
 	} else {
 		mailClient = &mailme.Mailer{
-			Host:    instanceConfig.SMTP.Host,
-			Port:    instanceConfig.SMTP.Port,
-			User:    instanceConfig.SMTP.User,
-			Pass:    instanceConfig.SMTP.Pass,
+			Host:    globalConfig.SMTP.Host,
+			Port:    globalConfig.SMTP.Port,
+			User:    globalConfig.SMTP.User,
+			Pass:    globalConfig.SMTP.Pass,
 			From:    from,
-			BaseURL: instanceConfig.SiteURL,
+			BaseURL: globalConfig.SiteURL,
 			Logger:  logrus.StandardLogger(),
 		}
 	}
 
 	return &TemplateMailer{
-		SiteURL: instanceConfig.SiteURL,
-		Config:  instanceConfig,
+		SiteURL: globalConfig.SiteURL,
+		Config:  globalConfig,
 		Mailer:  mailClient,
 	}
 }

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -19,8 +19,6 @@ type TemplateMailer struct {
 	Mailer  MailClient
 }
 
-var configFile = ""
-
 const defaultInviteMail = `<h2>You have been invited</h2>
 
 <p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>
@@ -64,14 +62,12 @@ func (m TemplateMailer) ValidateEmail(email string) error {
 
 // InviteMail sends a invite mail to a new user
 func (m *TemplateMailer) InviteMail(user *models.User, otp, referrerURL string) error {
-	globalConfig, _ := conf.LoadGlobal(configFile)
-
 	redirectParam := ""
 	if len(referrerURL) > 0 {
 		redirectParam = "&redirect_to=" + referrerURL
 	}
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite"+redirectParam)
+	url, err := getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite"+redirectParam)
 	if err != nil {
 		return err
 	}
@@ -94,15 +90,11 @@ func (m *TemplateMailer) InviteMail(user *models.User, otp, referrerURL string) 
 
 // ConfirmationMail sends a signup confirmation mail to a new user
 func (m *TemplateMailer) ConfirmationMail(user *models.User, otp, referrerURL string) error {
-	globalConfig, err := conf.LoadGlobal(configFile)
-	if err != nil {
-		return err
-	}
 	redirectParam := ""
 	if len(referrerURL) > 0 {
 		redirectParam = "&redirect_to=" + referrerURL
 	}
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup"+redirectParam)
+	url, err := getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup"+redirectParam)
 	if err != nil {
 		return err
 	}
@@ -171,11 +163,6 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, 
 		})
 	}
 
-	globalConfig, err := conf.LoadGlobal(configFile)
-	if err != nil {
-		return err
-	}
-
 	redirectParam := ""
 	if len(referrerURL) > 0 {
 		redirectParam = "&redirect_to=" + referrerURL
@@ -184,7 +171,7 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, 
 	for _, email := range emails {
 		url, err := getSiteURL(
 			referrerURL,
-			globalConfig.API.ExternalURL,
+			m.Config.API.ExternalURL,
 			m.Config.Mailer.URLPaths.EmailChange,
 			"token="+email.TokenHash+"&type=email_change"+redirectParam,
 		)
@@ -222,17 +209,12 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, 
 
 // RecoveryMail sends a password recovery mail
 func (m *TemplateMailer) RecoveryMail(user *models.User, otp, referrerURL string) error {
-	globalConfig, err := conf.LoadGlobal(configFile)
-	if err != nil {
-		return err
-	}
-
 	redirectParam := ""
 	if len(referrerURL) > 0 {
 		redirectParam = "&redirect_to=" + referrerURL
 	}
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=recovery"+redirectParam)
+	url, err := getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=recovery"+redirectParam)
 	if err != nil {
 		return err
 	}
@@ -255,17 +237,12 @@ func (m *TemplateMailer) RecoveryMail(user *models.User, otp, referrerURL string
 
 // MagicLinkMail sends a login link mail
 func (m *TemplateMailer) MagicLinkMail(user *models.User, otp, referrerURL string) error {
-	globalConfig, err := conf.LoadGlobal(configFile)
-	if err != nil {
-		return err
-	}
-
 	redirectParam := ""
 	if len(referrerURL) > 0 {
 		redirectParam = "&redirect_to=" + referrerURL
 	}
 
-	url, err := getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=magiclink"+redirectParam)
+	url, err := getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=magiclink"+redirectParam)
 	if err != nil {
 		return err
 	}
@@ -299,10 +276,7 @@ func (m TemplateMailer) Send(user *models.User, subject, body string, data map[s
 
 // GetEmailActionLink returns a magiclink, recovery or invite link based on the actionType passed.
 func (m TemplateMailer) GetEmailActionLink(user *models.User, actionType, referrerURL string) (string, error) {
-	globalConfig, err := conf.LoadGlobal(configFile)
-	if err != nil {
-		return "", err
-	}
+	var err error
 
 	redirectParam := ""
 	if len(referrerURL) > 0 {
@@ -312,17 +286,17 @@ func (m TemplateMailer) GetEmailActionLink(user *models.User, actionType, referr
 	var url string
 	switch actionType {
 	case "magiclink":
-		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=magiclink"+redirectParam)
+		url, err = getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=magiclink"+redirectParam)
 	case "recovery":
-		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=recovery"+redirectParam)
+		url, err = getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.Recovery, "token="+user.RecoveryToken+"&type=recovery"+redirectParam)
 	case "invite":
-		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite"+redirectParam)
+		url, err = getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.Invite, "token="+user.ConfirmationToken+"&type=invite"+redirectParam)
 	case "signup":
-		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup"+redirectParam)
+		url, err = getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.Confirmation, "token="+user.ConfirmationToken+"&type=signup"+redirectParam)
 	case "email_change_current":
-		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.EmailChange, "token="+user.EmailChangeTokenCurrent+"&type=email_change"+redirectParam)
+		url, err = getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.EmailChange, "token="+user.EmailChangeTokenCurrent+"&type=email_change"+redirectParam)
 	case "email_change_new":
-		url, err = getSiteURL(referrerURL, globalConfig.API.ExternalURL, m.Config.Mailer.URLPaths.EmailChange, "token="+user.EmailChangeTokenNew+"&type=email_change"+redirectParam)
+		url, err = getSiteURL(referrerURL, m.Config.API.ExternalURL, m.Config.Mailer.URLPaths.EmailChange, "token="+user.EmailChangeTokenNew+"&type=email_change"+redirectParam)
 	default:
 		return "", fmt.Errorf("invalid email action link type: %s", actionType)
 	}


### PR DESCRIPTION
`mailer` had unnecessary calls to `conf.LoadGlobal('')` which were re-parsing the environment config on every request. This PR removes those calls, as the global config is already present.

Part of #679.