### PR TITLE
feat: add password hashing metrics

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -5,11 +5,10 @@ import (
 	"testing"
 
 	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
+	"github.com/netlify/gotrue/crypto"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -18,7 +17,7 @@ const (
 )
 
 func init() {
-	models.PasswordHashCost = bcrypt.MinCost
+	crypto.PasswordHashCost = crypto.QuickHashCost
 }
 
 // setupAPIForTest creates a new API to run tests with.

--- a/crypto/password.go
+++ b/crypto/password.go
@@ -84,13 +84,13 @@ func CompareHashAndPassword(ctx context.Context, hash, password string) error {
 // password, using PasswordHashCost. Context can be used to cancel the hashing
 // if the algorithm supports it.
 func GenerateFromPassword(ctx context.Context, password string) (string, error) {
-	hashCost := bcrypt.DefaultCost
+        var hashCost int
 
 	switch PasswordHashCost {
 	case QuickHashCost:
 		hashCost = bcrypt.MinCost
 
-	case DefaultHashCost:
+        default:
 		hashCost = bcrypt.DefaultCost
 	}
 

--- a/crypto/password.go
+++ b/crypto/password.go
@@ -1,0 +1,111 @@
+package crypto
+
+import (
+	"context"
+	"errors"
+
+	"github.com/netlify/gotrue/observability"
+	"go.opentelemetry.io/otel/attribute"
+	metricinstrument "go.opentelemetry.io/otel/metric/instrument"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type HashCost = int
+
+const (
+	// DefaultHashCost represents the default
+	// hashing cost for any hashing algorithm.
+	DefaultHashCost HashCost = iota
+
+	// QuickHashCosts represents the quickest
+	// hashing cost for any hashing algorithm,
+	// useful for tests only.
+	QuickHashCost HashCost = iota
+)
+
+// PasswordHashCost is the current pasword hashing cost
+// for all new hashes generated with
+// GenerateHashFromPassword.
+var PasswordHashCost = DefaultHashCost
+
+type metricCounter interface {
+	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
+}
+
+func obtainMetricCounter(name, desc string) metricCounter {
+	counter, err := observability.Meter("gotrue").SyncInt64().Counter(name, metricinstrument.WithDescription(desc))
+	if err != nil {
+		panic(err)
+	}
+
+	return counter
+}
+
+var (
+	generateFromPasswordSubmittedCounter = obtainMetricCounter("gotrue_generate_from_password_submitted", "Number of submitted GenerateFromPassword hashing attempts")
+	generateFromPasswordCompletedCounter = obtainMetricCounter("gotrue_generate_from_password_completed", "Number of completed GenerateFromPassword hashing attempts")
+)
+
+var (
+	compareHashAndPasswordSubmittedCounter = obtainMetricCounter("gotrue_compare_hash_and_password_submitted", "Number of submitted CompareHashAndPassword hashing attempts")
+	compareHashAndPasswordCompletedCounter = obtainMetricCounter("gotrue_compare_hash_and_password_completed", "Number of completed CompareHashAndPassword hashing attempts")
+)
+
+// CompareHashAndPassword compares the hash and
+// password, returns nil if equal otherwise an error. Context can be used to
+// cancel the hashing if the algorithm supports it.
+func CompareHashAndPassword(ctx context.Context, hash, password string) error {
+	hashCost, err := bcrypt.Cost([]byte(hash))
+	if err != nil {
+		return err
+	}
+
+	attributes := []attribute.KeyValue{
+		attribute.String("alg", "bcrypt"),
+		attribute.Int("bcrypt_cost", hashCost),
+	}
+
+	compareHashAndPasswordSubmittedCounter.Add(ctx, 1, attributes...)
+	defer func() {
+		attributes = append(attributes, attribute.Bool(
+			"match",
+			!errors.Is(err, bcrypt.ErrMismatchedHashAndPassword),
+		))
+
+		compareHashAndPasswordCompletedCounter.Add(ctx, 1, attributes...)
+	}()
+
+	err = bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+
+	return err
+}
+
+// GenerateFromPassword generates a password hash from a
+// password, using PasswordHashCost. Context can be used to cancel the hashing
+// if the algorithm supports it.
+func GenerateFromPassword(ctx context.Context, password string) (string, error) {
+	hashCost := bcrypt.DefaultCost
+
+	switch PasswordHashCost {
+	case QuickHashCost:
+		hashCost = bcrypt.MinCost
+
+	case DefaultHashCost:
+		hashCost = bcrypt.DefaultCost
+	}
+
+	attributes := []attribute.KeyValue{
+		attribute.String("alg", "bcrypt"),
+		attribute.Int("bcrypt_cost", hashCost),
+	}
+
+	generateFromPasswordSubmittedCounter.Add(ctx, 1, attributes...)
+	defer generateFromPasswordCompletedCounter.Add(ctx, 1, attributes...)
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), hashCost)
+	if err != nil {
+		return "", err
+	}
+
+	return string(hash), nil
+}

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -4,18 +4,18 @@ import (
 	"testing"
 
 	"github.com/netlify/gotrue/conf"
+	"github.com/netlify/gotrue/crypto"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/crypto/bcrypt"
 )
 
 const modelsTestConfig = "../hack/test.env"
 
 func init() {
-	PasswordHashCost = bcrypt.MinCost
+	crypto.PasswordHashCost = crypto.QuickHashCost
 }
 
 type UserTestSuite struct {


### PR DESCRIPTION
Refactors the password hashing code to live in a central place under `crypto` and adds metrics that count the number of submitted and completed password hashing attempts. These metrics can be useful to determine whether GoTrue is under a password stuffing attack (where submitted will rise drastically over completed or not-matched will rise drastically over matched). Example:

```prometheus
# HELP gotrue_compare_hash_and_password_completed Number of completed CompareHashAndPassword hashing attempts
# TYPE gotrue_compare_hash_and_password_completed counter
gotrue_compare_hash_and_password_completed{alg="bcrypt",bcrypt_cost="10",gotrue_version="",match="false"} 4
gotrue_compare_hash_and_password_completed{alg="bcrypt",bcrypt_cost="10",gotrue_version="",match="true"} 3
# HELP gotrue_compare_hash_and_password_submitted Number of submitted CompareHashAndPassword hashing attempts
# TYPE gotrue_compare_hash_and_password_submitted counter
gotrue_compare_hash_and_password_submitted{alg="bcrypt",bcrypt_cost="10",gotrue_version=""} 7
# HELP gotrue_generate_from_password_completed Number of completed GenerateFromPassword hashing attempts
# TYPE gotrue_generate_from_password_completed counter
gotrue_generate_from_password_completed{alg="bcrypt",bcrypt_cost="10",gotrue_version=""} 1
# HELP gotrue_generate_from_password_submitted Number of submitted GenerateFromPassword hashing attempts
# TYPE gotrue_generate_from_password_submitted counter
gotrue_generate_from_password_submitted{alg="bcrypt",bcrypt_cost="10",gotrue_version=""} 1
```