### PR TITLE
fix: add index on `(session_id, revoked)` in `refresh_tokens`

### DIFF
--- a/migrations/20221021073300_add_refresh_tokens_session_id_revoked_index.up.sql
+++ b/migrations/20221021073300_add_refresh_tokens_session_id_revoked_index.up.sql
@@ -1,0 +1,1 @@
+create index if not exists refresh_tokens_session_id_revoked_idx on {{ index .Options "Namespace" }}.refresh_tokens (session_id, revoked);

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -72,7 +72,7 @@ func RevokeTokenFamily(tx *storage.Connection, token *RefreshToken) error {
 	var err error
 	tablename := (&pop.Model{Value: RefreshToken{}}).TableName()
 	if token.SessionId != nil {
-		err = tx.RawQuery(`update `+tablename+` set revoked = true where session_id = ?;`, token.SessionId).Exec()
+		err = tx.RawQuery(`update `+tablename+` set revoked = true where session_id = ? and revoked = false;`, token.SessionId).Exec()
 	} else {
 		err = tx.RawQuery(`
 		with recursive token_family as (


### PR DESCRIPTION
Certain long-lived user sessions will have a large number of refresh tokens. Each new subsequent refresh token action scans this large set of rows and updates all to be revoked. This change adds an index for the operation, and also limits the number of affected rows by forcing the query to update only non-revoked tokens.