### PR TITLE
refactor: move version variable to utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build deps dev-deps image migrate test vet sec format unused
 CHECK_FILES?=./...
-FLAGS?=-ldflags "-X github.com/netlify/gotrue/cmd.Version=`git describe --tags`"
+FLAGS?=-ldflags "-X github.com/netlify/gotrue/utilities.Version=`git describe --tags`"
 DEV_DOCKER_COMPOSE:=docker-compose-dev.yml
 
 help: ## Show this help.

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/netlify/gotrue/api"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage"
+	"github.com/netlify/gotrue/utilities"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +27,7 @@ func serve(config *conf.GlobalConfiguration) {
 	}
 	defer db.Close()
 
-	api := api.NewAPIWithVersion(context.Background(), config, db, Version)
+	api := api.NewAPIWithVersion(context.Background(), config, db, utilities.Version)
 
 	l := fmt.Sprintf("%v:%v", config.API.Host, config.API.Port)
 	logrus.Infof("GoTrue API started on: %s", l)

--- a/cmd/version_cmd.go
+++ b/cmd/version_cmd.go
@@ -3,11 +3,9 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/netlify/gotrue/utilities"
 	"github.com/spf13/cobra"
 )
-
-// Version is the SHA of the git commit from which this binary was built.
-var Version string
 
 var versionCmd = cobra.Command{
 	Run: showVersion,
@@ -15,5 +13,5 @@ var versionCmd = cobra.Command{
 }
 
 func showVersion(cmd *cobra.Command, args []string) {
-	fmt.Println(Version)
+	fmt.Println(utilities.Version)
 }

--- a/utilities/version.go
+++ b/utilities/version.go
@@ -1,0 +1,4 @@
+package utilities
+
+// Version is git commit or release tag from which this binary was built.
+var Version string


### PR DESCRIPTION
Today it lives in `cmd` but this means that if you want to use it from anywhere else, you risk creating a circular dependency (since `cmd` is what starts the process).

This way it lives in `utilities` and anyone can grab it for any purpose.