### PR TITLE
fix: allow all URL forms in redirects

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
-	"strings"
 
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
@@ -103,13 +102,8 @@ func isRedirectURLValid(config *conf.GlobalConfiguration, redirectURL string) bo
 	}
 
 	// For case when user came from mobile app or other permitted resource - redirect back
-	for uri, g := range config.URIAllowListMap {
-		// Only allow wildcard matching if url scheme is http(s)
-		if strings.HasPrefix(uri, "http") || strings.HasPrefix(uri, "https") {
-			if g.Match(redirectURL) {
-				return true
-			}
-		} else if redirectURL == uri {
+	for _, pattern := range config.URIAllowListMap {
+		if pattern.Match(redirectURL) {
 			return true
 		}
 	}

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -450,12 +450,15 @@ func (ts *VerifyTestSuite) TestVerifySignupWithredirectURLContainedPath() {
 			requestredirectURL:  "twitter://timeline",
 			expectedredirectURL: "twitter://timeline",
 		},
+		// previously the below example was not allowed and with good
+		// reason, however users do want flexibility in the redirect
+		// URL after the scheme, which is why the example is now corrected
 		{
 			desc:                "wildcard mobile deep link redirect url in allow list",
 			siteURL:             "http://test.dev:3000/#/",
-			uriAllowList:        []string{"com.mobile.*"},
-			requestredirectURL:  "com.mobile.app",
-			expectedredirectURL: "http://test.dev:3000/#/",
+			uriAllowList:        []string{"com.example.app://**"},
+			requestredirectURL:  "com.example.app://sign-in/v2",
+			expectedredirectURL: "com.example.app://sign-in/v2",
 		},
 		{
 			desc:                "redirect respects . separator",


### PR DESCRIPTION
GoTrue limited wildcard redirect patterns only on `http` or `https` URLs. This presents a problem in mobile apps that have dynamic redirects back to their application.

See: #710.