### PR TITLE
refactor: extract `AccessTokenResponse` encoding as URL to method

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -314,11 +313,8 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 		if providerRefreshToken != "" {
 			q.Set("provider_refresh_token", providerRefreshToken)
 		}
-		q.Set("access_token", token.Token)
-		q.Set("token_type", token.TokenType)
-		q.Set("expires_in", strconv.Itoa(token.ExpiresIn))
-		q.Set("refresh_token", token.RefreshToken)
-		rurl += "#" + q.Encode()
+
+		rurl = token.AsRedirectURL(rurl, q)
 
 		if err := a.setCookieTokens(config, token, false, w); err != nil {
 			return internalServerError("Failed to set JWT cookie. %s", err)

--- a/api/token.go
+++ b/api/token.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -39,6 +40,17 @@ type AccessTokenResponse struct {
 	ExpiresIn    int          `json:"expires_in"`
 	RefreshToken string       `json:"refresh_token"`
 	User         *models.User `json:"user"`
+}
+
+// AsRedirectURL encodes the AccessTokenResponse as a redirect URL that
+// includes the access token response data in a URL fragment.
+func (r *AccessTokenResponse) AsRedirectURL(redirectURL string, extraParams url.Values) string {
+	extraParams.Set("access_token", r.Token)
+	extraParams.Set("token_type", r.TokenType)
+	extraParams.Set("expires_in", strconv.Itoa(r.ExpiresIn))
+	extraParams.Set("refresh_token", r.RefreshToken)
+
+	return redirectURL + "#" + extraParams.Encode()
 }
 
 // PasswordGrantParams are the parameters the ResourceOwnerPasswordGrant method accepts

--- a/api/verify.go
+++ b/api/verify.go
@@ -150,13 +150,11 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 	rurl := params.RedirectTo
 	if token != nil {
 		q := url.Values{}
-		q.Set("access_token", token.Token)
-		q.Set("token_type", token.TokenType)
-		q.Set("expires_in", strconv.Itoa(token.ExpiresIn))
-		q.Set("refresh_token", token.RefreshToken)
 		q.Set("type", params.Type)
-		rurl += "#" + q.Encode()
+
+		rurl = token.AsRedirectURL(rurl, q)
 	}
+
 	http.Redirect(w, r, rurl, http.StatusSeeOther)
 	return nil
 }


### PR DESCRIPTION
Extracts the redirect URL encoding logic as a method on `AccessTokenResponse` so it can be reused easily.