### PR TITLE
fix: add missing index on `user_id` under `sessions`

### DIFF
--- a/migrations/20221020193600_add_sessions_user_id_index.up.sql
+++ b/migrations/20221020193600_add_sessions_user_id_index.up.sql
@@ -1,0 +1,1 @@
+create index if not exists sessions_user_id_idx on {{ index .Options "Namespace" }}.sessions (user_id);

--- a/migrations/20221020193600_add_sessions_user_id_index.up.sql
+++ b/migrations/20221020193600_add_sessions_user_id_index.up.sql
@@ -1,1 +1,2 @@
 create index if not exists sessions_user_id_idx on {{ index .Options "Namespace" }}.sessions (user_id);
+


### PR DESCRIPTION
Indexes, they get you every time.

It was forgotten and in cases where there are many users x sessions the database can spend many cycles trying to delete sessions on logout.