### PR TITLE
fix: load user after sign-up to pull data from triggers

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -324,5 +324,13 @@ func (a *API) signupNewUser(ctx context.Context, conn *storage.Connection, param
 		return nil, err
 	}
 
+	// sometimes there may be triggers in the database that will modify the
+	// user data as it is being inserted. thus we load the user object
+	// again to fetch those changes.
+	err = conn.Eager().Load(user)
+	if err != nil {
+		return nil, internalServerError("Database error loading user after sign-up").WithInternalError(err)
+	}
+
 	return user, nil
 }


### PR DESCRIPTION
Some developers attach triggers to the `users` table where they add custom columns or other data upon the creation of a new user. This data was not visible in the response from the sign up API call.

This PR loads the user again after the initial sign-up to pull the latest data from the database.

See: #288 