### PR TITLE
fix: lowercase emails for verify otp

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -234,7 +234,8 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Email != "" {
-		if err := a.validateEmail(ctx, params.Email); err != nil {
+		params.Email, err = a.validateEmail(ctx, params.Email)
+		if err != nil {
 			return err
 		}
 		if exists, err := models.IsDuplicatedEmail(db, params.Email, aud); err != nil {

--- a/api/invite.go
+++ b/api/invite.go
@@ -31,7 +31,8 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read Invite params: %v", err)
 	}
 
-	if err := a.validateEmail(ctx, params.Email); err != nil {
+	params.Email, err = a.validateEmail(ctx, params.Email)
+	if err != nil {
 		return err
 	}
 

--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -43,7 +43,8 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	if params.Email == "" {
 		return unprocessableEntityError("Password recovery requires an email")
 	}
-	if err := a.validateEmail(ctx, params.Email); err != nil {
+	params.Email, err = a.validateEmail(ctx, params.Email)
+	if err != nil {
 		return err
 	}
 

--- a/api/otp.go
+++ b/api/otp.go
@@ -171,7 +171,8 @@ func (a *API) shouldCreateUser(r *http.Request, params *OtpParams) (bool, error)
 		aud := a.requestAud(ctx, r)
 		var err error
 		if params.Email != "" {
-			if err := a.validateEmail(ctx, params.Email); err != nil {
+			params.Email, err = a.validateEmail(ctx, params.Email)
+			if err != nil {
 				return false, err
 			}
 			_, err = models.FindUserByEmailAndAudience(db, params.Email, aud)

--- a/api/recover.go
+++ b/api/recover.go
@@ -37,7 +37,8 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	var user *models.User
 	aud := a.requestAud(ctx, r)
 
-	if err := a.validateEmail(ctx, params.Email); err != nil {
+	params.Email, err = a.validateEmail(ctx, params.Email)
+	if err != nil {
 		return err
 	}
 	user, err = models.FindUserByEmailAndAudience(db, params.Email, aud)

--- a/api/signup.go
+++ b/api/signup.go
@@ -73,7 +73,8 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if !config.External.Email.Enabled {
 			return badRequestError("Email signups are disabled")
 		}
-		if err := a.validateEmail(ctx, params.Email); err != nil {
+		params.Email, err = a.validateEmail(ctx, params.Email)
+		if err != nil {
 			return err
 		}
 		user, err = models.FindUserByEmailAndAudience(db, params.Email, params.Aud)

--- a/api/user.go
+++ b/api/user.go
@@ -98,7 +98,8 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if params.Email != "" && params.Email != user.GetEmail() {
-			if terr = a.validateEmail(ctx, params.Email); terr != nil {
+			params.Email, terr = a.validateEmail(ctx, params.Email)
+			if terr != nil {
 				return terr
 			}
 

--- a/api/verify.go
+++ b/api/verify.go
@@ -475,7 +475,8 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 			return nil, badRequestError("Invalid sms verification type")
 		}
 	} else if isEmailOtpVerification(params) {
-		if err := a.validateEmail(ctx, params.Email); err != nil {
+		params.Email, err = a.validateEmail(ctx, params.Email)
+		if err != nil {
 			return nil, unprocessableEntityError("Invalid email format").WithInternalError(err)
 		}
 		tokenHash = fmt.Sprintf("%x", sha256.Sum224([]byte(string(params.Email)+params.Token)))


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes https://github.com/supabase/gotrue-js/issues/435 because the `POST /verify` takes in the email in the request and hashes it without making it case-insensitive first
* Lowercase all emails passed through the `validateEmail` function
