### PR TITLE
fix: convert `string` -> `*string` for AAL and AMR

### DIFF
--- a/api/mfa.go
+++ b/api/mfa.go
@@ -292,7 +292,7 @@ func (a *API) UnenrollFactor(w http.ResponseWriter, r *http.Request) error {
 	factor := getFactor(ctx)
 	session := getSession(ctx)
 
-	if factor.Status == models.FactorStateVerified && *session.AAL != models.AAL2.String() {
+	if factor.Status == models.FactorStateVerified && session.GetAAL() != models.AAL2.String() {
 		return badRequestError("AAL2 required to unenroll verified factor")
 	}
 

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -292,7 +292,7 @@ func (a *API) UnenrollFactor(w http.ResponseWriter, r *http.Request) error {
 	factor := getFactor(ctx)
 	session := getSession(ctx)
 
-	if factor.Status == models.FactorStateVerified && session.AAL != models.AAL2.String() {
+	if factor.Status == models.FactorStateVerified && *session.AAL != models.AAL2.String() {
 		return badRequestError("AAL2 required to unenroll verified factor")
 	}
 

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -327,7 +327,7 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 				_, err = models.FindFactorByFactorID(ts.API.db, f.ID)
 				require.EqualError(ts.T(), err, models.FactorNotFoundError{}.Error())
 				session, _ := models.FindSessionById(ts.API.db, secondarySession.ID)
-				require.Equal(ts.T(), models.AAL1.String(), session.AAL)
+				require.Equal(ts.T(), models.AAL1.String(), *session.AAL)
 				require.Nil(ts.T(), session.FactorID)
 
 			}
@@ -368,7 +368,7 @@ func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 	_, err = models.FindFactorByFactorID(ts.API.db, f.ID)
 	require.EqualError(ts.T(), err, models.FactorNotFoundError{}.Error())
 	session, _ := models.FindSessionById(ts.API.db, secondarySession.ID)
-	require.Equal(ts.T(), models.AAL1.String(), session.AAL)
+	require.Equal(ts.T(), models.AAL1.String(), *session.AAL)
 	require.Nil(ts.T(), session.FactorID)
 
 }
@@ -396,7 +396,7 @@ func (ts *MFATestSuite) TestSessionsMaintainAALOnRefresh() {
 	require.NoError(ts.T(), err)
 	ctx, err = ts.API.maybeLoadUserOrSession(ctx)
 	require.NoError(ts.T(), err)
-	require.Equal(ts.T(), models.AAL2.String(), getSession(ctx).AAL)
+	require.Equal(ts.T(), models.AAL2.String(), *(getSession(ctx).AAL))
 }
 
 // Performing MFA Verification followed by a sign in should return an AAL1 session and an AAL2 session
@@ -422,10 +422,10 @@ func (ts *MFATestSuite) TestMFAFollowedByPasswordSignIn() {
 	require.NoError(ts.T(), err)
 	ctx, err = ts.API.maybeLoadUserOrSession(ctx)
 	require.NoError(ts.T(), err)
-	require.Equal(ts.T(), models.AAL1.String(), getSession(ctx).AAL)
+	require.Equal(ts.T(), models.AAL1.String(), *(getSession(ctx).AAL))
 	session, err := models.FindSessionByUserID(ts.API.db, token.User.ID)
 	require.NoError(ts.T(), err)
-	require.Equal(ts.T(), models.AAL2.String(), session.AAL)
+	require.Equal(ts.T(), models.AAL2.String(), *session.AAL)
 }
 
 func signUp(ts *MFATestSuite, email, password string) (signUpResp AccessTokenResponse) {

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -327,7 +327,7 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 				_, err = models.FindFactorByFactorID(ts.API.db, f.ID)
 				require.EqualError(ts.T(), err, models.FactorNotFoundError{}.Error())
 				session, _ := models.FindSessionById(ts.API.db, secondarySession.ID)
-				require.Equal(ts.T(), models.AAL1.String(), *session.AAL)
+				require.Equal(ts.T(), models.AAL1.String(), session.GetAAL())
 				require.Nil(ts.T(), session.FactorID)
 
 			}
@@ -368,7 +368,7 @@ func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 	_, err = models.FindFactorByFactorID(ts.API.db, f.ID)
 	require.EqualError(ts.T(), err, models.FactorNotFoundError{}.Error())
 	session, _ := models.FindSessionById(ts.API.db, secondarySession.ID)
-	require.Equal(ts.T(), models.AAL1.String(), *session.AAL)
+	require.Equal(ts.T(), models.AAL1.String(), session.GetAAL())
 	require.Nil(ts.T(), session.FactorID)
 
 }
@@ -396,7 +396,7 @@ func (ts *MFATestSuite) TestSessionsMaintainAALOnRefresh() {
 	require.NoError(ts.T(), err)
 	ctx, err = ts.API.maybeLoadUserOrSession(ctx)
 	require.NoError(ts.T(), err)
-	require.Equal(ts.T(), models.AAL2.String(), *(getSession(ctx).AAL))
+	require.Equal(ts.T(), models.AAL2.String(), getSession(ctx).GetAAL())
 }
 
 // Performing MFA Verification followed by a sign in should return an AAL1 session and an AAL2 session
@@ -422,7 +422,7 @@ func (ts *MFATestSuite) TestMFAFollowedByPasswordSignIn() {
 	require.NoError(ts.T(), err)
 	ctx, err = ts.API.maybeLoadUserOrSession(ctx)
 	require.NoError(ts.T(), err)
-	require.Equal(ts.T(), models.AAL1.String(), *(getSession(ctx).AAL))
+	require.Equal(ts.T(), models.AAL1.String(), getSession(ctx).GetAAL())
 	session, err := models.FindSessionByUserID(ts.API.db, token.User.ID)
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), models.AAL2.String(), *session.AAL)

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -425,7 +425,7 @@ func (ts *MFATestSuite) TestMFAFollowedByPasswordSignIn() {
 	require.Equal(ts.T(), models.AAL1.String(), getSession(ctx).GetAAL())
 	session, err := models.FindSessionByUserID(ts.API.db, token.User.ID)
 	require.NoError(ts.T(), err)
-	require.Equal(ts.T(), models.AAL2.String(), *session.AAL)
+	require.Equal(ts.T(), models.AAL2.String(), session.GetAAL())
 }
 
 func signUp(ts *MFATestSuite, email, password string) (signUpResp AccessTokenResponse) {

--- a/models/amr.go
+++ b/models/amr.go
@@ -33,3 +33,10 @@ func AddClaimToSession(tx *storage.Connection, session *Session, authenticationM
 			ON CONFLICT ON CONSTRAINT mfa_amr_claims_session_id_authentication_method_pkey
 			DO UPDATE SET updated_at = ?;`, id, session.ID, currentTime, currentTime, authenticationMethod.String(), currentTime).Exec()
 }
+
+func (a *AMRClaim) GetAuthenticationMethod() string {
+	if a.AuthenticationMethod == nil {
+		return ""
+	}
+	return *(a.AuthenticationMethod)
+}

--- a/models/amr.go
+++ b/models/amr.go
@@ -14,7 +14,7 @@ type AMRClaim struct {
 	SessionID            uuid.UUID `json:"session_id" db:"session_id"`
 	CreatedAt            time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt            time.Time `json:"updated_at" db:"updated_at"`
-	AuthenticationMethod string    `json:"authentication_method" db:"authentication_method"`
+	AuthenticationMethod *string   `json:"authentication_method" db:"authentication_method"`
 }
 
 func (AMRClaim) TableName() string {

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -61,7 +61,7 @@ type Session struct {
 	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
 	FactorID  *uuid.UUID `json:"factor_id" db:"factor_id"`
 	AMRClaims []AMRClaim `json:"amr,omitempty" has_many:"amr_claims"`
-	AAL       string     `json:"aal" db:"aal"`
+	AAL       *string    `json:"aal" db:"aal"`
 }
 
 func (Session) TableName() string {
@@ -74,12 +74,13 @@ func NewSession(user *User, factorID *uuid.UUID) (*Session, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Error generating unique session id")
 	}
+	defaultAAL := AAL1.String()
 
 	session := &Session{
 		ID:        id,
 		UserID:    user.ID,
 		FactorID:  factorID,
-		AAL:       AAL1.String(),
+		AAL:       &defaultAAL,
 		AMRClaims: []AMRClaim{},
 	}
 	return session, nil
@@ -160,17 +161,17 @@ func (s *Session) UpdateAssociatedFactor(tx *storage.Connection, factorID *uuid.
 }
 
 func (s *Session) UpdateAssociatedAAL(tx *storage.Connection, aal string) error {
-	s.AAL = aal
+	s.AAL = &aal
 	return tx.Update(s)
 }
 
 func (s *Session) CalculateAALAndAMR() (aal string, amr []AMREntry) {
 	amr, aal = []AMREntry{}, AAL1.String()
 	for _, claim := range s.AMRClaims {
-		if claim.AuthenticationMethod == TOTPSignIn.String() {
+		if *claim.AuthenticationMethod == TOTPSignIn.String() {
 			aal = AAL2.String()
 		}
-		amr = append(amr, AMREntry{Method: claim.AuthenticationMethod, Timestamp: claim.UpdatedAt.Unix()})
+		amr = append(amr, AMREntry{Method: *claim.AuthenticationMethod, Timestamp: claim.UpdatedAt.Unix()})
 	}
 
 	// makes sure that the AMR claims are always ordered most-recent first

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -74,6 +74,7 @@ func NewSession(user *User, factorID *uuid.UUID) (*Session, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Error generating unique session id")
 	}
+
 	defaultAAL := AAL1.String()
 
 	session := &Session{
@@ -187,4 +188,11 @@ func (s *Session) CalculateAALAndAMR() (aal string, amr []AMREntry) {
 	})
 
 	return aal, amr
+}
+
+func (s *Session) GetAAL() string {
+	if s.AAL == nil {
+		return ""
+	}
+	return *(s.AAL)
 }

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -172,7 +172,7 @@ func (s *Session) CalculateAALAndAMR() (aal string, amr []AMREntry) {
 		if *claim.AuthenticationMethod == TOTPSignIn.String() {
 			aal = AAL2.String()
 		}
-		amr = append(amr, AMREntry{Method: *claim.AuthenticationMethod, Timestamp: claim.UpdatedAt.Unix()})
+		amr = append(amr, AMREntry{Method: claim.GetAuthenticationMethod(), Timestamp: claim.UpdatedAt.Unix()})
 	}
 
 	// makes sure that the AMR claims are always ordered most-recent first

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -75,7 +75,7 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	require.Equal(ts.T(), totalDistinctClaims, len(amr))
 	found := false
 	for _, claim := range session.AMRClaims {
-		if claim.AuthenticationMethod == TOTPSignIn.String() {
+		if *claim.AuthenticationMethod == TOTPSignIn.String() {
 			require.True(ts.T(), firstClaimAddedTime.Before(claim.UpdatedAt))
 			found = true
 		}

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -75,7 +75,7 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	require.Equal(ts.T(), totalDistinctClaims, len(amr))
 	found := false
 	for _, claim := range session.AMRClaims {
-		if *claim.AuthenticationMethod == TOTPSignIn.String() {
+		if claim.GetAuthenticationMethod() == TOTPSignIn.String() {
 			require.True(ts.T(), firstClaimAddedTime.Before(claim.UpdatedAt))
 			found = true
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

There was a brief incident last week where users with pre-MFA sessions would run into errors when attempting to sign in. This was because past sessions would have an empty `AAL` claims  field(thus null) while the Sessions model was expecting a string. This resulted in an error as a null was being coerced into a string.

## What is the current behavior?
Both models use `string`

## What is the new behavior?

We modify both the AAL and AMR fields to accept `*string` in case there are future instances which have null values for some reason

## Additional context


How this was tested:
1. Revert to `85cff37bac7fdd22a87235890caca7d6ace6c244` (pre-MFA)
2. Create a few sessions by making a few signups, check DB to ensure they have null field
3. Pull to come back to the current version and apply existing migrations.
4. Attempt to sign up, sign in, get user, and then make a full enrolment.