### PR TITLE
Add Rate limiters for MFA

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -164,7 +164,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 				r.Use(api.loadUser)
 				r.Route("/factor", func(r *router) {
 					r.Post("/", api.EnrollFactor)
-					r.With(api.requireAuthentication).Route("/{factor_id}", func(r *router) {
+					r.Route("/{factor_id}", func(r *router) {
 						r.Use(api.loadFactor)
 
 						r.With(api.limitHandler(

--- a/api/api.go
+++ b/api/api.go
@@ -168,11 +168,11 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 						r.Use(api.loadFactor)
 
 						r.With(api.limitHandler(
-							tollbooth.NewLimiter(api.config.MFA.RateLimitVerify/(60*5), &limiter.ExpirableOptions{
+							tollbooth.NewLimiter(api.config.MFA.RateLimitChallengeAndVerify/(60*5), &limiter.ExpirableOptions{
 								DefaultExpirationTTL: time.Hour,
 							}).SetBurst(30))).Post("/verify", api.VerifyFactor)
 						r.With(api.limitHandler(
-							tollbooth.NewLimiter(api.config.MFA.RateLimitChallenge/(60*5), &limiter.ExpirableOptions{
+							tollbooth.NewLimiter(api.config.MFA.RateLimitChallengeAndVerify/(60*5), &limiter.ExpirableOptions{
 								DefaultExpirationTTL: time.Hour,
 							}).SetBurst(30))).Post("/challenge", api.ChallengeFactor)
 						r.Delete("/", api.UnenrollFactor)

--- a/api/api.go
+++ b/api/api.go
@@ -163,11 +163,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			r.Route("/{user_id}", func(r *router) {
 				r.Use(api.loadUser)
 				r.Route("/factor", func(r *router) {
-					r.With(api.limitHandler(
-						tollbooth.NewLimiter(api.config.MFA.RateLimitEnroll/(60*5), &limiter.ExpirableOptions{
-							DefaultExpirationTTL: time.Hour,
-						}).SetBurst(30),
-					)).Post("/", api.EnrollFactor)
+					r.Post("/", api.EnrollFactor)
 					r.With(api.requireAuthentication).Route("/{factor_id}", func(r *router) {
 						r.Use(api.loadFactor)
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -56,8 +56,8 @@ type JWTConfiguration struct {
 type MFAConfiguration struct {
 	ChallengeExpiryDuration float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	RateLimitChallenge      float64 `split_words:"true" default:"15"`
- 	RateLimitEnroll         float64 `split_words:"true" default:"10"`
- 	RateLimitVerify         float64 `split_words:"true" default:"10"`
+	RateLimitEnroll         float64 `split_words:"true" default:"10"`
+	RateLimitVerify         float64 `split_words:"true" default:"10"`
 }
 
 type APIConfiguration struct {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -55,7 +55,11 @@ type JWTConfiguration struct {
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
 	ChallengeExpiryDuration float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
+	RateLimitChallenge      float64 `split_words:"true" default:"15"`
+ 	RateLimitEnroll         float64 `split_words:"true" default:"10"`
+ 	RateLimitVerify         float64 `split_words:"true" default:"10"`
 }
+
 type APIConfiguration struct {
 	Host            string
 	Port            int `envconfig:"PORT" default:"8081"`

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -56,8 +56,8 @@ type JWTConfiguration struct {
 type MFAConfiguration struct {
 	ChallengeExpiryDuration float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	RateLimitChallenge      float64 `split_words:"true" default:"15"`
-	RateLimitEnroll         float64 `split_words:"true" default:"10"`
 	RateLimitVerify         float64 `split_words:"true" default:"10"`
+	MaxEnrolledFactors      float64 `split_words:"true" default:"10"`
 }
 
 type APIConfiguration struct {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -54,10 +54,9 @@ type JWTConfiguration struct {
 
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
-	ChallengeExpiryDuration float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
-	RateLimitChallenge      float64 `split_words:"true" default:"15"`
-	RateLimitVerify         float64 `split_words:"true" default:"10"`
-	MaxEnrolledFactors      float64 `split_words:"true" default:"10"`
+	ChallengeExpiryDuration     float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
+	RateLimitChallengeAndVerify float64 `split_words:"true" default:"15"`
+	MaxEnrolledFactors          float64 `split_words:"true" default:"10"`
 }
 
 type APIConfiguration struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces tollbooth rate limiters as in PR

Exact values  are up for discussion. Decided not to slap hcaptcha on as captcha is already deployed on the 1FA routes

## What is the current behavior?

No rate limiters



Add any other context or screenshots.
