### PR TITLE
Fix bug preventing OIDC from working with Apple

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -71,7 +71,7 @@ func (p *IdTokenGrantParams) getVerifier(ctx context.Context, config *conf.Globa
 	switch p.Provider {
 	case "apple":
 		oAuthProvider = config.External.Apple
-		oAuthProviderClientId = config.External.IosBundleId
+		oAuthProviderClientId = oAuthProvider.ClientID
 		provider, err = oidc.NewProvider(ctx, "https://appleid.apple.com")
 	case "azure":
 		oAuthProvider = config.External.Azure


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updates OIDC to fix bug preventing SignInWithApple.

Fixes bug that prevents using openID with Sign in with Apple.

## What is the current behavior?
 Always returns "invalid configuration, clientID must be provided or SkipClientIDCheck".

https://github.com/supabase/gotrue/issues/412#issuecomment-1260517168

## What is the new behavior?
Should actually use the cliendID being passed in from the request.
