### PR TITLE
refactor: update factors.go and getBodyBytes 

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -32,7 +32,6 @@ type AdminUserParams struct {
 type adminUserUpdateFactorParams struct {
 	FriendlyName string `json:"friendly_name"`
 	FactorType   string `json:"factor_type"`
-	FactorStatus string `json:"factor_status"`
 }
 type AdminListUsersResponse struct {
 	Users []*models.User `json:"users"`
@@ -435,10 +434,13 @@ func (a *API) adminUserUpdateFactor(w http.ResponseWriter, r *http.Request) erro
 	user := getUser(ctx)
 	adminUser := getAdminUser(ctx)
 	params := &adminUserUpdateFactorParams{}
-	jsonDecoder := json.NewDecoder(r.Body)
-	err := jsonDecoder.Decode(params)
+	body, err := getBodyBytes(r)
 	if err != nil {
-		return badRequestError("Please check the params passed into admin user update factor: %v", err)
+		return badRequestError("Could not read body").WithInternalError(err)
+	}
+
+	if err := json.Unmarshal(body, params); err != nil {
+		return badRequestError("Could not read factor update params: %v", err)
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {
@@ -449,14 +451,6 @@ func (a *API) adminUserUpdateFactor(w http.ResponseWriter, r *http.Request) erro
 		}
 		if params.FactorType != "" && params.FactorType != models.TOTP {
 			if terr := factor.UpdateFactorType(tx, params.FactorType); terr != nil {
-				return terr
-			}
-		}
-		if params.FactorStatus != "" {
-			if !isValidFactorStatus(params.FactorStatus) {
-				return errors.New("factor Status should be one of the valid factor states: verified, unverified or disabled")
-			}
-			if terr := factor.UpdateStatus(tx, params.FactorStatus); terr != nil {
 				return terr
 			}
 		}
@@ -475,8 +469,4 @@ func (a *API) adminUserUpdateFactor(w http.ResponseWriter, r *http.Request) erro
 	}
 
 	return sendJSON(w, http.StatusOK, factor)
-}
-
-func isValidFactorStatus(factorStatus string) bool {
-	return factorStatus == models.FactorStateVerified || factorStatus == models.FactorStateUnverified
 }

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -591,14 +591,6 @@ func (ts *AdminTestSuite) TestAdminUserUpdateFactor() {
 			map[string]interface{}{
 				"friendly_name": "john",
 				"factor_type":   models.TOTP,
-				"factor_status": "unverified",
-			},
-			http.StatusOK,
-		},
-		{
-			"Update Factor Status",
-			map[string]interface{}{
-				"factor_status": models.FactorStateVerified,
 			},
 			http.StatusOK,
 		},

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -67,7 +67,7 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if err := json.Unmarshal(body, params); err != nil {
-		return badRequestError("Could not read verification params: %v", err)
+		return badRequestError("Could not read enroll params: %v", err)
 	}
 
 	factorType := params.FactorType

--- a/models/factor.go
+++ b/models/factor.go
@@ -9,8 +9,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const FactorStateUnverified = "unverified"
-const FactorStateVerified = "verified"
+const (
+	FactorStateUnverified = "unverified"
+	FactorStateVerified   = "verified"
+)
 
 const TOTP = "totp"
 
@@ -131,19 +133,19 @@ func FindVerifiedFactorsByUser(tx *storage.Connection, user *User) ([]*Factor, e
 	return factors, nil
 }
 
-// Change the friendly name
+// UpdateFriendlyName changes the friendly name
 func (f *Factor) UpdateFriendlyName(tx *storage.Connection, friendlyName string) error {
 	f.FriendlyName = friendlyName
 	return tx.UpdateOnly(f, "friendly_name", "updated_at")
 }
 
-// Change the factor status
+// UpdateStatus modifies the factor status
 func (f *Factor) UpdateStatus(tx *storage.Connection, status string) error {
 	f.Status = status
 	return tx.UpdateOnly(f, "status", "updated_at")
 }
 
-// Checks if MFA is Enabled
+// IsMFAEnabled determines if user has met the conditions to activate MFA
 func IsMFAEnabled(tx *storage.Connection, user *User) (bool, error) {
 	factors, err := FindVerifiedFactorsByUser(tx, user)
 	if err != nil {
@@ -155,7 +157,7 @@ func IsMFAEnabled(tx *storage.Connection, user *User) (bool, error) {
 	return false, nil
 }
 
-// Change the factor type
+// UpdateFactorType modifies the factor type
 func (f *Factor) UpdateFactorType(tx *storage.Connection, factorType string) error {
 	f.FactorType = factorType
 	return tx.UpdateOnly(f, "factor_type", "updated_at")


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Across all files, use getBodyBytes instead of r.Body and json.Unmarshal instead of a decoder.
- Documentation comments should start with the function name. Example: // IsMFAEnabled returns whethe
- Admin users can no longer update factor status
