### PR TITLE
fix: unenroll should remove totp amr claim

### DIFF
--- a/models/factor.go
+++ b/models/factor.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
@@ -146,6 +147,15 @@ func (f *Factor) UpdateFactorType(tx *storage.Connection, factorType string) err
 }
 
 func (f *Factor) DowngradeSessionsToAAL1(tx *storage.Connection) error {
+	sessions, err := FindSessionsByFactorID(tx, f.ID)
+	if err != nil {
+		return err
+	}
+	for _, session := range sessions {
+		if err := tx.RawQuery("DELETE FROM "+(&pop.Model{Value: AMRClaim{}}).TableName()+" WHERE session_id = ? AND authentication_method like '%totp%'", session.ID).Exec(); err != nil {
+			return err
+		}
+	}
 	return updateFactorAssociatedSessions(tx, f.UserID, f.ID, AAL1.String())
 
 }

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -130,7 +130,7 @@ func FindSessionByUserID(tx *storage.Connection, userId uuid.UUID) (*Session, er
 }
 
 func updateFactorAssociatedSessions(tx *storage.Connection, userID, factorID uuid.UUID, aal string) error {
-	return tx.RawQuery("UPDATE "+(&pop.Model{Value: Session{}}).TableName()+" set aal = ?, factor_id = ? WHERE user_id = ? AND factor_id = ?", aal, uuid.Nil, userID, factorID).Exec()
+	return tx.RawQuery("UPDATE "+(&pop.Model{Value: Session{}}).TableName()+" set aal = ?, factor_id = ? WHERE user_id = ? AND factor_id = ?", aal, nil, userID, factorID).Exec()
 }
 
 func InvalidateSessionsWithAALLessThan(tx *storage.Connection, userID uuid.UUID, level string) error {

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -129,6 +129,14 @@ func FindSessionByUserID(tx *storage.Connection, userId uuid.UUID) (*Session, er
 	return session, nil
 }
 
+func FindSessionsByFactorID(tx *storage.Connection, factorID uuid.UUID) ([]*Session, error) {
+	sessions := []*Session{}
+	if err := tx.Q().Where("factor_id = ?", factorID).All(&sessions); err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
 func updateFactorAssociatedSessions(tx *storage.Connection, userID, factorID uuid.UUID, aal string) error {
 	return tx.RawQuery("UPDATE "+(&pop.Model{Value: Session{}}).TableName()+" set aal = ?, factor_id = ? WHERE user_id = ? AND factor_id = ?", aal, nil, userID, factorID).Exec()
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes a bug where upon unenrolling a verified factor associated to the session, the session's AAL level does not get downgraded because the MFA factor's AMR claim is not being removed