### PR TITLE
refactor: signal handling with cleanup

### DIFF
--- a/api/cleanup.go
+++ b/api/cleanup.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+	"sync"
+)
+
+var (
+	cleanupWaitGroup sync.WaitGroup
+)
+
+// WaitForCleanup waits until all API servers are shut down cleanly or until
+// the provided context signals done, whichever comes first.
+func WaitForCleanup(ctx context.Context) {
+	cleanupDone := make(chan struct{})
+
+	go func() {
+		defer close(cleanupDone)
+
+		cleanupWaitGroup.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return
+
+	case <-cleanupDone:
+		return
+	}
+}

--- a/api/listener.go
+++ b/api/listener.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ListenAndServe starts the REST API
+func (a *API) ListenAndServe(ctx context.Context, hostAndPort string) {
+	baseCtx, cancel := context.WithCancel(context.Background())
+
+	log := logrus.WithField("component", "api")
+
+	server := &http.Server{
+		Addr:              hostAndPort,
+		Handler:           a.handler,
+		ReadHeaderTimeout: 2 * time.Second, // to mitigate a Slowloris attack
+		BaseContext: func(net.Listener) context.Context {
+			return baseCtx
+		},
+	}
+
+	cleanupWaitGroup.Add(1)
+	go func() {
+		defer cleanupWaitGroup.Done()
+
+		<-ctx.Done()
+
+		defer cancel() // close baseContext
+
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Minute)
+		defer shutdownCancel()
+
+		if err := server.Shutdown(shutdownCtx); err != nil && !errors.Is(err, context.Canceled) {
+			log.WithError(err).Error("shutdown failed")
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		log.WithError(err).Fatal("http server listen failed")
+	}
+}

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -13,8 +13,8 @@ var configFile = ""
 var rootCmd = cobra.Command{
 	Use: "gotrue",
 	Run: func(cmd *cobra.Command, args []string) {
-		migrate(&migrateCmd, args)
-		execWithConfig(cmd, serve)
+		migrate(cmd, args)
+		serve(cmd.Context())
 	},
 }
 
@@ -41,10 +41,6 @@ func loadGlobalConfig() *conf.GlobalConfiguration {
 	}
 
 	return config
-}
-
-func execWithConfig(cmd *cobra.Command, fn func(config *conf.GlobalConfiguration)) {
-	fn(loadGlobalConfig())
 }
 
 func execWithConfigAndArgs(cmd *cobra.Command, fn func(config *conf.GlobalConfiguration, args []string), args []string) {

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"context"
-	"fmt"
+	"net"
 
 	"github.com/netlify/gotrue/api"
 	"github.com/netlify/gotrue/conf"
@@ -16,20 +16,26 @@ var serveCmd = cobra.Command{
 	Use:  "serve",
 	Long: "Start API server",
 	Run: func(cmd *cobra.Command, args []string) {
-		execWithConfig(cmd, serve)
+		serve(cmd.Context())
 	},
 }
 
-func serve(config *conf.GlobalConfiguration) {
+func serve(ctx context.Context) {
+	config, err := conf.LoadGlobal(configFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to load config")
+	}
+
 	db, err := storage.Dial(config)
 	if err != nil {
-		logrus.Fatalf("Error opening database: %+v", err)
+		logrus.Fatalf("error opening database: %+v", err)
 	}
 	defer db.Close()
 
-	api := api.NewAPIWithVersion(context.Background(), config, db, utilities.Version)
+	api := api.NewAPIWithVersion(ctx, config, db, utilities.Version)
 
-	l := fmt.Sprintf("%v:%v", config.API.Host, config.API.Port)
-	logrus.Infof("GoTrue API started on: %s", l)
-	api.ListenAndServe(l)
+	addr := net.JoinHostPort(config.API.Host, config.API.Port)
+	logrus.Infof("GoTrue API started on: %s", addr)
+
+	api.ListenAndServe(ctx, addr)
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -53,7 +53,7 @@ type JWTConfiguration struct {
 
 type APIConfiguration struct {
 	Host            string
-	Port            int `envconfig:"PORT" default:"8081"`
+	Port            string `envconfig:"PORT" default:"8081"`
 	Endpoint        string
 	RequestIDHeader string `envconfig:"REQUEST_ID_HEADER"`
 	ExternalURL     string `json:"external_url" envconfig:"API_EXTERNAL_URL"`

--- a/main.go
+++ b/main.go
@@ -1,13 +1,71 @@
 package main
 
 import (
-	"log"
+	"context"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
 
+	"github.com/netlify/gotrue/api"
 	"github.com/netlify/gotrue/cmd"
+	"github.com/netlify/gotrue/observability"
+	"github.com/sirupsen/logrus"
 )
 
+func init() {
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+}
+
 func main() {
-	if err := cmd.RootCommand().Execute(); err != nil {
-		log.Fatal(err)
+	execCtx, execCancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGHUP, syscall.SIGINT)
+	defer execCancel()
+
+	go func() {
+		<-execCtx.Done()
+		logrus.Info("received graceful shutdown signal")
+	}()
+
+	// command is expected to obey the cancellation signal on execCtx and
+	// block while it is running
+	if err := cmd.RootCommand().ExecuteContext(execCtx); err != nil {
+		logrus.WithError(err).Fatal(err)
+	}
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Minute)
+	defer shutdownCancel()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// wait for API servers to shut down gracefully
+		api.WaitForCleanup(shutdownCtx)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// wait for metrics and trace exporters to shut down gracefully
+		observability.WaitForCleanup(shutdownCtx)
+	}()
+
+	cleanupDone := make(chan struct{})
+	go func() {
+		defer close(cleanupDone)
+		wg.Wait()
+	}()
+
+	select {
+	case <-shutdownCtx.Done():
+		// cleanup timed out
+		return
+
+	case <-cleanupDone:
+		// cleanup finished before timing out
+		return
 	}
 }

--- a/observability/cleanup.go
+++ b/observability/cleanup.go
@@ -1,0 +1,30 @@
+package observability
+
+import (
+	"context"
+	"sync"
+)
+
+var (
+	cleanupWaitGroup sync.WaitGroup
+)
+
+// WaitForCleanup waits until all observability long-running goroutines shut
+// down cleanly or until the provided context signals done.
+func WaitForCleanup(ctx context.Context) {
+	cleanupDone := make(chan struct{})
+
+	go func() {
+		defer close(cleanupDone)
+
+		cleanupWaitGroup.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return
+
+	case <-cleanupDone:
+		return
+	}
+}


### PR DESCRIPTION
Refactors signal handling (i.e. `Ctrl-C` behavior) using a top level context using `signal.NotifyContext`. This context is propagated down to the API server, which will shut down cleanly when it gets cancelled.

Furthermore, adds clean up functions for any additional servers that were started but not waited upon -- specifically in `api` and `observability`.

Part of #679.