### PR TITLE
Fix mobile/native Apple login in the `id_token` grant flow for hosted instances

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -72,6 +72,9 @@ func (p *IdTokenGrantParams) getVerifier(ctx context.Context, config *conf.Globa
 	case "apple":
 		oAuthProvider = config.External.Apple
 		oAuthProviderClientId = config.External.IosBundleId
+		if oAuthProviderClientId == "" {
+			oAuthProviderClientId = oAuthProvider.ClientID
+		}
 		provider, err = oidc.NewProvider(ctx, "https://appleid.apple.com")
 	case "azure":
 		oAuthProvider = config.External.Azure


### PR DESCRIPTION
Every other supported provider used provided client ID that could be modified and set via the Supabase studio/dashboard but the Apple login was the only one that used a separate `config.External.IosBundleId` that comes from a config file and can't be set in the dashboard.

To fix this, we first try and read the value provided by the config and then try to fallback onto using client IDs, just like it's done for the remaining providers.

cc @kangmingtay who implemented the initial `id_token` grant flow

This should address the error seen by @k0shk0sh in https://github.com/supabase/gotrue/issues/412#issuecomment-1114193213 (happened to me, this PR is an attempt to fix that).

## What kind of change does this PR introduce?

Fixes a bug/omission introduced in https://github.com/supabase/gotrue/pull/189

## What is the current behavior?

The user can use the `id_token` grant login using native Apple sign in only if there exists a configuration file with specified `ios_bundle_id` value, which is not exposed in the online/self-hosted Supabase dashboard: https://github.com/supabase/gotrue/blob/de6cd793280c43dc580afea7877f1430aba964eb/conf/configuration.go#L136

## What is the new behavior?

If the explicit key is missing (by default), then we fall back to using the client ID (Apple Services ID) specified in `/project/[ref]/auth/settings`.

## Additional context

As outlined in https://github.com/supabase/gotrue/pull/189#issuecomment-936117397, it's possible to link App IDs to Service IDs, so I believe one can use a single Service ID (specified in the dashboard) for both native and web auth flows. This means, that this should not break the existing auth flow and one can configure it so that both are supported using a single Service ID.

Without this change, for a app-only flow, users have to configure a new Service ID for a dummy web auth and use the browser-based login flow.
