### PR TITLE
fix: improve abuse message, don't log request

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -319,7 +319,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 					return internalServerError(err.Error())
 				}
 			}
-			return oauthError("invalid_grant", "Invalid Refresh Token").WithInternalMessage("Possible abuse attempt: %v", r)
+			return oauthError("invalid_grant", "Invalid Refresh Token").WithInternalMessage("Possible abuse attempt with refresh tokens. Often this is caused by a buggy implementation of Server-Side Rendering.")
 		}
 	}
 
@@ -422,7 +422,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 		// verify nonce to mitigate replay attacks
 		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(params.Nonce)))
 		if hash != hashedNonce.(string) {
-			return oauthError("invalid nonce", "").WithInternalMessage("Possible abuse attempt: %v", r)
+			return oauthError("invalid nonce", "").WithInternalMessage("Possible abuse attempt with refresh tokens. Often this is caused by a buggy implementation of Server-Side Rendering.")
 		}
 	}
 


### PR DESCRIPTION
Logging the request may leak some dangerous information such as the `Authorization` header. Adds clarification about the common cause for this error.