### PR TITLE
refactor: pass request context to database queries

### DIFF
--- a/api/audit.go
+++ b/api/audit.go
@@ -14,6 +14,9 @@ var filterColumnMap = map[string][]string{
 }
 
 func (a *API) adminAuditLog(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	db := a.db.WithContext(ctx)
+
 	// aud := a.requestAud(ctx, r)
 	pageParams, err := paginate(r)
 	if err != nil {
@@ -33,7 +36,7 @@ func (a *API) adminAuditLog(w http.ResponseWriter, r *http.Request) error {
 		qval = qparts[1]
 	}
 
-	logs, err := models.FindAuditLogEntries(a.db, col, qval, pageParams)
+	logs, err := models.FindAuditLogEntries(db, col, qval, pageParams)
 	if err != nil {
 		return internalServerError("Error searching for audit logs").WithInternalError(err)
 	}

--- a/api/auth.go
+++ b/api/auth.go
@@ -80,7 +80,9 @@ func (a *API) parseJWTClaims(bearer string, r *http.Request, w http.ResponseWrit
 }
 
 func (a *API) maybeLoadUserOrSession(ctx context.Context) (context.Context, error) {
+	db := a.db.WithContext(ctx)
 	claims := getClaims(ctx)
+
 	if claims == nil {
 		return ctx, errors.New("invalid token")
 	}
@@ -95,7 +97,7 @@ func (a *API) maybeLoadUserOrSession(ctx context.Context) (context.Context, erro
 		if err != nil {
 			return ctx, err
 		}
-		user, err = models.FindUserByID(a.db, userId)
+		user, err = models.FindUserByID(db, userId)
 		if err != nil {
 			return ctx, err
 		}
@@ -108,7 +110,7 @@ func (a *API) maybeLoadUserOrSession(ctx context.Context) (context.Context, erro
 		if err != nil {
 			return ctx, err
 		}
-		session, err = models.FindSessionById(a.db, sessionId)
+		session, err = models.FindSessionById(db, sessionId)
 		if err != nil && !models.IsNotFoundError(err) {
 			return ctx, err
 		}

--- a/api/external.go
+++ b/api/external.go
@@ -38,6 +38,7 @@ type ExternalSignupParams struct {
 // ExternalProviderRedirect redirects the request to the corresponding oauth provider
 func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	db := a.db.WithContext(ctx)
 	config := a.config
 
 	query := r.URL.Query()
@@ -51,7 +52,7 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 
 	inviteToken := query.Get("invite_token")
 	if inviteToken != "" {
-		_, userErr := models.FindUserByConfirmationToken(a.db, inviteToken)
+		_, userErr := models.FindUserByConfirmationToken(db, inviteToken)
 		if userErr != nil {
 			if models.IsNotFoundError(userErr) {
 				return notFoundError(userErr.Error())
@@ -105,6 +106,7 @@ func (a *API) ExternalProviderCallback(w http.ResponseWriter, r *http.Request) e
 
 func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	db := a.db.WithContext(ctx)
 	config := a.config
 
 	providerType := getExternalProviderType(ctx)
@@ -133,7 +135,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 
 	var user *models.User
 	var token *AccessTokenResponse
-	err := a.db.Transaction(func(tx *storage.Connection) error {
+	err := db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		inviteToken := getInviteToken(ctx)
 		if inviteToken != "" {

--- a/api/logout.go
+++ b/api/logout.go
@@ -10,6 +10,7 @@ import (
 // Logout is the endpoint for logging out a user and thereby revoking any refresh tokens
 func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	db := a.db.WithContext(ctx)
 	config := a.config
 
 	a.clearCookieTokens(config, w)
@@ -17,7 +18,7 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	s := getSession(ctx)
 	u := getUser(ctx)
 
-	err := a.db.Transaction(func(tx *storage.Connection) error {
+	err := db.Transaction(func(tx *storage.Connection) error {
 		if terr := models.NewAuditLogEntry(r, tx, u, models.LogoutAction, "", nil); terr != nil {
 			return terr
 		}

--- a/api/reauthenticate.go
+++ b/api/reauthenticate.go
@@ -17,6 +17,7 @@ const InvalidNonceMessage = "Nonce has expired or is invalid"
 // Reauthenticate sends a reauthentication otp to either the user's email or phone
 func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	db := a.db.WithContext(ctx)
 	config := a.config
 
 	user := getUser(ctx)
@@ -36,7 +37,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	err := a.db.Transaction(func(tx *storage.Connection) error {
+	err := db.Transaction(func(tx *storage.Connection) error {
 		if terr := models.NewAuditLogEntry(r, tx, user, models.UserReauthenticateAction, "", nil); terr != nil {
 			return terr
 		}

--- a/api/token.go
+++ b/api/token.go
@@ -154,6 +154,8 @@ func (a *API) Token(w http.ResponseWriter, r *http.Request) error {
 
 // ResourceOwnerPasswordGrant implements the password grant type flow
 func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	db := a.db.WithContext(ctx)
+
 	params := &PasswordGrantParams{}
 
 	body, err := getBodyBytes(r)
@@ -179,14 +181,14 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		if !config.External.Email.Enabled {
 			return badRequestError("Email logins are disabled")
 		}
-		user, err = models.FindUserByEmailAndAudience(a.db, params.Email, aud)
+		user, err = models.FindUserByEmailAndAudience(db, params.Email, aud)
 	} else if params.Phone != "" {
 		provider = "phone"
 		if !config.External.Phone.Enabled {
 			return badRequestError("Phone logins are disabled")
 		}
 		params.Phone = a.formatPhoneNumber(params.Phone)
-		user, err = models.FindUserByPhoneAndAudience(a.db, params.Phone, aud)
+		user, err = models.FindUserByPhoneAndAudience(db, params.Phone, aud)
 	} else {
 		return oauthError("invalid_grant", InvalidLoginMessage)
 	}
@@ -209,7 +211,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	}
 
 	var token *AccessTokenResponse
-	err = a.db.Transaction(func(tx *storage.Connection) error {
+	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		if terr = models.NewAuditLogEntry(r, tx, user, models.LoginAction, "", map[string]interface{}{
 			"provider": provider,
@@ -239,6 +241,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 
 // RefreshTokenGrant implements the refresh_token grant type flow
 func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	db := a.db.WithContext(ctx)
 	config := a.config
 
 	params := &RefreshTokenGrantParams{}
@@ -256,7 +259,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 		return oauthError("invalid_request", "refresh_token required")
 	}
 
-	user, token, err := models.FindUserWithRefreshToken(a.db, params.RefreshToken)
+	user, token, err := models.FindUserWithRefreshToken(db, params.RefreshToken)
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			return oauthError("invalid_grant", "Invalid Refresh Token")
@@ -271,7 +274,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 	var newToken *models.RefreshToken
 	if token.Revoked {
 		a.clearCookieTokens(config, w)
-		err = a.db.Transaction(func(tx *storage.Connection) error {
+		err = db.Transaction(func(tx *storage.Connection) error {
 			validToken, terr := models.GetValidChildToken(tx, token)
 			if terr != nil {
 				if errors.Is(terr, models.RefreshTokenNotFoundError{}) {
@@ -296,7 +299,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 		if newToken == nil {
 			if config.Security.RefreshTokenRotationEnabled {
 				// Revoke all tokens in token family
-				err = a.db.Transaction(func(tx *storage.Connection) error {
+				err = db.Transaction(func(tx *storage.Connection) error {
 					var terr error
 					if terr = models.RevokeTokenFamily(tx, token); terr != nil {
 						return terr
@@ -314,7 +317,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 	var tokenString string
 	var newTokenResponse *AccessTokenResponse
 
-	err = a.db.Transaction(func(tx *storage.Connection) error {
+	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		if terr = models.NewAuditLogEntry(r, tx, user, models.TokenRefreshedAction, "", nil); terr != nil {
 			return terr
@@ -354,6 +357,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 
 // IdTokenGrant implements the id_token grant type flow
 func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	db := a.db.WithContext(ctx)
 	config := a.config
 
 	params := &IdTokenGrantParams{}
@@ -423,7 +427,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 	var user *models.User
 	var grantParams models.GrantParams
 	var token *AccessTokenResponse
-	err = a.db.Transaction(func(tx *storage.Connection) error {
+	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		var identity *models.Identity
 

--- a/api/user.go
+++ b/api/user.go
@@ -40,6 +40,7 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 // UserUpdate updates fields on a user
 func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	db := a.db.WithContext(ctx)
 	config := a.config
 
 	params := &UserUpdateParams{}
@@ -57,7 +58,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	log := logger.GetLogEntry(r)
 	log.Debugf("Checking params for token %v", params)
 
-	err = a.db.Transaction(func(tx *storage.Connection) error {
+	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		if params.Password != nil {
 			if len(*params.Password) < config.PasswordMinLength {

--- a/api/verify.go
+++ b/api/verify.go
@@ -70,6 +70,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 
 func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	db := a.db.WithContext(ctx)
 	config := a.config
 	params := &VerifyParams{}
 	params.Token = r.FormValue("token")
@@ -83,7 +84,7 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 		token       *AccessTokenResponse
 	)
 
-	err = a.db.Transaction(func(tx *storage.Connection) error {
+	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		if params.Token == "" {
 			return badRequestError("Verify requires a token")
@@ -158,6 +159,7 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 
 func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	db := a.db.WithContext(ctx)
 	config := a.config
 	params := &VerifyParams{}
 
@@ -188,7 +190,7 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
 		token       *AccessTokenResponse
 	)
 
-	err = a.db.Transaction(func(tx *storage.Connection) error {
+	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		aud := a.requestAud(ctx, r)
 		user, terr = a.verifyUserAndToken(ctx, tx, params, aud)

--- a/storage/dial.go
+++ b/storage/dial.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"net/url"
 	"reflect"
 
@@ -51,6 +52,12 @@ func (c *Connection) Transaction(fn func(*Connection) error) error {
 		})
 	}
 	return fn(c)
+}
+
+// WithContext returns a new connection with an updated context. This is
+// typically used for tracing as the context contains trace span information.
+func (c *Connection) WithContext(ctx context.Context) *Connection {
+	return &Connection{c.Connection.WithContext(ctx)}
 }
 
 func getExcludedColumns(model interface{}, includeColumns ...string) ([]string, error) {


### PR DESCRIPTION
Passes the request's context down to the database queries so that tracing and correlation can work.

Part of #679.