### PR TITLE
refactor: move request structured logger to o11y

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/logger"
 	"github.com/netlify/gotrue/models"
+	"github.com/netlify/gotrue/observability"
 	"github.com/netlify/gotrue/storage"
 	"github.com/sethvargo/go-password/password"
 )
@@ -38,7 +38,7 @@ func (a *API) loadUser(w http.ResponseWriter, r *http.Request) (context.Context,
 		return nil, badRequestError("user_id must be an UUID")
 	}
 
-	logger.LogEntrySetField(r, "user_id", userID)
+	observability.LogEntrySetField(r, "user_id", userID)
 
 	u, err := models.FindUserByID(db, userID)
 	if err != nil {

--- a/api/api.go
+++ b/api/api.go
@@ -14,8 +14,8 @@ import (
 	"github.com/didip/tollbooth/v5/limiter"
 	"github.com/go-chi/chi"
 	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/logger"
 	"github.com/netlify/gotrue/mailer"
+	"github.com/netlify/gotrue/observability"
 	"github.com/netlify/gotrue/storage"
 	"github.com/rs/cors"
 	"github.com/sebest/xff"
@@ -101,7 +101,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 	api.deprecationNotices(ctx)
 
 	xffmw, _ := xff.Default()
-	logger := logger.NewStructuredLogger(logrus.StandardLogger())
+	logger := observability.NewStructuredLogger(logrus.StandardLogger())
 
 	r := newRouter()
 	r.UseBypass(xffmw.Handler)

--- a/api/errors.go
+++ b/api/errors.go
@@ -8,7 +8,7 @@ import (
 	"runtime/debug"
 
 	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/logger"
+	"github.com/netlify/gotrue/observability"
 	"github.com/netlify/gotrue/utilities"
 	"github.com/pkg/errors"
 )
@@ -211,7 +211,7 @@ func recoverer(w http.ResponseWriter, r *http.Request) (context.Context, error) 
 	defer func() {
 		if rvr := recover(); rvr != nil {
 
-			logEntry := logger.GetLogEntry(r)
+			logEntry := observability.GetLogEntry(r)
 			if logEntry != nil {
 				logEntry.Panic(rvr, debug.Stack())
 			} else {
@@ -236,7 +236,7 @@ type ErrorCause interface {
 }
 
 func handleError(err error, w http.ResponseWriter, r *http.Request) {
-	log := logger.GetLogEntry(r)
+	log := observability.GetLogEntry(r)
 	errorID := getRequestID(r.Context())
 	switch e := err.(type) {
 	case *HTTPError:

--- a/api/external.go
+++ b/api/external.go
@@ -14,8 +14,8 @@ import (
 	jwt "github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/api/provider"
 	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/logger"
 	"github.com/netlify/gotrue/models"
+	"github.com/netlify/gotrue/observability"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/utilities"
 	"github.com/sirupsen/logrus"
@@ -62,7 +62,7 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 	}
 
 	redirectURL := a.getRedirectURLOrReferrer(r, query.Get("redirect_to"))
-	log := logger.GetLogEntry(r)
+	log := observability.GetLogEntry(r)
 	log.WithField("provider", providerType).Info("Redirecting to external provider")
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, ExternalProviderClaims{
@@ -445,7 +445,7 @@ func (a *API) Provider(ctx context.Context, name string, scopes string, query *u
 
 func (a *API) redirectErrors(handler apiHandler, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	log := logger.GetLogEntry(r)
+	log := observability.GetLogEntry(r)
 	errorID := getRequestID(ctx)
 	err := handler(w, r)
 	if err != nil {

--- a/api/external_oauth.go
+++ b/api/external_oauth.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mrjones/oauth"
 	"github.com/netlify/gotrue/api/provider"
-	"github.com/netlify/gotrue/logger"
+	"github.com/netlify/gotrue/observability"
 	"github.com/netlify/gotrue/storage"
 	"github.com/sirupsen/logrus"
 )
@@ -68,7 +68,7 @@ func (a *API) oAuthCallback(ctx context.Context, r *http.Request, providerType s
 		return nil, badRequestError("Unsupported provider: %+v", err).WithInternalError(err)
 	}
 
-	log := logger.GetLogEntry(r)
+	log := observability.GetLogEntry(r)
 	log.WithFields(logrus.Fields{
 		"provider": providerType,
 		"code":     oauthCode,

--- a/api/user.go
+++ b/api/user.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/netlify/gotrue/api/sms_provider"
-	"github.com/netlify/gotrue/logger"
 	"github.com/netlify/gotrue/models"
+	"github.com/netlify/gotrue/observability"
 	"github.com/netlify/gotrue/storage"
 )
 
@@ -55,7 +55,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	user := getUser(ctx)
-	log := logger.GetLogEntry(r)
+	log := observability.GetLogEntry(r)
 	log.Debugf("Checking params for token %v", params)
 
 	err = db.Transaction(func(tx *storage.Connection) error {

--- a/api/verify.go
+++ b/api/verify.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/netlify/gotrue/logger"
 	"github.com/netlify/gotrue/models"
+	"github.com/netlify/gotrue/observability"
 	"github.com/netlify/gotrue/storage"
 	"github.com/sethvargo/go-password/password"
 )
@@ -345,7 +345,7 @@ func (a *API) smsVerify(r *http.Request, ctx context.Context, conn *storage.Conn
 func (a *API) prepErrorRedirectURL(err *HTTPError, r *http.Request, rurl string) string {
 	q := url.Values{}
 
-	log := logger.GetLogEntry(r)
+	log := observability.GetLogEntry(r)
 	log.Error(err.Message)
 
 	if str, ok := oauthErrorMap[err.Code]; ok {

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/logger"
+	"github.com/netlify/gotrue/observability"
 	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -91,7 +91,7 @@ func NewAuditLogEntry(r *http.Request, tx *storage.Connection, actor *User, acti
 		IPAddress: ipAddress,
 	}
 
-	logger.LogEntrySetFields(r, logrus.Fields{
+	observability.LogEntrySetFields(r, logrus.Fields{
 		"auth_event": logrus.Fields(payload),
 	})
 

--- a/observability/request-logger.go
+++ b/observability/request-logger.go
@@ -1,4 +1,4 @@
-package logger
+package observability
 
 import (
 	"fmt"


### PR DESCRIPTION
Today the structured logger for the API lives under the `api` package, but it's place is better suited under the `observability` package as logs can be correlated to traces and metrics easily.

Part of #679.