### PR TITLE
chore: add feature flag

### DIFF
--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -522,7 +522,7 @@ func (ts *AdminTestSuite) TestAdminUserCreateWithDisabledLogin() {
 
 // TestAdminUserDeleteFactor tests API /admin/users/<user_id>/factor/<factor_id>/
 func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
-	if !ts.API.config.MFA.Enabled{
+	if !ts.API.config.MFA.Enabled {
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
@@ -550,7 +550,7 @@ func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
 
 // TestAdminUserGetFactor tests API /admin/user/<user_id>/factors/
 func (ts *AdminTestSuite) TestAdminUserGetFactors() {
-	if !ts.API.config.MFA.Enabled{
+	if !ts.API.config.MFA.Enabled {
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
@@ -572,7 +572,7 @@ func (ts *AdminTestSuite) TestAdminUserGetFactors() {
 }
 
 func (ts *AdminTestSuite) TestAdminUserUpdateFactor() {
-	if !ts.API.config.MFA.Enabled{
+	if !ts.API.config.MFA.Enabled {
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
-	"os"
 
 	jwt "github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/conf"
@@ -523,7 +523,7 @@ func (ts *AdminTestSuite) TestAdminUserCreateWithDisabledLogin() {
 
 // TestAdminUserDeleteFactor tests API /admin/users/<user_id>/factor/<factor_id>/
 func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
-	if os.Getenv("MFA_ENABLED") {
+	if os.Getenv("MFA_ENABLED") != "true" {
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
@@ -551,7 +551,7 @@ func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
 
 // TestAdminUserGetFactor tests API /admin/user/<user_id>/factors/
 func (ts *AdminTestSuite) TestAdminUserGetFactors() {
-	if os.Getenv("MFA_ENABLED") {
+	if !os.Getenv("MFA_ENABLED") != "true" {
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
@@ -573,7 +573,7 @@ func (ts *AdminTestSuite) TestAdminUserGetFactors() {
 }
 
 func (ts *AdminTestSuite) TestAdminUserUpdateFactor() {
-	if os.Getenv("MFA_ENABLED") {
+	if !os.Getenv("MFA_ENABLED") != "true" {
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+	"os"
 
 	jwt "github.com/golang-jwt/jwt"
 	"github.com/netlify/gotrue/conf"
@@ -522,6 +523,9 @@ func (ts *AdminTestSuite) TestAdminUserCreateWithDisabledLogin() {
 
 // TestAdminUserDeleteFactor tests API /admin/users/<user_id>/factor/<factor_id>/
 func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
+	if os.Getenv("MFA_ENABLED") {
+		return
+	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
@@ -547,6 +551,9 @@ func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
 
 // TestAdminUserGetFactor tests API /admin/user/<user_id>/factors/
 func (ts *AdminTestSuite) TestAdminUserGetFactors() {
+	if os.Getenv("MFA_ENABLED") {
+		return
+	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
@@ -566,6 +573,9 @@ func (ts *AdminTestSuite) TestAdminUserGetFactors() {
 }
 
 func (ts *AdminTestSuite) TestAdminUserUpdateFactor() {
+	if os.Getenv("MFA_ENABLED") {
+		return
+	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error making new user")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -523,7 +522,7 @@ func (ts *AdminTestSuite) TestAdminUserCreateWithDisabledLogin() {
 
 // TestAdminUserDeleteFactor tests API /admin/users/<user_id>/factor/<factor_id>/
 func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
-	if os.Getenv("MFA_ENABLED") != "true" {
+	if !ts.API.config.MFA.Enabled{
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
@@ -551,7 +550,7 @@ func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
 
 // TestAdminUserGetFactor tests API /admin/user/<user_id>/factors/
 func (ts *AdminTestSuite) TestAdminUserGetFactors() {
-	if os.Getenv("MFA_ENABLED") != "true" {
+	if !ts.API.config.MFA.Enabled{
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
@@ -573,7 +572,7 @@ func (ts *AdminTestSuite) TestAdminUserGetFactors() {
 }
 
 func (ts *AdminTestSuite) TestAdminUserUpdateFactor() {
-	if os.Getenv("MFA_ENABLED") != "true" {
+	if !ts.API.config.MFA.Enabled{
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -551,7 +551,7 @@ func (ts *AdminTestSuite) TestAdminUserDeleteFactor() {
 
 // TestAdminUserGetFactor tests API /admin/user/<user_id>/factors/
 func (ts *AdminTestSuite) TestAdminUserGetFactors() {
-	if !os.Getenv("MFA_ENABLED") != "true" {
+	if os.Getenv("MFA_ENABLED") != "true" {
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)
@@ -573,7 +573,7 @@ func (ts *AdminTestSuite) TestAdminUserGetFactors() {
 }
 
 func (ts *AdminTestSuite) TestAdminUserUpdateFactor() {
-	if !os.Getenv("MFA_ENABLED") != "true" {
+	if os.Getenv("MFA_ENABLED") != "true" {
 		return
 	}
 	u, err := models.NewUser("123456789", "test-delete@example.com", "test", ts.Config.JWT.Aud, nil)

--- a/api/api.go
+++ b/api/api.go
@@ -128,26 +128,29 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		r.With(api.requireAuthentication).Route("/user", func(r *router) {
 			r.Get("/", api.UserGet)
 			r.With(sharedLimiter).Put("/", api.UserUpdate)
-			r.Route("/{user_id}", func(r *router) {
-				r.Use(api.loadUser)
-				r.Route("/factor", func(r *router) {
-					r.Post("/", api.EnrollFactor)
-					r.Route("/{factor_id}", func(r *router) {
-						r.Use(api.loadFactor)
 
-						r.With(api.limitHandler(
-							tollbooth.NewLimiter(api.config.MFA.RateLimitChallengeAndVerify/60, &limiter.ExpirableOptions{
-								DefaultExpirationTTL: time.Minute,
-							}).SetBurst(30))).Post("/verify", api.VerifyFactor)
-						r.With(api.limitHandler(
-							tollbooth.NewLimiter(api.config.MFA.RateLimitChallengeAndVerify/60, &limiter.ExpirableOptions{
-								DefaultExpirationTTL: time.Minute,
-							}).SetBurst(30))).Post("/challenge", api.ChallengeFactor)
-						r.Delete("/", api.UnenrollFactor)
+			if api.config.MFA.Enabled {
+				r.Route("/{user_id}", func(r *router) {
+					r.Use(api.loadUser)
+					r.Route("/factor", func(r *router) {
+						r.Post("/", api.EnrollFactor)
+						r.Route("/{factor_id}", func(r *router) {
+							r.Use(api.loadFactor)
 
+							r.With(api.limitHandler(
+								tollbooth.NewLimiter(api.config.MFA.RateLimitChallengeAndVerify/60, &limiter.ExpirableOptions{
+									DefaultExpirationTTL: time.Minute,
+								}).SetBurst(30))).Post("/verify", api.VerifyFactor)
+							r.With(api.limitHandler(
+								tollbooth.NewLimiter(api.config.MFA.RateLimitChallengeAndVerify/60, &limiter.ExpirableOptions{
+									DefaultExpirationTTL: time.Minute,
+								}).SetBurst(30))).Post("/challenge", api.ChallengeFactor)
+							r.Delete("/", api.UnenrollFactor)
+
+						})
 					})
 				})
-			})
+			}
 
 		})
 
@@ -164,14 +167,16 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 				r.Route("/{user_id}", func(r *router) {
 					r.Use(api.loadUser)
-					r.Route("/factor", func(r *router) {
-						r.Get("/", api.adminUserGetFactors)
-						r.Route("/{factor_id}", func(r *router) {
-							r.Use(api.loadFactor)
-							r.Delete("/", api.adminUserDeleteFactor)
-							r.Put("/", api.adminUserUpdateFactor)
+					if api.config.MFA.Enabled {
+						r.Route("/factor", func(r *router) {
+							r.Get("/", api.adminUserGetFactors)
+							r.Route("/{factor_id}", func(r *router) {
+								r.Use(api.loadFactor)
+								r.Delete("/", api.adminUserDeleteFactor)
+								r.Put("/", api.adminUserUpdateFactor)
+							})
 						})
-					})
+					}
 
 					r.Get("/", api.adminUserGet)
 					r.Put("/", api.adminUserUpdate)

--- a/api/audit_test.go
+++ b/api/audit_test.go
@@ -48,7 +48,13 @@ func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
 
 	u.Role = "supabase_admin"
 
-	token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	var token string
+	if ts.Config.MFA.Enabled {
+		token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	} else {
+		token, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+
+	}
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -77,7 +77,13 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
-	s, err := models.CreateSession(ts.API.db, u, &uuid.Nil)
+	var s *models.Session
+	if ts.Config.MFA.Enabled {
+		s, err = models.MFA_CreateSession(ts.API.db, u, &uuid.Nil)
+	} else {
+		s, err = models.CreateSession(ts.API.db, u)
+
+	}
 	require.NoError(ts.T(), err)
 
 	cases := []struct {

--- a/api/external.go
+++ b/api/external.go
@@ -278,8 +278,11 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 				}
 			}
 		}
-
-		token, terr = a.issueRefreshToken(ctx, tx, user, models.OAuth, grantParams)
+		if config.MFA.Enabled {
+			token, terr = a.MFA_issueRefreshToken(ctx, tx, user, models.OAuth, grantParams)
+		} else {
+			token, terr = a.issueRefreshToken(ctx, tx, user, grantParams)
+		}
 
 		if terr != nil {
 			return oauthError("server_error", terr.Error())

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -58,7 +58,12 @@ func (ts *InviteTestSuite) makeSuperAdmin(email string) string {
 
 	u.Role = "supabase_admin"
 
-	token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	var token string
+	if ts.API.config.MFA.Enabled {
+		token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	} else {
+		token, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	}
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}

--- a/api/logout_test.go
+++ b/api/logout_test.go
@@ -41,7 +41,12 @@ func (ts *LogoutTestSuite) SetupTest() {
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 
 	// generate access token to use for logout
-	t, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	var t string
+	if ts.Config.MFA.Enabled {
+		t, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	} else {
+		t, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	}
 	require.NoError(ts.T(), err)
 	ts.token = t
 }

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -42,7 +41,7 @@ func TestMFA(t *testing.T) {
 		Config: config,
 	}
 	defer api.db.Close()
-	if os.Getenv("MFA_ENABLED") == "true" {
+	if config.MFA.Enabled {
 		suite.Run(t, ts)
 	}
 }

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -125,7 +125,7 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 			user, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 			ts.Require().NoError(err)
 
-			token, err := generateAccessToken(ts.API.db, user, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+			token, err := MFA_generateAccessToken(ts.API.db, user, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 			require.NoError(ts.T(), err)
 
 			w := httptest.NewRecorder()
@@ -162,7 +162,7 @@ func (ts *MFATestSuite) TestChallengeFactor() {
 	require.NoError(ts.T(), err)
 	f := factors[0]
 
-	token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	token, err := MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	var buffer bytes.Buffer
@@ -221,7 +221,7 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			require.NoError(ts.T(), err, "Error creating test session")
 			require.NoError(ts.T(), ts.API.db.Create(secondarySession), "Error saving test session")
 
-			token, err := generateAccessToken(ts.API.db, user, r.SessionId, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+			token, err := MFA_generateAccessToken(ts.API.db, user, r.SessionId, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 
 			require.NoError(ts.T(), err)
 
@@ -312,7 +312,7 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 
 			var buffer bytes.Buffer
 
-			token, err := generateAccessToken(ts.API.db, u, &s.ID, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+			token, err := MFA_generateAccessToken(ts.API.db, u, &s.ID, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 			require.NoError(ts.T(), err)
 
 			// Generate code for verification
@@ -366,7 +366,7 @@ func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 
 	var buffer bytes.Buffer
 
-	token, err := generateAccessToken(ts.API.db, u, &s.ID, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	token, err := MFA_generateAccessToken(ts.API.db, u, &s.ID, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
 		"factor_id": f.ID,

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -42,7 +42,7 @@ func TestMFA(t *testing.T) {
 		Config: config,
 	}
 	defer api.db.Close()
-	if os.Getenv("MFA_ENABLED") {
+	if os.Getenv("MFA_ENABLED") == "true" {
 		suite.Run(t, ts)
 	}
 }

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -41,8 +42,9 @@ func TestMFA(t *testing.T) {
 		Config: config,
 	}
 	defer api.db.Close()
-
-	suite.Run(t, ts)
+	if os.Getenv("MFA_ENABLED") {
+		suite.Run(t, ts)
+	}
 }
 
 func (ts *MFATestSuite) SetupTest() {

--- a/api/phone_test.go
+++ b/api/phone_test.go
@@ -126,7 +126,13 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 	u.PhoneConfirmedAt = &now
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
-	token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	var token string
+	if ts.Config.MFA.Enabled {
+		token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	} else {
+		token, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+
+	}
 	require.NoError(ts.T(), err)
 
 	cases := []struct {

--- a/api/signup.go
+++ b/api/signup.go
@@ -221,7 +221,11 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 
-			token, terr = a.issueRefreshToken(ctx, tx, user, models.AutoConfirmSignup, grantParams)
+			if config.MFA.Enabled {
+				token, terr = a.MFA_issueRefreshToken(ctx, tx, user, models.AutoConfirmSignup, grantParams)
+			} else {
+				token, terr = a.issueRefreshToken(ctx, tx, user, grantParams)
+			}
 
 			if terr != nil {
 				return terr

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -110,7 +110,7 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 
 		u, ok := data["user"].(map[string]interface{})
 		require.True(ok)
-		assert.Len(u, 11)
+		assert.Len(u, 10)
 		assert.Equal("authenticated", u["aud"])
 		assert.Equal("authenticated", u["role"])
 		assert.Equal("test@example.com", u["email"])

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -110,7 +110,6 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 
 		u, ok := data["user"].(map[string]interface{})
 		require.True(ok)
-		assert.Len(u, 10)
 		assert.Equal("authenticated", u["aud"])
 		assert.Equal("authenticated", u["role"])
 		assert.Equal("test@example.com", u["email"])

--- a/api/token.go
+++ b/api/token.go
@@ -663,7 +663,8 @@ func (a *API) MFA_issueRefreshToken(ctx context.Context, conn *storage.Connectio
 			return terr
 		}
 
-		tokenString, terr = generateAccessToken(tx, user, refreshToken.SessionId, time.Second*time.Duration(config.JWT.Exp), config.JWT.Secret)
+		// TODO(Joel): Replace when feature flag is lifted
+		tokenString, terr = MFA_generateAccessToken(tx, user, refreshToken.SessionId, time.Second*time.Duration(config.JWT.Exp), config.JWT.Secret)
 		if terr != nil {
 			return internalServerError("error generating jwt token").WithInternalError(terr)
 		}
@@ -713,7 +714,8 @@ func (a *API) updateMFASessionAndClaims(ctx context.Context, conn *storage.Conne
 			return err
 		}
 
-		tokenString, terr = generateAccessToken(tx, user, &sessionId, time.Second*time.Duration(config.JWT.Exp), config.JWT.Secret)
+		// TODO(Joel): Replace when feature flag is lifted
+		tokenString, terr = MFA_generateAccessToken(tx, user, &sessionId, time.Second*time.Duration(config.JWT.Exp), config.JWT.Secret)
 
 		if terr != nil {
 			return internalServerError("error generating jwt token").WithInternalError(terr)

--- a/api/token.go
+++ b/api/token.go
@@ -27,8 +27,8 @@ type GoTrueClaims struct {
 	AppMetaData                   map[string]interface{} `json:"app_metadata"`
 	UserMetaData                  map[string]interface{} `json:"user_metadata"`
 	Role                          string                 `json:"role"`
-	AuthenticatorAssuranceLevel   string                 `json:"aal"`
-	AuthenticationMethodReference []models.AMREntry      `json:"amr"`
+	AuthenticatorAssuranceLevel   string                 `json:"aal,omitempty"`
+	AuthenticationMethodReference []models.AMREntry      `json:"amr,omitempty"`
 	SessionId                     string                 `json:"session_id,omitempty"`
 }
 
@@ -223,8 +223,12 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		if terr = triggerEventHooks(ctx, tx, LoginEvent, user, config); terr != nil {
 			return terr
 		}
+		if config.MFA.Enabled {
+			token, terr = a.MFA_issueRefreshToken(ctx, tx, user, models.PasswordGrant, grantParams)
+		} else {
+			token, terr = a.issueRefreshToken(ctx, tx, user, grantParams)
+		}
 
-		token, terr = a.issueRefreshToken(ctx, tx, user, models.PasswordGrant, grantParams)
 		if terr != nil {
 			return terr
 		}
@@ -331,8 +335,11 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 				return internalServerError(terr.Error())
 			}
 		}
-
-		tokenString, terr = generateAccessToken(tx, user, newToken.SessionId, time.Second*time.Duration(config.JWT.Exp), config.JWT.Secret)
+		if config.MFA.Enabled {
+			tokenString, terr = MFA_generateAccessToken(tx, user, newToken.SessionId, time.Second*time.Duration(config.JWT.Exp), config.JWT.Secret)
+		} else {
+			tokenString, terr = generateAccessToken(user, newToken.SessionId, time.Second*time.Duration(config.JWT.Exp), config.JWT.Secret)
+		}
 		if terr != nil {
 			return internalServerError("error generating jwt token").WithInternalError(terr)
 		}
@@ -515,8 +522,12 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 				return terr
 			}
 		}
+		if config.MFA.Enabled {
+			token, terr = a.MFA_issueRefreshToken(ctx, tx, user, models.OAuthIDGrant, grantParams)
+		} else {
+			token, terr = a.issueRefreshToken(ctx, tx, user, grantParams)
 
-		token, terr = a.issueRefreshToken(ctx, tx, user, models.OAuthIDGrant, grantParams)
+		}
 
 		if terr != nil {
 			return oauthError("server_error", terr.Error())
@@ -536,7 +547,30 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 	return sendJSON(w, http.StatusOK, token)
 }
 
-func generateAccessToken(tx *storage.Connection, user *models.User, sessionId *uuid.UUID, expiresIn time.Duration, secret string) (string, error) {
+func generateAccessToken(user *models.User, sessionId *uuid.UUID, expiresIn time.Duration, secret string) (string, error) {
+	sid := ""
+	if sessionId != nil {
+		sid = sessionId.String()
+	}
+	claims := &GoTrueClaims{
+		StandardClaims: jwt.StandardClaims{
+			Subject:   user.ID.String(),
+			Audience:  user.Aud,
+			ExpiresAt: time.Now().Add(expiresIn).Unix(),
+		},
+		Email:        user.GetEmail(),
+		Phone:        user.GetPhone(),
+		AppMetaData:  user.AppMetaData,
+		UserMetaData: user.UserMetaData,
+		Role:         user.Role,
+		SessionId:    sid,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}
+
+func MFA_generateAccessToken(tx *storage.Connection, user *models.User, sessionId *uuid.UUID, expiresIn time.Duration, secret string) (string, error) {
 	aal, amr := models.AAL1.String(), []models.AMREntry{}
 	sid := ""
 	if sessionId != nil {
@@ -568,7 +602,42 @@ func generateAccessToken(tx *storage.Connection, user *models.User, sessionId *u
 	return token.SignedString([]byte(secret))
 }
 
-func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*AccessTokenResponse, error) {
+func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, user *models.User, grantParams models.GrantParams) (*AccessTokenResponse, error) {
+	config := a.config
+
+	now := time.Now()
+	user.LastSignInAt = &now
+
+	var tokenString string
+	var refreshToken *models.RefreshToken
+
+	err := conn.Transaction(func(tx *storage.Connection) error {
+		var terr error
+		refreshToken, terr = models.GrantAuthenticatedUser(tx, user, grantParams)
+		if terr != nil {
+			return internalServerError("Database error granting user").WithInternalError(terr)
+		}
+
+		tokenString, terr = generateAccessToken(user, refreshToken.SessionId, time.Second*time.Duration(config.JWT.Exp), config.JWT.Secret)
+		if terr != nil {
+			return internalServerError("error generating jwt token").WithInternalError(terr)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &AccessTokenResponse{
+		Token:        tokenString,
+		TokenType:    "bearer",
+		ExpiresIn:    config.JWT.Exp,
+		RefreshToken: refreshToken.Token,
+		User:         user,
+	}, nil
+}
+
+func (a *API) MFA_issueRefreshToken(ctx context.Context, conn *storage.Connection, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*AccessTokenResponse, error) {
 	config := a.config
 
 	now := time.Now()

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -47,7 +47,12 @@ func (ts *UserTestSuite) SetupTest() {
 func (ts *UserTestSuite) TestUserGet() {
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err, "Error finding user")
-	token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	var token string
+	if ts.API.config.MFA.Enabled {
+		token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	} else {
+		token, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	}
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	req := httptest.NewRequest(http.MethodGet, "http://localhost/user", nil)
@@ -111,7 +116,13 @@ func (ts *UserTestSuite) TestUserUpdateEmail() {
 			require.NoError(ts.T(), u.SetPhone(ts.API.db, c.userData["phone"]), "Error setting user phone")
 			require.NoError(ts.T(), ts.API.db.Create(u), "Error saving test user")
 
-			token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+			var token string
+			if ts.API.config.MFA.Enabled {
+				token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+			} else {
+				token, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+
+			}
 			require.NoError(ts.T(), err, "Error generating access token")
 
 			var buffer bytes.Buffer
@@ -170,7 +181,13 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
-			token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+			var token string
+			if ts.API.config.MFA.Enabled {
+				token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+			} else {
+				token, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+
+			}
 			require.NoError(ts.T(), err, "Error generating access token")
 
 			var buffer bytes.Buffer
@@ -244,7 +261,13 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 			req := httptest.NewRequest(http.MethodPut, "http://localhost/user", &buffer)
 			req.Header.Set("Content-Type", "application/json")
 
-			token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+			var token string
+			if ts.API.config.MFA.Enabled {
+				token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+			} else {
+				token, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+
+			}
 			require.NoError(ts.T(), err)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
@@ -272,7 +295,13 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	u.EmailConfirmedAt = &now
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
-	token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	var token string
+	if ts.API.config.MFA.Enabled {
+		token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	} else {
+		token, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+
+	}
 	require.NoError(ts.T(), err)
 
 	// request for reauthentication nonce

--- a/api/verify.go
+++ b/api/verify.go
@@ -123,7 +123,11 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 
-		token, terr = a.issueRefreshToken(ctx, tx, user, models.EmailVerification, grantParams)
+		if config.MFA.Enabled {
+			token, terr = a.MFA_issueRefreshToken(ctx, tx, user, models.EmailVerification, grantParams)
+		} else {
+			token, terr = a.issueRefreshToken(ctx, tx, user, grantParams)
+		}
 		if terr != nil {
 			return terr
 		}
@@ -220,8 +224,12 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
 		if terr != nil {
 			return terr
 		}
+		if config.MFA.Enabled {
+			token, terr = a.MFA_issueRefreshToken(ctx, tx, user, models.SMSOrEmailOTP, grantParams)
+		} else {
+			token, terr = a.issueRefreshToken(ctx, tx, user, grantParams)
 
-		token, terr = a.issueRefreshToken(ctx, tx, user, models.SMSOrEmailOTP, grantParams)
+		}
 		if terr != nil {
 			return terr
 		}

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -103,7 +103,13 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 	req.Header.Set("Content-Type", "application/json")
 
 	// Generate access token for request
-	token, err := generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	var token string
+	if ts.API.config.MFA.Enabled {
+		token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	} else {
+		token, err = generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+
+	}
 	require.NoError(ts.T(), err)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -107,7 +107,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 	if ts.API.config.MFA.Enabled {
 		token, err = MFA_generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 	} else {
-		token, err = generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+		token, err = generateAccessToken(u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 
 	}
 	require.NoError(ts.T(), err)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -54,7 +54,7 @@ type JWTConfiguration struct {
 
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
-	Enabled                     bool `default:"false" envconfig:"MFA_ENABLED"`
+	Enabled                     bool    `default:"false" envconfig:"MFA_ENABLED"`
 	ChallengeExpiryDuration     float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	RateLimitChallengeAndVerify float64 `split_words:"true" default:"15"`
 	MaxEnrolledFactors          float64 `split_words:"true" default:"10"`
@@ -173,7 +173,7 @@ type MailerConfiguration struct {
 }
 
 type PhoneProviderConfiguration struct {
-	Enabled                 bool `json:"enabled" default:"false"`
+	Enabled bool `json:"enabled" default:"false"`
 }
 
 type SmsProviderConfiguration struct {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -54,7 +54,7 @@ type JWTConfiguration struct {
 
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
-	Enabled                     bool `json:"enabled" default:"false"`
+	Enabled                     bool `default:"false" envconfig:"MFA_ENABLED"`
 	ChallengeExpiryDuration     float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	RateLimitChallengeAndVerify float64 `split_words:"true" default:"15"`
 	MaxEnrolledFactors          float64 `split_words:"true" default:"10"`

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -54,6 +54,7 @@ type JWTConfiguration struct {
 
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
+	Enabled                     bool `json:"enabled" default:"false"`
 	ChallengeExpiryDuration     float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	RateLimitChallengeAndVerify float64 `split_words:"true" default:"15"`
 	MaxEnrolledFactors          float64 `split_words:"true" default:"10"`

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -174,7 +174,6 @@ type MailerConfiguration struct {
 
 type PhoneProviderConfiguration struct {
 	Enabled                 bool `json:"enabled" default:"false"`
-	ChallengeExpiryDuration int  `json:"challenge_expiry_duration" default:"300"`
 }
 
 type SmsProviderConfiguration struct {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -54,7 +54,7 @@ type JWTConfiguration struct {
 
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
-	Enabled                     bool    `default:"false" envconfig:"MFA_ENABLED"`
+	Enabled                     bool    `default:"false"`
 	ChallengeExpiryDuration     float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	RateLimitChallengeAndVerify float64 `split_words:"true" default:"15"`
 	MaxEnrolledFactors          float64 `split_words:"true" default:"10"`

--- a/models/factor_test.go
+++ b/models/factor_test.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"testing"
-	"os"
 
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
@@ -26,7 +25,7 @@ func TestFactor(t *testing.T) {
 		db: conn,
 	}
 	defer ts.db.Close()
-	if os.Getenv("MFA_ENABLED") != "true" {
+	if globalConfig.MFA.Enabled {
 		suite.Run(t, ts)
 	}
 }

--- a/models/factor_test.go
+++ b/models/factor_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"testing"
+	"os"
 
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
@@ -25,7 +26,7 @@ func TestFactor(t *testing.T) {
 		db: conn,
 	}
 	defer ts.db.Close()
-	if os.Getenv("MFA_ENABLED") {
+	if os.Getenv("MFA_ENABLED") != "true" {
 		suite.Run(t, ts)
 	}
 }

--- a/models/factor_test.go
+++ b/models/factor_test.go
@@ -25,7 +25,9 @@ func TestFactor(t *testing.T) {
 		db: conn,
 	}
 	defer ts.db.Close()
-	suite.Run(t, ts)
+	if os.Getenv("MFA_ENABLED") {
+		suite.Run(t, ts)
+	}
 }
 
 func (ts *FactorTestSuite) SetupTest() {

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -130,7 +130,7 @@ func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshTok
 		var session *Session
 		var err error
 		// TODO(Joel): Find better workaround
-		if os.Getenv("MFA_ENABLED") == "true" {
+		if os.Getenv("GOTRUE_MFA_ENABLED") == "true" {
 			session, err = MFA_CreateSession(tx, user, params.FactorID)
 		} else {
 			session, err = CreateSession(tx, user)

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -3,6 +3,7 @@ package models
 import (
 	"database/sql"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gobuffalo/pop/v5"
@@ -126,7 +127,14 @@ func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshTok
 
 	if token.SessionId == nil {
 		// Existing refresh tokens may have a null session_id if they were created before v2.15.3
-		session, err := CreateSession(tx, user, params.FactorID)
+		var session *Session
+		var err error
+		// TODO(Joel): Find better workaround
+		if os.Getenv("MFA_ENABLED") != "true" {
+			session, err = MFA_CreateSession(tx, user, params.FactorID)
+		} else {
+			session, err = CreateSession(tx, user)
+		}
 		if err != nil {
 			return nil, errors.Wrap(err, "Error generated unique session id")
 		}

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -130,7 +130,7 @@ func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshTok
 		var session *Session
 		var err error
 		// TODO(Joel): Find better workaround
-		if os.Getenv("MFA_ENABLED") != "true" {
+		if os.Getenv("MFA_ENABLED") == "true" {
 			session, err = MFA_CreateSession(tx, user, params.FactorID)
 		} else {
 			session, err = CreateSession(tx, user)

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -68,7 +68,18 @@ func NewSession(user *User, factorID *uuid.UUID) (*Session, error) {
 	return session, nil
 }
 
-func CreateSession(tx *storage.Connection, user *User, factorID *uuid.UUID) (*Session, error) {
+func CreateSession(tx *storage.Connection, user *User) (*Session, error) {
+	session, err := NewSession(user, &uuid.Nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Create(session); err != nil {
+		return nil, errors.Wrap(err, "error creating session")
+	}
+	return session, nil
+}
+
+func MFA_CreateSession(tx *storage.Connection, user *User, factorID *uuid.UUID) (*Session, error) {
 	session, err := NewSession(user, factorID)
 	if err != nil {
 		return nil, err

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -1,12 +1,14 @@
 package models
 
 import (
+	"os"
+	"testing"
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"os"
+	"github.com/netlify/gotrue/storage/test"
 	"time"
 )
 
@@ -19,7 +21,7 @@ type SessionsTestSuite struct {
 func (ts *SessionsTestSuite) SetupTest() {
 	TruncateAll(ts.db)
 	email := "test@example.com"
-	user, err := NewUser("", email, "secret", "test", nil)
+	user, err := NewUser("", email, "secret", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err)
 
 	err = ts.db.Create(user)
@@ -33,10 +35,10 @@ func TestSession(t *testing.T) {
 	require.NoError(t, err)
 	ts := &SessionsTestSuite{
 		db:     conn,
-		Config: config,
+		Config: globalConfig,
 	}
 	defer ts.db.Close()
-	if os.Getenv("MFA_ENABLED") {
+	if os.Getenv("MFA_ENABLED") == "true" {
 		suite.Run(t, ts)
 	}
 }

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -53,7 +53,7 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	err = AddClaimToSession(ts.db, session, PasswordGrant)
 	require.NoError(ts.T(), err)
 
-	firstClaimAddedTime := time.Now().Unix()
+	firstClaimAddedTime := time.Now()
 	err = AddClaimToSession(ts.db, session, TOTPSignIn)
 	require.NoError(ts.T(), err)
 	session, err = FindSessionById(ts.db, session.ID)
@@ -76,7 +76,7 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	found := false
 	for _, claim := range session.AMRClaims {
 		if claim.AuthenticationMethod == TOTPSignIn.String() {
-			require.True(ts.T(), firstClaimAddedTime < claim.UpdatedAt.Unix())
+			require.True(ts.T(), firstClaimAddedTime.Before(claim.UpdatedAt))
 			found = true
 		}
 	}

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/netlify/gotrue/storage"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"os"
 	"time"
 )
 
@@ -23,6 +24,21 @@ func (ts *SessionsTestSuite) SetupTest() {
 
 	err = ts.db.Create(user)
 	require.NoError(ts.T(), err)
+}
+
+func TestSession(t *testing.T) {
+	globalConfig, err := conf.LoadGlobal(modelsTestConfig)
+	require.NoError(t, err)
+	conn, err := test.SetupDBConnection(globalConfig)
+	require.NoError(t, err)
+	ts := &SessionsTestSuite{
+		db:     conn,
+		Config: config,
+	}
+	defer ts.db.Close()
+	if os.Getenv("MFA_ENABLED") {
+		suite.Run(t, ts)
+	}
 }
 
 func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -46,7 +46,8 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	totalDistinctClaims := 2
 	u, err := FindUserByEmailAndAudience(ts.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
-	session, err := CreateSession(ts.db, u, &uuid.Nil)
+	// TODO(Joel): Replace with CreateSession once MFA feature flag is lifted
+	session, err := MFA_CreateSession(ts.db, u, &uuid.Nil)
 	require.NoError(ts.T(), err)
 
 	err = AddClaimToSession(ts.db, session, PasswordGrant)

--- a/models/user.go
+++ b/models/user.go
@@ -56,7 +56,7 @@ type User struct {
 	AppMetaData  JSONMap `json:"app_metadata" db:"raw_app_meta_data"`
 	UserMetaData JSONMap `json:"user_metadata" db:"raw_user_meta_data"`
 
-	Factors    []Factor   `json:"factors" has_many:"factors"`
+	Factors    []Factor   `json:"factors,omitempty" has_many:"factors"`
 	Identities []Identity `json:"identities" has_many:"identities"`
 
 	CreatedAt   time.Time  `json:"created_at" db:"created_at"`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add  a feature flag `MFA_ENABLED` which gates all MFA related tests, routes, and breaking changes.

We prefix the `MFA_` prefix for all breaking MFA changes and make use of the version without the prefix when the flag is toggled to off

`sessions_test.go` and `mfa_test.go` have not been flagged as they contain only MFA related functions and default to the `MFA_` functions. They are not run when the flag is set to false
