### PR TITLE
feat: add mfa indexes

### DIFF
--- a/migrations/20221004041400_add_index_on_refresh_token.up.sql
+++ b/migrations/20221004041400_add_index_on_refresh_token.up.sql
@@ -1,1 +1,0 @@
-create index if not exists refresh_token_session_id on {{ index .Options "Namespace" }}.refresh_tokens using btree (session_id);

--- a/migrations/20221011041400_add_mfa_indexes.up.sql
+++ b/migrations/20221011041400_add_mfa_indexes.up.sql
@@ -1,0 +1,9 @@
+create index if not exists refresh_token_session_id on {{ index .Options "Namespace" }}.refresh_tokens using btree(session_id);
+alter table {{ index .Options "Namespace" }}.mfa_amr_claims
+add column if not exists id uuid not null,
+add constraint amr_id_pk primary key(id);
+
+
+create index if not exists user_id_created_at_idx on {{ index .Options "Namespace" }}.sessions (user_id, created_at);
+create index if not exists factor_id_created_at_idx on {{ index .Options "Namespace" }}.mfa_factors (user_id, created_at);
+-- Add Index which handles the clause below

--- a/migrations/20221011041400_add_mfa_indexes.up.sql
+++ b/migrations/20221011041400_add_mfa_indexes.up.sql
@@ -1,8 +1,8 @@
 create index if not exists refresh_token_session_id on {{ index .Options "Namespace" }}.refresh_tokens using btree(session_id);
-alter table {{ index .Options "Namespace" }}.mfa_amr_claims
-add column if not exists id uuid not null,
-add constraint amr_id_pk primary key(id);
 
+alter table {{ index .Options "Namespace" }}.mfa_amr_claims
+  add column if not exists id uuid not null,
+  add constraint amr_id_pk primary key(id);
 
 create index if not exists user_id_created_at_idx on {{ index .Options "Namespace" }}.sessions (user_id, created_at);
 create index if not exists factor_id_created_at_idx on {{ index .Options "Namespace" }}.mfa_factors (user_id, created_at);

--- a/models/amr.go
+++ b/models/amr.go
@@ -6,9 +6,11 @@ import (
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/storage"
+	"github.com/pkg/errors"
 )
 
 type AMRClaim struct {
+	ID                   uuid.UUID `json:"id" db:"id"`
 	SessionID            uuid.UUID `json:"session_id" db:"session_id"`
 	CreatedAt            time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt            time.Time `json:"updated_at" db:"updated_at"`
@@ -21,7 +23,11 @@ func (AMRClaim) TableName() string {
 }
 
 func AddClaimToSession(tx *storage.Connection, session *Session, authenticationMethod AuthenticationMethod) error {
+	id, err := uuid.NewV4()
+	if err != nil {
+		return errors.Wrap(err, "Error generating unique claim id")
+	}
 	currentTime := time.Now()
 	return tx.RawQuery("INSERT INTO "+(&pop.Model{Value: AMRClaim{}}).TableName()+
-		"(session_id, created_at, updated_at, authentication_method) values(?, ?, ?, ?) "+"ON CONFLICT ON CONSTRAINT mfa_amr_claims_session_id_authentication_method_pkey "+"DO UPDATE SET updated_at = ?;", session.ID, currentTime, currentTime, authenticationMethod.String(), currentTime).Exec()
+		"(id, session_id, created_at, updated_at, authentication_method) values(?, ?, ?, ?, ?) "+"ON CONFLICT ON CONSTRAINT mfa_amr_claims_session_id_authentication_method_pkey "+"DO UPDATE SET updated_at = ?;", id, session.ID, currentTime, currentTime, authenticationMethod.String(), currentTime).Exec()
 }

--- a/models/amr.go
+++ b/models/amr.go
@@ -29,5 +29,7 @@ func AddClaimToSession(tx *storage.Connection, session *Session, authenticationM
 	}
 	currentTime := time.Now()
 	return tx.RawQuery("INSERT INTO "+(&pop.Model{Value: AMRClaim{}}).TableName()+
-		"(id, session_id, created_at, updated_at, authentication_method) values(?, ?, ?, ?, ?) "+"ON CONFLICT ON CONSTRAINT mfa_amr_claims_session_id_authentication_method_pkey "+"DO UPDATE SET updated_at = ?;", id, session.ID, currentTime, currentTime, authenticationMethod.String(), currentTime).Exec()
+		`(id, session_id, created_at, updated_at, authentication_method) values (?, ?, ?, ?, ?)
+			ON CONFLICT ON CONSTRAINT mfa_amr_claims_session_id_authentication_method_pkey
+			DO UPDATE SET updated_at = ?;`, id, session.ID, currentTime, currentTime, authenticationMethod.String(), currentTime).Exec()
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces indexes for mfa to target the following queries:


```
func FindFactorsByUser(tx *storage.Connection, user *User) ([]*Factor, error) {
 	factors := []*Factor{}
 	if err := tx.Q().Where("user_id = ?", user.ID).Order("created_at asc").All(&factors); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return factors, nil
 		}
 		return nil, errors.Wrap(err, "Database error when finding MFA factors associated to user")
 	}
 	return factors, nil
 }
```

Find Token by Session
```
func FindTokenBySessionID(tx *storage.Connection, sessionId *uuid.UUID) (*RefreshToken, error) {
 	refreshToken := &RefreshToken{}
 	err := tx.Q().Where("session_id = ?", sessionId).Order("created_at asc").First(refreshToken)
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, RefreshTokenNotFoundError{}
 		}
 		return nil, err
 	}
 	return refreshToken, nil
 }
```
https://github.com/supabase/gotrue/pull/736/files#diff-391a5058b1ace3b7d41e48d0c23859a417795c034274ae3cd5fdf2c4ad6dc7b4R104
Source: https://github.com/supabase/gotrue/pull/736/files#diff-21513bee858a7f7f89598f574f70bcac74a98ddbef23b75201960823301398d0R85


```
 func FindSessionByUserID(tx *storage.Connection, userId uuid.UUID) (*Session, error) {
 	session := &Session{}
 	if err := tx.Eager().Q().Where("user_id = ?", userId).Order("created_at asc").First(session); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, SessionNotFoundError{}
 		}
 		return nil, errors.Wrap(err, "error finding session")
 	}
 	return session, nil
 }
```

https://github.com/supabase/gotrue/pull/736/files#diff-b4f2ed95a2f612a5c133f50ebc2ee346ccb1cabb36343da567c3a1e336668e94R104


The change will go into the `mfa` branch and we will then cherry pick the changes for merge into master



---

Sanity checks:

![CleanShot 2022-10-11 at 17 10 44@2x](https://user-images.githubusercontent.com/8011761/195114673-0c15cc12-6a58-4f2e-80b0-f20130dade47.png)



![CleanShot 2022-10-11 at 17 11 38@2x](https://user-images.githubusercontent.com/8011761/195114917-4f2ddcca-69a5-4463-a94d-bbce1f31a770.png)



![CleanShot 2022-10-11 at 17 12 40@2x](https://user-images.githubusercontent.com/8011761/195115036-1e1d0f0a-ff9a-443b-85c0-fce11256cbc5.png)
