### PR TITLE
fix: rename metadata to data

### DIFF
--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -16,7 +16,7 @@ import (
 // MagicLinkParams holds the parameters for a magic link request
 type MagicLinkParams struct {
 	Email string                 `json:"email"`
-	Data  map[string]interface{} `json:"metadata"`
+	Data  map[string]interface{} `json:"data"`
 }
 
 // MagicLink sends a recovery email


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes https://github.com/supabase/gotrue/issues/699#issuecomment-1286382275
* The `data` param will only be passed on the first magiclink sent (which is a signup action). Subsequent magiclink requests for the same user will not trigger any updates to the user metadata