### PR TITLE
fix: allow any oauth providers to pass query params

### DIFF
--- a/api/external_oauth.go
+++ b/api/external_oauth.go
@@ -145,7 +145,7 @@ func (a *API) oAuth1Callback(ctx context.Context, r *http.Request, providerType 
 
 // OAuthProvider returns the corresponding oauth provider as an OAuthProvider interface
 func (a *API) OAuthProvider(ctx context.Context, name string) (provider.OAuthProvider, error) {
-	providerCandidate, err := a.Provider(ctx, name, "", nil)
+	providerCandidate, err := a.Provider(ctx, name, "")
 	if err != nil {
 		return nil, err
 	}

--- a/api/provider/workos.go
+++ b/api/provider/workos.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"errors"
-	"net/url"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -17,8 +16,7 @@ const (
 
 type workosProvider struct {
 	*oauth2.Config
-	APIPath         string
-	AuthCodeOptions []oauth2.AuthCodeOption
+	APIPath string
 }
 
 // See https://workos.com/docs/reference/sso/profile.
@@ -36,28 +34,11 @@ type workosUser struct {
 }
 
 // NewWorkOSProvider creates a WorkOS account provider.
-func NewWorkOSProvider(ext conf.OAuthProviderConfiguration, query *url.Values) (OAuthProvider, error) {
+func NewWorkOSProvider(ext conf.OAuthProviderConfiguration) (OAuthProvider, error) {
 	if err := ext.Validate(); err != nil {
 		return nil, err
 	}
 	apiPath := chooseHost(ext.URL, defaultWorkOSAPIBase)
-
-	// Attach custom query parameters to the WorkOS authorization URL.
-	// See https://workos.com/docs/reference/sso/authorize/get.
-	var authCodeOptions []oauth2.AuthCodeOption
-	if query != nil {
-		if connection := query.Get("connection"); connection != "" {
-			authCodeOptions = append(authCodeOptions, oauth2.SetAuthURLParam("connection", connection))
-		} else if organization := query.Get("organization"); organization != "" {
-			authCodeOptions = append(authCodeOptions, oauth2.SetAuthURLParam("organization", organization))
-		} else if provider := query.Get("workos_provider"); provider != "" {
-			authCodeOptions = append(authCodeOptions, oauth2.SetAuthURLParam("provider", provider))
-		}
-
-		if login_hint := query.Get("login_hint"); login_hint != "" {
-			authCodeOptions = append(authCodeOptions, oauth2.SetAuthURLParam("login_hint", login_hint))
-		}
-	}
 
 	return &workosProvider{
 		Config: &oauth2.Config{
@@ -69,14 +50,8 @@ func NewWorkOSProvider(ext conf.OAuthProviderConfiguration, query *url.Values) (
 			},
 			RedirectURL: ext.RedirectURI,
 		},
-		APIPath:         apiPath,
-		AuthCodeOptions: authCodeOptions,
+		APIPath: apiPath,
 	}, nil
-}
-
-func (g workosProvider) AuthCodeURL(state string, args ...oauth2.AuthCodeOption) string {
-	opts := append(args, g.AuthCodeOptions...)
-	return g.Config.AuthCodeURL(state, opts...)
 }
 
 func (g workosProvider) GetOAuthToken(code string) (*oauth2.Token, error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes [issue](https://github.com/supabase/gotrue-js/issues/131#issuecomment-1277378031) where some providers require passing an explicit query param (e.g. `access_type=offline`) before returning the provider refresh token 
* Refactored workos provider since this solution is generic enough to be used across all other oauth providers
