### PR TITLE
fix: skip rate limit if header not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ help: ## Show this help.
 all: vet sec static build ## Run the tests and build the binary.
 
 build: deps ## Build the binary.
-	go build $(FLAGS)
-	GOOS=linux GOARCH=arm64 go build $(FLAGS) -o gotrue-arm64
+	CGO_ENABLED=0 GOOS=linux go build $(FLAGS)
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o gotrue-arm64
 
 dev-deps: ## Install developer dependencies
 	@go install github.com/gobuffalo/pop/soda@latest


### PR DESCRIPTION
Rate limiting was applied to all users if the rate limit header value was not present in the request.