### PR TITLE
fix: add swagger docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,4 +25,3 @@ on:
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
             publish_dir: swagger-ui
-            

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs
+
+on:
+  workflow_dispatch:
+
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
+    branches:
+      - master
+
+  jobs:
+    docs:
+      name: Generate swagger docs
+      runs-on: ubuntu-20.04
+      steps:
+        - name: Generate Swagger UI
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          output: swagger-ui
+          spec-file: swagger.json
+
+        - name: Deploy to GitHub Pages
+          uses: peaceiris/actions-gh-pages@v3
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            publish_dir: swagger-ui
+            

--- a/api/admin.go
+++ b/api/admin.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sethvargo/go-password/password"
 )
 
-type adminUserParams struct {
+type AdminUserParams struct {
 	Aud          string                 `json:"aud"`
 	Role         string                 `json:"role"`
 	Email        string                 `json:"email"`
@@ -27,6 +27,11 @@ type adminUserParams struct {
 	UserMetaData map[string]interface{} `json:"user_metadata"`
 	AppMetaData  map[string]interface{} `json:"app_metadata"`
 	BanDuration  string                 `json:"ban_duration"`
+}
+
+type AdminListUsersResponse struct {
+	Users []*models.User `json:"users"`
+	Aud   string         `json:"aud"`
 }
 
 func (a *API) loadUser(w http.ResponseWriter, r *http.Request) (context.Context, error) {
@@ -51,8 +56,8 @@ func (a *API) loadUser(w http.ResponseWriter, r *http.Request) (context.Context,
 	return withUser(ctx, u), nil
 }
 
-func (a *API) getAdminParams(r *http.Request) (*adminUserParams, error) {
-	params := adminUserParams{}
+func (a *API) getAdminParams(r *http.Request) (*AdminUserParams, error) {
+	params := AdminUserParams{}
 
 	body, err := getBodyBytes(r)
 	if err != nil {
@@ -90,9 +95,9 @@ func (a *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 	}
 	addPaginationHeaders(w, r, pageParams)
 
-	return sendJSON(w, http.StatusOK, map[string]interface{}{
-		"users": users,
-		"aud":   aud,
+	return sendJSON(w, http.StatusOK, AdminListUsersResponse{
+		Users: users,
+		Aud:   aud,
 	})
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -211,12 +211,18 @@ func NewAPIFromConfigFile(filename string, version string) (*API, *conf.GlobalCo
 	return NewAPIWithVersion(context.Background(), config, db, version), config, nil
 }
 
+type HealthCheckResponse struct {
+	Version     string `json:"version"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
 // HealthCheck endpoint indicates if the gotrue api service is available
 func (a *API) HealthCheck(w http.ResponseWriter, r *http.Request) error {
-	return sendJSON(w, http.StatusOK, map[string]string{
-		"version":     a.version,
-		"name":        "GoTrue",
-		"description": "GoTrue is a user registration and authentication API",
+	return sendJSON(w, http.StatusOK, HealthCheckResponse{
+		Version:     a.version,
+		Name:        "GoTrue",
+		Description: "GoTrue is a user registration and authentication API",
 	})
 }
 

--- a/api/mail.go
+++ b/api/mail.go
@@ -30,6 +30,15 @@ type GenerateLinkParams struct {
 	RedirectTo string                 `json:"redirect_to"`
 }
 
+type GenerateLinkResponse struct {
+	models.User
+	ActionLink       string `json:"action_link"`
+	EmailOtp         string `json:"email_otp"`
+	HashedToken      string `json:"hashed_token"`
+	VerificationType string `json:"verification_type"`
+	RedirectTo       string `json:"redirect_to"`
+}
+
 func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	db := a.db.WithContext(ctx)
@@ -186,19 +195,14 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	resp := make(map[string]interface{})
-	u, err := json.Marshal(user)
-	if err != nil {
-		return internalServerError("User serialization error").WithInternalError(err)
+	resp := GenerateLinkResponse{
+		User:             *user,
+		ActionLink:       url,
+		EmailOtp:         otp,
+		HashedToken:      hashedToken,
+		VerificationType: params.Type,
+		RedirectTo:       referrer,
 	}
-	if err = json.Unmarshal(u, &resp); err != nil {
-		return internalServerError("User serialization error").WithInternalError(err)
-	}
-	resp["action_link"] = url
-	resp["email_otp"] = otp
-	resp["hashed_token"] = hashedToken
-	resp["verification_type"] = params.Type
-	resp["redirect_to"] = referrer
 
 	return sendJSON(w, http.StatusOK, resp)
 }

--- a/docs/admin.go
+++ b/docs/admin.go
@@ -1,0 +1,105 @@
+package docs
+
+import (
+	"github.com/netlify/gotrue/api"
+)
+
+// swagger:route GET /admin/users admin admin-list-users
+// List all users.
+// security:
+//   - bearer:
+// responses:
+//   200: adminListUserResponse
+// 	 401: unauthorizedError
+
+// The list of users.
+// swagger:response adminListUserResponse
+type adminListUserResponseWrapper struct {
+	// in:body
+	Body api.AdminListUsersResponse
+}
+
+// swagger:route POST /admin/users admin admin-create-user
+// Returns the created user.
+// security:
+//   - bearer:
+// responses:
+//   200: userResponse
+// 	 401: unauthorizedError
+
+// The user to be created.
+// swagger:parameters admin-create-user
+type adminUserParamsWrapper struct {
+	// in:body
+	Body api.AdminUserParams
+}
+
+// swagger:route GET /admin/user/{user_id} admin admin-get-user
+// Get a user.
+// security:
+//   - bearer:
+// parameters:
+// + name: user_id
+//   in: path
+//   description: The user's id
+//   required: true
+// responses:
+//   200: userResponse
+// 	 401: unauthorizedError
+
+// The user specified.
+// swagger:response userResponse
+
+// swagger:route PUT /admin/user/{user_id} admin admin-update-user
+// Update a user.
+// security:
+//   - bearer:
+// parameters:
+// + name: user_id
+//   in: path
+//   description: The user's id
+//   required: true
+// responses:
+//   200: userResponse
+// 	 401: unauthorizedError
+
+// The updated user.
+// swagger:response userResponse
+
+// swagger:route DELETE /admin/user/{user_id} admin admin-delete-user
+// Deletes a user.
+// security:
+//   - bearer:
+// parameters:
+// + name: user_id
+//   in: path
+//   description: The user's id
+//   required: true
+// responses:
+//   200: deleteUserResponse
+// 	 401: unauthorizedError
+
+// The updated user.
+// swagger:response deleteUserResponse
+type deleteUserResponseWrapper struct{}
+
+// swagger:route POST /admin/generate_link admin admin-generate-link
+// Generates an email action link.
+// security:
+//   - bearer:
+// responses:
+//   200: generateLinkResponse
+// 	 401: unauthorizedError
+
+// swagger:parameters admin-generate-link
+type generateLinkParams struct {
+	// in:body
+	Body api.GenerateLinkParams
+}
+
+// The response object for generate link.
+// swagger:response generateLinkResponse
+type generateLinkResponseWrapper struct {
+	// in:body
+	Body api.GenerateLinkResponse
+}

--- a/docs/admin.go
+++ b/docs/admin.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import (

--- a/docs/doc.go
+++ b/docs/doc.go
@@ -1,0 +1,15 @@
+// Package classification gotrue
+//
+// Documentation of the gotrue API.
+//
+//     Schemes: http, https
+//     BasePath: /
+//     Version: 1.0.0
+//     Host: localhost:9999
+//
+//
+//     Produces:
+//     - application/json
+//
+// swagger:meta
+package docs

--- a/docs/doc.go
+++ b/docs/doc.go
@@ -7,6 +7,11 @@
 //     Version: 1.0.0
 //     Host: localhost:9999
 //
+//     SecurityDefinitions:
+//     bearer:
+//       type: apiKey
+//       name: Authentication
+//       in: header
 //
 //     Produces:
 //     - application/json

--- a/docs/errors.go
+++ b/docs/errors.go
@@ -1,0 +1,5 @@
+package docs
+
+// This endpoint requires a bearer token.
+// swagger:response unauthorizedError
+type unauthorizedError struct{}

--- a/docs/errors.go
+++ b/docs/errors.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 // This endpoint requires a bearer token.

--- a/docs/health.go
+++ b/docs/health.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import "github.com/netlify/gotrue/api"

--- a/docs/health.go
+++ b/docs/health.go
@@ -1,0 +1,14 @@
+package docs
+
+import "github.com/netlify/gotrue/api"
+
+// swagger:route GET /health health health
+// The healthcheck endpoint for gotrue. Returns the current gotrue version.
+// responses:
+//   200: healthCheckResponse
+
+// swagger:response healthCheckResponse
+type healthCheckResponseWrapper struct {
+	// in:body
+	Body api.HealthCheckResponse
+}

--- a/docs/invite.go
+++ b/docs/invite.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import "github.com/netlify/gotrue/api"

--- a/docs/invite.go
+++ b/docs/invite.go
@@ -1,0 +1,17 @@
+package docs
+
+import "github.com/netlify/gotrue/api"
+
+// swagger:route POST /invite invite invite
+// Sends an invite link to the user.
+// responses:
+//   200: inviteResponse
+
+// swagger:parameters invite
+type inviteParamsWrapper struct {
+	// in:body
+	Body api.InviteParams
+}
+
+// swagger:response inviteResponse
+type inviteResponseWrapper struct{}

--- a/docs/logout.go
+++ b/docs/logout.go
@@ -1,0 +1,11 @@
+package docs
+
+// swagger:route POST /logout logout logout
+// Logs out the user.
+// security:
+//   - bearer:
+// responses:
+//   204: logoutResponse
+
+// swagger:response logoutResponse
+type logoutResponseWrapper struct{}

--- a/docs/logout.go
+++ b/docs/logout.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 // swagger:route POST /logout logout logout

--- a/docs/oauth.go
+++ b/docs/oauth.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 // swagger:route GET /authorize oauth authorize

--- a/docs/oauth.go
+++ b/docs/oauth.go
@@ -1,0 +1,24 @@
+package docs
+
+// swagger:route GET /authorize oauth authorize
+// Redirects the user to the 3rd-party OAuth provider to start the OAuth1.0 or OAuth2.0 authentication process.
+// parameters:
+// + name: redirect_to
+//   in: query
+//   description: The redirect url to return the user to after the `/callback` endpoint has completed.
+//   required: false
+// responses:
+//   302: authorizeResponse
+
+// Redirects user to the 3rd-party OAuth provider
+// swagger:response authorizeResponse
+type authorizeResponseWrapper struct{}
+
+// swagger:route GET /callback oauth callback
+// Receives the redirect from an external provider during the OAuth authentication process. Starts the process of creating an access and refresh token.
+// responses:
+//   302: callbackResponse
+
+// Redirects user to the redirect url specified in `/authorize`. If no `redirect_url` is provided, the user will be redirected to the `SITE_URL`.
+// swagger:response callbackResponse
+type callbackResponseWrapper struct{}

--- a/docs/otp.go
+++ b/docs/otp.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import "github.com/netlify/gotrue/api"

--- a/docs/otp.go
+++ b/docs/otp.go
@@ -1,0 +1,18 @@
+package docs
+
+import "github.com/netlify/gotrue/api"
+
+// swagger:route POST /otp otp otp
+// Passwordless sign-in method for email or phone.
+// responses:
+//   200: otpResponse
+
+// swagger:parameters otp
+type otpParamsWrapper struct {
+	// Only an email or phone should be provided.
+	// in:body
+	Body api.OtpParams
+}
+
+// swagger:response otpResponse
+type otpResponseWrapper struct{}

--- a/docs/recover.go
+++ b/docs/recover.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import "github.com/netlify/gotrue/api"

--- a/docs/recover.go
+++ b/docs/recover.go
@@ -1,0 +1,17 @@
+package docs
+
+import "github.com/netlify/gotrue/api"
+
+// swagger:route POST /recover recovery recovery
+// Sends a password recovery email link to the user's email.
+// responses:
+//   200: recoveryResponse
+
+// swagger:parameters recovery
+type recoveryParamsWrapper struct {
+	// in:body
+	Body api.RecoverParams
+}
+
+// swagger:response recoveryResponse
+type recoveryResponseWrapper struct{}

--- a/docs/settings.go
+++ b/docs/settings.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import "github.com/netlify/gotrue/api"

--- a/docs/settings.go
+++ b/docs/settings.go
@@ -1,0 +1,14 @@
+package docs
+
+import "github.com/netlify/gotrue/api"
+
+// swagger:route GET /settings settings settings
+// Returns the configuration settings for the gotrue server.
+// responses:
+//   200: settingsResponse
+
+// swagger:response settingsResponse
+type settingsResponseWrapper struct {
+	// in:body
+	Body api.Settings
+}

--- a/docs/signup.go
+++ b/docs/signup.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import (

--- a/docs/signup.go
+++ b/docs/signup.go
@@ -1,0 +1,16 @@
+package docs
+
+import (
+	"github.com/netlify/gotrue/api"
+)
+
+// swagger:route POST /signup signup signup
+// Password-based signup with either email or phone.
+// responses:
+//   200: userResponse
+
+// swagger:parameters signup
+type signupParamsWrapper struct {
+	// in:body
+	Body api.SignupParams
+}

--- a/docs/token.go
+++ b/docs/token.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import (

--- a/docs/token.go
+++ b/docs/token.go
@@ -1,0 +1,33 @@
+package docs
+
+import (
+	"github.com/netlify/gotrue/api"
+)
+
+// swagger:route POST /token?grant_type=password token token-password
+// Signs in a user with a password.
+// responses:
+//   200: tokenResponse
+
+// swagger:parameters token-password
+type tokenPasswordGrantParamsWrapper struct {
+	// in:body
+	Body api.PasswordGrantParams
+}
+
+// swagger:route POST /token?grant_type=refresh_token token token-refresh
+// Refreshes a user's refresh token.
+// responses:
+//   200: tokenResponse
+
+// swagger:parameters token-refresh
+type tokenRefreshTokenGrantParamsWrapper struct {
+	// in:body
+	Body api.RefreshTokenGrantParams
+}
+
+// swagger:response tokenResponse
+type tokenResponseWrapper struct {
+	// in:body
+	Body api.AccessTokenResponse
+}

--- a/docs/user.go
+++ b/docs/user.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import (

--- a/docs/user.go
+++ b/docs/user.go
@@ -1,0 +1,36 @@
+package docs
+
+import (
+	"github.com/netlify/gotrue/api"
+	"github.com/netlify/gotrue/models"
+)
+
+// swagger:route GET /user user user-get
+// Get information for the logged-in user.
+// security:
+//   - bearer:
+// responses:
+//   200: userResponse
+// 	 401: unauthorizedError
+
+// The current user.
+// swagger:response userResponse
+type userResponseWrapper struct {
+	// in:body
+	Body models.User
+}
+
+// swagger:route PUT /user user user-put
+// Returns the updated user.
+// security:
+//   - bearer:
+// responses:
+//   200: userResponse
+// 	 401: unauthorizedError
+
+// The current user.
+// swagger:parameters user-put
+type userUpdateParams struct {
+	// in:body
+	Body api.UserUpdateParams
+}

--- a/docs/verify.go
+++ b/docs/verify.go
@@ -1,0 +1,23 @@
+package docs
+
+import (
+	"github.com/netlify/gotrue/api"
+)
+
+// swagger:route GET /verify verify verify-get
+// Verifies a sign up.
+
+// swagger:parameters verify-get
+type verifyGetParamsWrapper struct {
+	// in:query
+	api.VerifyParams
+}
+
+// swagger:route POST /verify verify verify-post
+// Verifies a sign up.
+
+// swagger:parameters verify-post
+type verifyPostParamsWrapper struct {
+	// in:body
+	Body api.VerifyParams
+}

--- a/docs/verify.go
+++ b/docs/verify.go
@@ -1,3 +1,4 @@
+//lint:file-ignore U1000 ignore go-swagger template
 package docs
 
 import (

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"log"
 
 	"github.com/netlify/gotrue/cmd"
-	_ "github.com/netlify/gotrue/docs"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/netlify/gotrue/cmd"
+	_ "github.com/netlify/gotrue/docs"
 )
 
 func main() {

--- a/swagger.json
+++ b/swagger.json
@@ -60,7 +60,7 @@
         "operationId": "admin-get-user",
         "parameters": [
           {
-            "description": "the user's id",
+            "description": "The user's id",
             "name": "user_id",
             "in": "path",
             "required": true
@@ -88,7 +88,7 @@
         "operationId": "admin-update-user",
         "parameters": [
           {
-            "description": "the user's id",
+            "description": "The user's id",
             "name": "user_id",
             "in": "path",
             "required": true
@@ -116,7 +116,7 @@
         "operationId": "admin-delete-user",
         "parameters": [
           {
-            "description": "the user's id",
+            "description": "The user's id",
             "name": "user_id",
             "in": "path",
             "required": true
@@ -1283,6 +1283,13 @@
       "schema": {
         "$ref": "#/definitions/User"
       }
+    }
+  },
+  "securityDefinitions": {
+    "bearer": {
+      "type": "apiKey",
+      "name": "Authentication",
+      "in": "header"
     }
   }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,1288 @@
+{
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "swagger": "2.0",
+  "info": {
+    "description": "Documentation of the gotrue API.",
+    "title": "gotrue",
+    "version": "1.0.0"
+  },
+  "host": "localhost:9999",
+  "basePath": "/",
+  "paths": {
+    "/admin/generate_link": {
+      "post": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "admin"
+        ],
+        "summary": "Generates an email action link.",
+        "operationId": "admin-generate-link",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/GenerateLinkParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/generateLinkResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorizedError"
+          }
+        }
+      }
+    },
+    "/admin/user/{user_id}": {
+      "get": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get a user.",
+        "operationId": "admin-get-user",
+        "parameters": [
+          {
+            "description": "the user's id",
+            "name": "user_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/userResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorizedError"
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "admin"
+        ],
+        "summary": "Update a user.",
+        "operationId": "admin-update-user",
+        "parameters": [
+          {
+            "description": "the user's id",
+            "name": "user_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/userResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorizedError"
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "admin"
+        ],
+        "summary": "Deletes a user.",
+        "operationId": "admin-delete-user",
+        "parameters": [
+          {
+            "description": "the user's id",
+            "name": "user_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/deleteUserResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorizedError"
+          }
+        }
+      }
+    },
+    "/admin/users": {
+      "get": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "admin"
+        ],
+        "summary": "List all users.",
+        "operationId": "admin-list-users",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/adminListUserResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorizedError"
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "admin"
+        ],
+        "summary": "Returns the created user.",
+        "operationId": "admin-create-user",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/AdminUserParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/userResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorizedError"
+          }
+        }
+      }
+    },
+    "/authorize": {
+      "get": {
+        "tags": [
+          "oauth"
+        ],
+        "summary": "Redirects the user to the 3rd-party OAuth provider to start the OAuth1.0 or OAuth2.0 authentication process.",
+        "operationId": "authorize",
+        "parameters": [
+          {
+            "description": "The redirect url to return the user to after the `/callback` endpoint has completed.",
+            "name": "redirect_to",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "302": {
+            "$ref": "#/responses/authorizeResponse"
+          }
+        }
+      }
+    },
+    "/callback": {
+      "get": {
+        "tags": [
+          "oauth"
+        ],
+        "summary": "Receives the redirect from an external provider during the OAuth authentication process. Starts the process of creating an access and refresh token.",
+        "operationId": "callback",
+        "responses": {
+          "302": {
+            "$ref": "#/responses/callbackResponse"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "The healthcheck endpoint for gotrue. Returns the current gotrue version.",
+        "operationId": "health",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/healthCheckResponse"
+          }
+        }
+      }
+    },
+    "/invite": {
+      "post": {
+        "tags": [
+          "invite"
+        ],
+        "summary": "Sends an invite link to the user.",
+        "operationId": "invite",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/InviteParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/inviteResponse"
+          }
+        }
+      }
+    },
+    "/logout": {
+      "post": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "logout"
+        ],
+        "summary": "Logs out the user.",
+        "operationId": "logout",
+        "responses": {
+          "204": {
+            "$ref": "#/responses/logoutResponse"
+          }
+        }
+      }
+    },
+    "/otp": {
+      "post": {
+        "tags": [
+          "otp"
+        ],
+        "summary": "Passwordless sign-in method for email or phone.",
+        "operationId": "otp",
+        "parameters": [
+          {
+            "description": "Only an email or phone should be provided.",
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/OtpParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/otpResponse"
+          }
+        }
+      }
+    },
+    "/recover": {
+      "post": {
+        "tags": [
+          "recovery"
+        ],
+        "summary": "Sends a password recovery email link to the user's email.",
+        "operationId": "recovery",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/RecoverParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/recoveryResponse"
+          }
+        }
+      }
+    },
+    "/settings": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Returns the configuration settings for the gotrue server.",
+        "operationId": "settings",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/settingsResponse"
+          }
+        }
+      }
+    },
+    "/signup": {
+      "post": {
+        "tags": [
+          "signup"
+        ],
+        "summary": "Password-based signup with either email or phone.",
+        "operationId": "signup",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/SignupParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/userResponse"
+          }
+        }
+      }
+    },
+    "/token?grant_type=password": {
+      "post": {
+        "tags": [
+          "token"
+        ],
+        "summary": "Signs in a user with a password.",
+        "operationId": "token-password",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/PasswordGrantParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/tokenResponse"
+          }
+        }
+      }
+    },
+    "/token?grant_type=refresh_token": {
+      "post": {
+        "tags": [
+          "token"
+        ],
+        "summary": "Refreshes a user's refresh token.",
+        "operationId": "token-refresh",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/RefreshTokenGrantParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/tokenResponse"
+          }
+        }
+      }
+    },
+    "/user": {
+      "get": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "user"
+        ],
+        "summary": "Get information for the logged-in user.",
+        "operationId": "user-get",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/userResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorizedError"
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "user"
+        ],
+        "summary": "Returns the updated user.",
+        "operationId": "user-put",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/UserUpdateParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/userResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorizedError"
+          }
+        }
+      }
+    },
+    "/verify": {
+      "get": {
+        "tags": [
+          "verify"
+        ],
+        "summary": "Verifies a sign up.",
+        "operationId": "verify-get",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Type",
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Token",
+            "name": "token",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Email",
+            "name": "email",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Phone",
+            "name": "phone",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "RedirectTo",
+            "name": "redirect_to",
+            "in": "query"
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "verify"
+        ],
+        "summary": "Verifies a sign up.",
+        "operationId": "verify-post",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/VerifyParams"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "AccessTokenResponse": {
+      "description": "AccessTokenResponse represents an OAuth2 success response",
+      "type": "object",
+      "properties": {
+        "access_token": {
+          "type": "string",
+          "x-go-name": "Token"
+        },
+        "expires_in": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ExpiresIn"
+        },
+        "refresh_token": {
+          "type": "string",
+          "x-go-name": "RefreshToken"
+        },
+        "token_type": {
+          "type": "string",
+          "x-go-name": "TokenType"
+        },
+        "user": {
+          "$ref": "#/definitions/User"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "AdminListUsersResponse": {
+      "type": "object",
+      "properties": {
+        "aud": {
+          "type": "string",
+          "x-go-name": "Aud"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/User"
+          },
+          "x-go-name": "Users"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "AdminUserParams": {
+      "type": "object",
+      "properties": {
+        "app_metadata": {
+          "type": "object",
+          "additionalProperties": {},
+          "x-go-name": "AppMetaData"
+        },
+        "aud": {
+          "type": "string",
+          "x-go-name": "Aud"
+        },
+        "ban_duration": {
+          "type": "string",
+          "x-go-name": "BanDuration"
+        },
+        "email": {
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "email_confirm": {
+          "type": "boolean",
+          "x-go-name": "EmailConfirm"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "phone": {
+          "type": "string",
+          "x-go-name": "Phone"
+        },
+        "phone_confirm": {
+          "type": "boolean",
+          "x-go-name": "PhoneConfirm"
+        },
+        "role": {
+          "type": "string",
+          "x-go-name": "Role"
+        },
+        "user_metadata": {
+          "type": "object",
+          "additionalProperties": {},
+          "x-go-name": "UserMetaData"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "GenerateLinkParams": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": {},
+          "x-go-name": "Data"
+        },
+        "email": {
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "new_email": {
+          "type": "string",
+          "x-go-name": "NewEmail"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "redirect_to": {
+          "type": "string",
+          "x-go-name": "RedirectTo"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "GenerateLinkResponse": {
+      "type": "object",
+      "properties": {
+        "action_link": {
+          "type": "string",
+          "x-go-name": "ActionLink"
+        },
+        "app_metadata": {
+          "$ref": "#/definitions/JSONMap"
+        },
+        "aud": {
+          "type": "string",
+          "x-go-name": "Aud"
+        },
+        "banned_until": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "BannedUntil"
+        },
+        "confirmation_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "ConfirmationSentAt"
+        },
+        "confirmed_at": {
+          "description": "For backward compatibility only. Use EmailConfirmedAt or PhoneConfirmedAt instead.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "ConfirmedAt"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "email": {
+          "$ref": "#/definitions/NullString"
+        },
+        "email_change_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "EmailChangeSentAt"
+        },
+        "email_confirmed_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "EmailConfirmedAt"
+        },
+        "email_otp": {
+          "type": "string",
+          "x-go-name": "EmailOtp"
+        },
+        "hashed_token": {
+          "type": "string",
+          "x-go-name": "HashedToken"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "x-go-name": "ID"
+        },
+        "identities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Identity"
+          },
+          "x-go-name": "Identities"
+        },
+        "invited_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "InvitedAt"
+        },
+        "last_sign_in_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "LastSignInAt"
+        },
+        "new_email": {
+          "type": "string",
+          "x-go-name": "EmailChange"
+        },
+        "new_phone": {
+          "type": "string",
+          "x-go-name": "PhoneChange"
+        },
+        "phone": {
+          "$ref": "#/definitions/NullString"
+        },
+        "phone_change_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "PhoneChangeSentAt"
+        },
+        "phone_confirmed_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "PhoneConfirmedAt"
+        },
+        "reauthentication_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "ReauthenticationSentAt"
+        },
+        "recovery_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "RecoverySentAt"
+        },
+        "redirect_to": {
+          "type": "string",
+          "x-go-name": "RedirectTo"
+        },
+        "role": {
+          "type": "string",
+          "x-go-name": "Role"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        },
+        "user_metadata": {
+          "$ref": "#/definitions/JSONMap"
+        },
+        "verification_type": {
+          "type": "string",
+          "x-go-name": "VerificationType"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "HealthCheckResponse": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "x-go-name": "Description"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "version": {
+          "type": "string",
+          "x-go-name": "Version"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "Identity": {
+      "type": "object",
+      "properties": {
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "identity_data": {
+          "$ref": "#/definitions/JSONMap"
+        },
+        "last_sign_in_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "LastSignInAt"
+        },
+        "provider": {
+          "type": "string",
+          "x-go-name": "Provider"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        },
+        "user_id": {
+          "type": "string",
+          "format": "uuid",
+          "x-go-name": "UserID"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/models"
+    },
+    "InviteParams": {
+      "description": "InviteParams are the parameters the Signup endpoint accepts",
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": {},
+          "x-go-name": "Data"
+        },
+        "email": {
+          "type": "string",
+          "x-go-name": "Email"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "JSONMap": {
+      "type": "object",
+      "additionalProperties": {},
+      "x-go-package": "github.com/netlify/gotrue/models"
+    },
+    "NullString": {
+      "type": "string",
+      "x-go-package": "github.com/netlify/gotrue/storage"
+    },
+    "OtpParams": {
+      "description": "OtpParams contains the request body params for the otp endpoint",
+      "type": "object",
+      "properties": {
+        "create_user": {
+          "type": "boolean",
+          "x-go-name": "CreateUser"
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": {},
+          "x-go-name": "Data"
+        },
+        "email": {
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "phone": {
+          "type": "string",
+          "x-go-name": "Phone"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "PasswordGrantParams": {
+      "description": "PasswordGrantParams are the parameters the ResourceOwnerPasswordGrant method accepts",
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "phone": {
+          "type": "string",
+          "x-go-name": "Phone"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "ProviderSettings": {
+      "type": "object",
+      "properties": {
+        "apple": {
+          "type": "boolean",
+          "x-go-name": "Apple"
+        },
+        "azure": {
+          "type": "boolean",
+          "x-go-name": "Azure"
+        },
+        "bitbucket": {
+          "type": "boolean",
+          "x-go-name": "Bitbucket"
+        },
+        "discord": {
+          "type": "boolean",
+          "x-go-name": "Discord"
+        },
+        "email": {
+          "type": "boolean",
+          "x-go-name": "Email"
+        },
+        "facebook": {
+          "type": "boolean",
+          "x-go-name": "Facebook"
+        },
+        "github": {
+          "type": "boolean",
+          "x-go-name": "GitHub"
+        },
+        "gitlab": {
+          "type": "boolean",
+          "x-go-name": "GitLab"
+        },
+        "google": {
+          "type": "boolean",
+          "x-go-name": "Google"
+        },
+        "keycloak": {
+          "type": "boolean",
+          "x-go-name": "Keycloak"
+        },
+        "linkedin": {
+          "type": "boolean",
+          "x-go-name": "Linkedin"
+        },
+        "notion": {
+          "type": "boolean",
+          "x-go-name": "Notion"
+        },
+        "phone": {
+          "type": "boolean",
+          "x-go-name": "Phone"
+        },
+        "saml": {
+          "type": "boolean",
+          "x-go-name": "SAML"
+        },
+        "slack": {
+          "type": "boolean",
+          "x-go-name": "Slack"
+        },
+        "spotify": {
+          "type": "boolean",
+          "x-go-name": "Spotify"
+        },
+        "twitch": {
+          "type": "boolean",
+          "x-go-name": "Twitch"
+        },
+        "twitter": {
+          "type": "boolean",
+          "x-go-name": "Twitter"
+        },
+        "workos": {
+          "type": "boolean",
+          "x-go-name": "WorkOS"
+        },
+        "zoom": {
+          "type": "boolean",
+          "x-go-name": "Zoom"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "RecoverParams": {
+      "description": "RecoverParams holds the parameters for a password recovery request",
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "x-go-name": "Email"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "RefreshTokenGrantParams": {
+      "description": "RefreshTokenGrantParams are the parameters the RefreshTokenGrant method accepts",
+      "type": "object",
+      "properties": {
+        "refresh_token": {
+          "type": "string",
+          "x-go-name": "RefreshToken"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "Settings": {
+      "type": "object",
+      "properties": {
+        "disable_signup": {
+          "type": "boolean",
+          "x-go-name": "DisableSignup"
+        },
+        "external": {
+          "$ref": "#/definitions/ProviderSettings"
+        },
+        "mailer_autoconfirm": {
+          "type": "boolean",
+          "x-go-name": "MailerAutoconfirm"
+        },
+        "phone_autoconfirm": {
+          "type": "boolean",
+          "x-go-name": "PhoneAutoconfirm"
+        },
+        "sms_provider": {
+          "type": "string",
+          "x-go-name": "SmsProvider"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "SignupParams": {
+      "description": "SignupParams are the parameters the Signup endpoint accepts",
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": {},
+          "x-go-name": "Data"
+        },
+        "email": {
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "phone": {
+          "type": "string",
+          "x-go-name": "Phone"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "User": {
+      "description": "User respresents a registered user with email/password authentication",
+      "type": "object",
+      "properties": {
+        "app_metadata": {
+          "$ref": "#/definitions/JSONMap"
+        },
+        "aud": {
+          "type": "string",
+          "x-go-name": "Aud"
+        },
+        "banned_until": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "BannedUntil"
+        },
+        "confirmation_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "ConfirmationSentAt"
+        },
+        "confirmed_at": {
+          "description": "For backward compatibility only. Use EmailConfirmedAt or PhoneConfirmedAt instead.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "ConfirmedAt"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreatedAt"
+        },
+        "email": {
+          "$ref": "#/definitions/NullString"
+        },
+        "email_change_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "EmailChangeSentAt"
+        },
+        "email_confirmed_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "EmailConfirmedAt"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "x-go-name": "ID"
+        },
+        "identities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Identity"
+          },
+          "x-go-name": "Identities"
+        },
+        "invited_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "InvitedAt"
+        },
+        "last_sign_in_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "LastSignInAt"
+        },
+        "new_email": {
+          "type": "string",
+          "x-go-name": "EmailChange"
+        },
+        "new_phone": {
+          "type": "string",
+          "x-go-name": "PhoneChange"
+        },
+        "phone": {
+          "$ref": "#/definitions/NullString"
+        },
+        "phone_change_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "PhoneChangeSentAt"
+        },
+        "phone_confirmed_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "PhoneConfirmedAt"
+        },
+        "reauthentication_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "ReauthenticationSentAt"
+        },
+        "recovery_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "RecoverySentAt"
+        },
+        "role": {
+          "type": "string",
+          "x-go-name": "Role"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "UpdatedAt"
+        },
+        "user_metadata": {
+          "$ref": "#/definitions/JSONMap"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/models"
+    },
+    "UserUpdateParams": {
+      "description": "UserUpdateParams parameters for updating a user",
+      "type": "object",
+      "properties": {
+        "app_metadata": {
+          "type": "object",
+          "additionalProperties": {},
+          "x-go-name": "AppData"
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": {},
+          "x-go-name": "Data"
+        },
+        "email": {
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "nonce": {
+          "type": "string",
+          "x-go-name": "Nonce"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "phone": {
+          "type": "string",
+          "x-go-name": "Phone"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    },
+    "VerifyParams": {
+      "description": "VerifyParams are the parameters the Verify endpoint accepts",
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "x-go-name": "Email"
+        },
+        "phone": {
+          "type": "string",
+          "x-go-name": "Phone"
+        },
+        "redirect_to": {
+          "type": "string",
+          "x-go-name": "RedirectTo"
+        },
+        "token": {
+          "type": "string",
+          "x-go-name": "Token"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-package": "github.com/netlify/gotrue/api"
+    }
+  },
+  "responses": {
+    "adminListUserResponse": {
+      "description": "The list of users.",
+      "schema": {
+        "$ref": "#/definitions/AdminListUsersResponse"
+      }
+    },
+    "authorizeResponse": {
+      "description": "Redirects user to the 3rd-party OAuth provider"
+    },
+    "callbackResponse": {
+      "description": "Redirects user to the redirect url specified in `/authorize`. If no `redirect_url` is provided, the user will be redirected to the `SITE_URL`."
+    },
+    "deleteUserResponse": {
+      "description": "The updated user."
+    },
+    "generateLinkResponse": {
+      "description": "The response object for generate link.",
+      "schema": {
+        "$ref": "#/definitions/GenerateLinkResponse"
+      }
+    },
+    "healthCheckResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/HealthCheckResponse"
+      }
+    },
+    "inviteResponse": {
+      "description": ""
+    },
+    "logoutResponse": {
+      "description": ""
+    },
+    "otpResponse": {
+      "description": ""
+    },
+    "recoveryResponse": {
+      "description": ""
+    },
+    "settingsResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/Settings"
+      }
+    },
+    "tokenResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/AccessTokenResponse"
+      }
+    },
+    "unauthorizedError": {
+      "description": "This endpoint requires a bearer token."
+    },
+    "userResponse": {
+      "description": "The current user.",
+      "schema": {
+        "$ref": "#/definitions/User"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Supersedes #230  
* Adds swagger spec for gotrue's API
* Had to change the response data structure from a `map[string]interface{}` to a proper struct for some endpoint so they can be reused in `/docs` 

## To run
```
# Make sure you install go-swagger locally
$ git clone https://github.com/go-swagger/go-swagger && cd go-swagger

# go-swagger >0.30.0 is broken and does not generate the spec from a struct properly. v0.30.0 is the latest working version.
$ git checkout v0.30.0

# Install the swagger command 
$ go install -ldflags "-X github.com/go-swagger/go-swagger/cmd/swagger/commands.Version=$(git describe --tags) -X github.com/go-swagger/go-swagger/cmd/swagger/commands.Commit=$(git rev-parse HEAD)" ./cmd/swagger

# cd into your local gotrue clone and generate the spec
$ swagger generate spec -o ./swagger.json

# Serve the swagger ui locally
$ swagger serve -F=swagger swagger.json
```