### PR TITLE
fix: add dynamic captcha configuration

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -33,7 +33,7 @@ func (a *API) requireAuthentication(w http.ResponseWriter, r *http.Request) (con
 	return ctx, err
 }
 
-func (a *API) requireAdmin(ctx context.Context, w http.ResponseWriter, r *http.Request) (context.Context, error) {
+func (a *API) requireAdmin(ctx context.Context, r *http.Request) (context.Context, error) {
 	// Find the administrative user
 	claims := getClaims(ctx)
 	if claims == nil {

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -116,7 +116,7 @@ func (a *API) requireAdminCredentials(w http.ResponseWriter, req *http.Request) 
 		return nil, err
 	}
 
-	return a.requireAdmin(ctx, w, req)
+	return a.requireAdmin(ctx, req)
 }
 
 func (a *API) requireEmailProvider(w http.ResponseWriter, req *http.Request) (context.Context, error) {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -214,9 +214,10 @@ type VonageProviderConfiguration struct {
 }
 
 type CaptchaConfiguration struct {
-	Enabled  bool   `json:"enabled" default:"false"`
-	Provider string `json:"provider" default:"hcaptcha"`
-	Secret   string `json:"provider_secret"`
+	Enabled  bool     `json:"enabled" default:"false"`
+	Provider string   `json:"provider" default:"hcaptcha"`
+	Secret   string   `json:"provider_secret"`
+	Routes   []string `json:"routes"`
 }
 
 type SecurityConfiguration struct {
@@ -377,6 +378,10 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 	}
 	if config.MFA.ChallengeExpiryDuration < defaultChallengeExpiryDuration {
 		config.MFA.ChallengeExpiryDuration = defaultChallengeExpiryDuration
+	}
+
+	if config.Security.Captcha.Routes == nil || len(config.Security.Captcha.Routes) == 0 {
+		config.Security.Captcha.Routes = []string{"/signup", "/recover", "/magiclink", "/otp", "/token", "/verify"}
 	}
 
 	return nil


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Previously, if captcha was enabled in gotrue, it would be enforced on the following routes: `"/signup", "/recover", "/magiclink", "/otp", "/token", "/verify"` 
* This PR aims to make this configuration dynamic via a new config variable `GOTRUE_SECURITY_CAPTCHA_ROUTES`
* For example: In some cases, a user might want to enforce captcha protection on the `/admin/generate_link` route. Previously, this isn't possible because of the following reasons:
  1. The captcha middleware is not added to the `/admin/generate_link` endpoint
  2. The captcha middleware can be bypassed if an admin JWT is provided
  
  * This PR aims to solve (2) by introducing a new header (`X-CAPTCHA-BYPASS`) which will bypass captcha on a route if a JWT with a "captcha" role claim is provided. 
  * For backward compatibility sake, if the new header is not present, it will default to bypassing if the admin JWT is present. However, it will not allow bypassing captcha on any `/admin` endpoints (which is the same as the current behaviour). 