### PR TITLE
tools: add `-buildvcs=false` to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build deps dev-deps image migrate test vet sec format unused
 CHECK_FILES?=./...
-FLAGS?=-ldflags "-X github.com/netlify/gotrue/utilities.Version=`git describe --tags`"
+FLAGS?=-ldflags "-X github.com/netlify/gotrue/utilities.Version=`git describe --tags`" -buildvcs=false
 DEV_DOCKER_COMPOSE:=docker-compose-dev.yml
 
 help: ## Show this help.


### PR DESCRIPTION
Newer Go versions are getting confused by the `github.com/netlify/gotrue` package (since git says this repo has an origin at `github.com/supabase/gotrue`) and fails with the following error:


```
gotrue           | go build -ldflags "-X github.com/netlify/gotrue/utilities.Version=`git describe --tags`"
gotrue           | fatal: detected dubious ownership in repository at '/go/src/github.com/netlify/gotrue'
gotrue           | To add an exception for this directory, call:
gotrue           |
gotrue           | 	git config --global --add safe.directory /go/src/github.com/netlify/gotrue
gotrue           | error obtaining VCS status: exit status 128
gotrue           | 	Use -buildvcs=false to disable VCS stamping.```

Until we change the package, this should stop the error from appearing.