### PR TITLE
test: add sanity checks to ensure secret does not leak

### DIFF
--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -569,6 +569,9 @@ func (ts *AdminTestSuite) TestAdminUserGetFactors() {
 
 	ts.API.handler.ServeHTTP(w, req)
 	require.Equal(ts.T(), http.StatusOK, w.Code)
+	getFactorsResp := []*models.Factor{}
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&getFactorsResp))
+	require.Equal(ts.T(), getFactorsResp[0].Secret, nil)
 }
 
 func (ts *AdminTestSuite) TestAdminUserUpdateFactor() {

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -293,7 +293,7 @@ func (a *API) UnenrollFactor(w http.ResponseWriter, r *http.Request) error {
 	session := getSession(ctx)
 
 	if factor.Status == models.FactorStateVerified && session.AAL != models.AAL2.String() {
-		return unauthorizedError("AAL2 required to unenroll verified factor")
+		return badRequestError("AAL2 required to unenroll verified factor")
 	}
 
 	err = a.db.Transaction(func(tx *storage.Connection) error {

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -278,7 +278,7 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 		{
 			desc:             "Verified Factor: AAL1",
 			isAAL2:           false,
-			expectedHTTPCode: http.StatusUnauthorized,
+			expectedHTTPCode: http.StatusBadRequest,
 		},
 		{
 			desc:             "Verified Factor: AAL2, Success",

--- a/models/factor_test.go
+++ b/models/factor_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -78,4 +79,17 @@ func (ts *FactorTestSuite) TestUpdateFriendlyName() {
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), f.UpdateFriendlyName(ts.db, newSimpleName))
 	require.Equal(ts.T(), newSimpleName, f.FriendlyName)
+}
+
+func (ts *FactorTestSuite) TestEncodedFactorDoesNotLeakSecret() {
+	u, err := NewUser("", "", "", "", nil)
+	require.NoError(ts.T(), err)
+
+	f, err := NewFactor(u, "A1B2C3", TOTP, FactorStateUnverified, "some-secret")
+	require.NoError(ts.T(), err)
+	encodedFactor, err := json.Marshal(f)
+	require.NoError(ts.T(), err)
+	decodedFactor := Factor{}
+	json.Unmarshal(encodedFactor, &decodedFactor)
+	require.Equal(ts.T(), decodedFactor.Secret, "")
 }


### PR DESCRIPTION
Add a few sanity checks on `mfa_test.go` and  `admin_test.go` to ensure secret is not leaked

Also change the status codes for unenroll from `unauthorised` to `bad request` if user doesn't have AAL2 JWT