### PR TITLE
fix: rate limiting not applied on phone OTP

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -98,7 +98,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 		r.Get("/authorize", api.ExternalProviderRedirect)
 
-		sharedLimiter := api.limitEmailSentHandler()
+		sharedLimiter := api.limitEmailOrPhoneSentHandler()
 		r.With(sharedLimiter).With(api.requireAdminCredentials).Post("/invite", api.Invite)
 		r.With(sharedLimiter).With(api.verifyCaptcha).Post("/signup", api.Signup)
 		r.With(sharedLimiter).With(api.verifyCaptcha).With(api.requireEmailProvider).Post("/recover", api.Recover)


### PR DESCRIPTION
Rate limiting was not getting applied because the shared email+phone limiter for OTP only rate limited when the request body contained an `email` attribute; which is not the case with SMS OTP.