### PR TITLE
refactor: pluralize factors endpoint, use lowercase `totp`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -131,7 +131,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		})
 
 		if api.config.MFA.Enabled {
-			r.With(api.requireAuthentication).Route("/factor", func(r *router) {
+			r.With(api.requireAuthentication).Route("/factors", func(r *router) {
 				r.Post("/", api.EnrollFactor)
 				r.Route("/{factor_id}", func(r *router) {
 					r.Use(api.loadFactor)
@@ -164,7 +164,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 				r.Route("/{user_id}", func(r *router) {
 					r.Use(api.loadUser)
 					if api.config.MFA.Enabled {
-						r.Route("/factor", func(r *router) {
+						r.Route("/factors", func(r *router) {
 							r.Get("/", api.adminUserGetFactors)
 							r.Route("/{factor_id}", func(r *router) {
 								r.Use(api.loadFactor)

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -36,7 +36,7 @@ type TOTPObject struct {
 type EnrollFactorResponse struct {
 	ID   uuid.UUID  `json:"id"`
 	Type string     `json:"type"`
-	TOTP TOTPObject `json:"TOTP,omitempty"`
+	TOTP TOTPObject `json:"totp,omitempty"`
 }
 
 type VerifyFactorParams struct {

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -129,7 +129,7 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 			require.NoError(ts.T(), err)
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, "/factor", &buffer)
+			req := httptest.NewRequest(http.MethodPost, "/factors", &buffer)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 			req.Header.Set("Content-Type", "application/json")
 			ts.API.handler.ServeHTTP(w, req)
@@ -166,7 +166,7 @@ func (ts *MFATestSuite) TestChallengeFactor() {
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	var buffer bytes.Buffer
-	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost/factor/%s/challenge", f.ID), &buffer)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost/factors/%s/challenge", f.ID), &buffer)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
@@ -226,7 +226,7 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			require.NoError(ts.T(), err)
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/factor/%s/verify", f.ID), &buffer)
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/factors/%s/verify", f.ID), &buffer)
 			testIPAddress := utilities.GetIPAddress(req)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 			c, err := models.NewChallenge(f, testIPAddress)
@@ -341,7 +341,7 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 			}))
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/factor/%s/", f.ID), &buffer)
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/factors/%s/", f.ID), &buffer)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 			ts.API.handler.ServeHTTP(w, req)
 			require.Equal(ts.T(), v.expectedHTTPCode, w.Code)
@@ -384,7 +384,7 @@ func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 	}))
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/factor/%s", f.ID), &buffer)
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/factors/%s", f.ID), &buffer)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	ts.API.handler.ServeHTTP(w, req)
 	require.Equal(ts.T(), http.StatusOK, w.Code)
@@ -485,7 +485,7 @@ func enrollAndVerify(ts *MFATestSuite, user *models.User, token string) (verifyR
 	w := httptest.NewRecorder()
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]string{"friendly_name": "john", "factor_type": models.TOTP, "issuer": ts.TestDomain}))
 
-	req := httptest.NewRequest(http.MethodPost, "http://localhost/factor/", &buffer)
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/factors/", &buffer)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	req.Header.Set("Content-Type", "application/json")
 
@@ -498,7 +498,7 @@ func enrollAndVerify(ts *MFATestSuite, user *models.User, token string) (verifyR
 	// Challenge
 	var challengeBuffer bytes.Buffer
 	x := httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost/factor/%s/challenge", factorID), &challengeBuffer)
+	req = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost/factors/%s/challenge", factorID), &challengeBuffer)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	req.Header.Set("Content-Type", "application/json")
 	ts.API.handler.ServeHTTP(x, req)
@@ -527,7 +527,7 @@ func enrollAndVerify(ts *MFATestSuite, user *models.User, token string) (verifyR
 		"challenge_id": challengeID,
 		"code":         code,
 	}))
-	req = httptest.NewRequest(http.MethodPost, fmt.Sprintf("/factor/%s/verify", factorID), &verifyBuffer)
+	req = httptest.NewRequest(http.MethodPost, fmt.Sprintf("/factors/%s/verify", factorID), &verifyBuffer)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	req.Header.Set("Content-Type", "application/json")
 


### PR DESCRIPTION
Use a plural version of `/factors`, lowercase `totp` response on enrollment.