### PR TITLE
fix: trigger token swap on MFA verify to ensure token is latest one

### DIFF
--- a/api/mfa.go
+++ b/api/mfa.go
@@ -263,7 +263,7 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 		if terr != nil {
 			return terr
 		}
-		token, terr = a.updateMFASessionAndClaims(ctx, tx, user, models.TOTPSignIn, models.GrantParams{
+		token, terr = a.updateMFASessionAndClaims(r, ctx, tx, user, models.TOTPSignIn, models.GrantParams{
 			FactorID: &factor.ID,
 		})
 		if terr != nil {

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -263,7 +263,7 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 		if terr != nil {
 			return terr
 		}
-		token, terr = a.updateMFASessionAndClaims(r, ctx, tx, user, models.TOTPSignIn, models.GrantParams{
+		token, terr = a.updateMFASessionAndClaims(r, tx, user, models.TOTPSignIn, models.GrantParams{
 			FactorID: &factor.ID,
 		})
 		if terr != nil {

--- a/api/token.go
+++ b/api/token.go
@@ -613,9 +613,7 @@ func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, u
 	}, nil
 }
 
-func (a *API) updateMFASessionAndClaims(r *http.Request, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*AccessTokenResponse, error) {
-ctx := r.Context()
-conn := a.db
+func (a *API) updateMFASessionAndClaims(r *http.Request, ctx context.Context, conn *storage.Connection, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*AccessTokenResponse, error) {
 	config := a.config
 	var tokenString string
 	var refreshToken *models.RefreshToken

--- a/api/token.go
+++ b/api/token.go
@@ -613,7 +613,9 @@ func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, u
 	}, nil
 }
 
-func (a *API) updateMFASessionAndClaims(r *http.Request, ctx context.Context, conn *storage.Connection, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*AccessTokenResponse, error) {
+func (a *API) updateMFASessionAndClaims(r *http.Request, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*AccessTokenResponse, error) {
+ctx := r.Context()
+conn := a.db
 	config := a.config
 	var tokenString string
 	var refreshToken *models.RefreshToken

--- a/api/token.go
+++ b/api/token.go
@@ -613,7 +613,8 @@ func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, u
 	}, nil
 }
 
-func (a *API) updateMFASessionAndClaims(r *http.Request, ctx context.Context, conn *storage.Connection, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*AccessTokenResponse, error) {
+func (a *API) updateMFASessionAndClaims(r *http.Request, tx *storage.Connection, user *models.User, authenticationMethod models.AuthenticationMethod, grantParams models.GrantParams) (*AccessTokenResponse, error) {
+	ctx := r.Context()
 	config := a.config
 	var tokenString string
 	var refreshToken *models.RefreshToken
@@ -622,7 +623,7 @@ func (a *API) updateMFASessionAndClaims(r *http.Request, ctx context.Context, co
 	if err != nil {
 		return nil, internalServerError("Cannot read SessionId claim as UUID").WithInternalError(err)
 	}
-	err = conn.Transaction(func(tx *storage.Connection) error {
+	err = tx.Transaction(func(tx *storage.Connection) error {
 		session, terr := models.FindSessionById(tx, sessionId)
 		if terr != nil {
 			return terr

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -90,6 +90,17 @@ func FindSessionById(tx *storage.Connection, id uuid.UUID) (*Session, error) {
 	return session, nil
 }
 
+func FindSessionByUserID(tx *storage.Connection, userId uuid.UUID) (*Session, error) {
+	session := &Session{}
+	if err := tx.Eager().Q().Where("user_id = ?", userId).Order("created_at asc").First(session); err != nil {
+		if errors.Cause(err) == sql.ErrNoRows {
+			return nil, SessionNotFoundError{}
+		}
+		return nil, errors.Wrap(err, "error finding session")
+	}
+	return session, nil
+}
+
 func updateFactorAssociatedSessions(tx *storage.Connection, userID, factorID uuid.UUID, aal string) error {
 	return tx.RawQuery("UPDATE "+(&pop.Model{Value: Session{}}).TableName()+" set aal = ?, factor_id = ? WHERE user_id = ? AND factor_id = ?", aal, uuid.Nil, userID, factorID).Exec()
 }

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -92,7 +92,7 @@ func FindSessionById(tx *storage.Connection, id uuid.UUID) (*Session, error) {
 
 func FindSessionByUserID(tx *storage.Connection, userId uuid.UUID) (*Session, error) {
 	session := &Session{}
-	if err := tx.Eager().Q().Where("user_id = ?", userId).First(session); err != nil {
+	if err := tx.Eager().Q().Where("user_id = ?", userId).Order("created_at asc").First(session); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, SessionNotFoundError{}
 		}

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -90,17 +90,6 @@ func FindSessionById(tx *storage.Connection, id uuid.UUID) (*Session, error) {
 	return session, nil
 }
 
-func FindSessionByUserID(tx *storage.Connection, userId uuid.UUID) (*Session, error) {
-	session := &Session{}
-	if err := tx.Eager().Q().Where("user_id = ?", userId).Order("created_at asc").First(session); err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
-			return nil, SessionNotFoundError{}
-		}
-		return nil, errors.Wrap(err, "error finding session")
-	}
-	return session, nil
-}
-
 func updateFactorAssociatedSessions(tx *storage.Connection, userID, factorID uuid.UUID, aal string) error {
 	return tx.RawQuery("UPDATE "+(&pop.Model{Value: Session{}}).TableName()+" set aal = ?, factor_id = ? WHERE user_id = ? AND factor_id = ?", aal, uuid.Nil, userID, factorID).Exec()
 }

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -1,11 +1,9 @@
 package models
 
 import (
-	"database/sql"
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"time"
@@ -25,17 +23,6 @@ func (ts *SessionsTestSuite) SetupTest() {
 
 	err = ts.db.Create(user)
 	require.NoError(ts.T(), err)
-}
-
-func FindSessionByUserID(tx *storage.Connection, userId uuid.UUID) (*Session, error) {
-	session := &Session{}
-	if err := tx.Eager().Q().Where("user_id = ?", userId).Order("created_at asc").First(session); err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
-			return nil, SessionNotFoundError{}
-		}
-		return nil, errors.Wrap(err, "error finding session")
-	}
-	return session, nil
 }
 
 func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

We now trigger a refreshToken swap on successful verification of a TOTP token.

## What is the new behavior?

We now trigger a refreshToken swap on successful verification of a TOTP token.


## What is the current behavior?

As @kangmingtay pointed out, the following series of events could lead to a race condition resulting into a state refresh token being sent back:

1. Sign-in
2. Enroll MFA
3. Verify Enrollment
4. Automatic refresh of access token
When Steps 4 happens during / after the transaction in step 3 completes GoTrue returns an old refresh Token


## Additional context
Nil

