### PR TITLE
fix: return mfa enabled in settings

### DIFF
--- a/api/settings.go
+++ b/api/settings.go
@@ -31,6 +31,7 @@ type Settings struct {
 	MailerAutoconfirm bool             `json:"mailer_autoconfirm"`
 	PhoneAutoconfirm  bool             `json:"phone_autoconfirm"`
 	SmsProvider       string           `json:"sms_provider"`
+	MFAEnabled        bool             `json:"mfa_enabled"`
 }
 
 func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
@@ -63,5 +64,6 @@ func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
 		MailerAutoconfirm: config.Mailer.Autoconfirm,
 		PhoneAutoconfirm:  config.Sms.Autoconfirm,
 		SmsProvider:       config.Sms.Provider,
+		MFAEnabled:        config.MFA.Enabled,
 	})
 }

--- a/api/settings_test.go
+++ b/api/settings_test.go
@@ -24,6 +24,8 @@ func TestSettings_DefaultProviders(t *testing.T) {
 	resp := Settings{}
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 
+	require.False(t, resp.MFAEnabled)
+
 	p := resp.ExternalProviders
 
 	require.False(t, p.Phone)


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Return the `MFA_ENABLED` config in `/settings` 