### PR TITLE
feat: no email password resets for users with no email identity

### DIFF
--- a/api/recover.go
+++ b/api/recover.go
@@ -54,6 +54,24 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 			return terr
 		}
+		identities, terr := models.FindIdentitiesByUser(tx, user)
+		if terr != nil {
+			return terr
+		}
+		hasEmailProvider := false
+		for _, identity := range identities {
+			if identity.Provider == "email" {
+				hasEmailProvider = true
+				break
+			}
+		}
+		if !hasEmailProvider {
+			if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryDeniedAction, "", nil); terr != nil {
+				return terr
+			}
+			// don't send a recovery email if the user doesn't have an email identity
+			return nil
+		}
 		mailer := a.Mailer(ctx)
 		referrer := a.getReferrer(r)
 		return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency, referrer, config.Mailer.OtpLength)

--- a/api/recover_test.go
+++ b/api/recover_test.go
@@ -41,6 +41,14 @@ func (ts *RecoverTestSuite) SetupTest() {
 	u, err := models.NewUser("", "test@example.com", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
+
+	// Create corresponding identity
+	i, err := ts.API.createNewIdentity(ts.API.db, u, "email", map[string]interface{}{
+		"sub":   u.ID.String(),
+		"email": u.GetEmail(),
+	})
+	require.NoError(ts.T(), err, "Error creating test identity for test user model")
+	require.NotNil(ts.T(), i)
 }
 
 func (ts *RecoverTestSuite) TestRecover_FirstRecovery() {

--- a/api/recover_test.go
+++ b/api/recover_test.go
@@ -63,6 +63,7 @@ func (ts *RecoverTestSuite) SetupTest() {
 		EmailVerified: true,
 		ProviderId:    "oauth-sub",
 	}).ToMap()
+	require.NoError(ts.T(), err)
 
 	oauthIdentity, err := ts.API.createNewIdentity(ts.API.db, u, "email", oauthClaims)
 	require.NoError(ts.T(), err, "Error creating test identity for test user model")

--- a/api/recover_test.go
+++ b/api/recover_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/netlify/gotrue/api/provider"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,23 @@ func (ts *RecoverTestSuite) SetupTest() {
 	})
 	require.NoError(ts.T(), err, "Error creating test identity for test user model")
 	require.NotNil(ts.T(), i)
+
+	// Create oauth user
+	oauthUser, err := models.NewUser("", "testoauth@example.com", "", ts.Config.JWT.Aud, nil)
+	require.NoError(ts.T(), err, "Error creating test oauth user model")
+	require.NoError(ts.T(), ts.API.db.Create(oauthUser), "Error saving new test ")
+
+	// Create corresponding oauth identity
+	oauthClaims, err := (&provider.Claims{
+		Subject:       "oauth-sub",
+		Email:         "testoauth@example.com",
+		EmailVerified: true,
+		ProviderId:    "oauth-sub",
+	}).ToMap()
+
+	oauthIdentity, err := ts.API.createNewIdentity(ts.API.db, u, "email", oauthClaims)
+	require.NoError(ts.T(), err, "Error creating test identity for test user model")
+	require.NotNil(ts.T(), oauthIdentity)
 }
 
 func (ts *RecoverTestSuite) TestRecover_FirstRecovery() {
@@ -158,4 +176,31 @@ func (ts *RecoverTestSuite) TestRecover_NoSideChannelLeak() {
 	w := httptest.NewRecorder()
 	ts.API.handler.ServeHTTP(w, req)
 	assert.Equal(ts.T(), http.StatusOK, w.Code)
+}
+
+func (ts *RecoverTestSuite) TestRecover_NotAllowedIfNoEmailIdentity() {
+	oauthUserEmail := "testoauth@example.com"
+	u, err := models.FindUserByEmailAndAudience(ts.API.db, oauthUserEmail, ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), u)
+
+	// Request body
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email": u.GetEmail(),
+	}))
+
+	// Setup request
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/recover", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Setup response recorder
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	assert.Equal(ts.T(), http.StatusOK, w.Code)
+
+	u, err = models.FindUserByEmailAndAudience(ts.API.db, oauthUserEmail, ts.Config.JWT.Aud)
+	require.NoError(ts.T(), err)
+	require.Nil(ts.T(), u.RecoverySentAt)
+	require.Equal(ts.T(), "", u.RecoveryToken)
 }

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -45,6 +45,14 @@ func (ts *VerifyTestSuite) SetupTest() {
 	u, err := models.NewUser("12345678", "test@example.com", "password", ts.Config.JWT.Aud, nil)
 	require.NoError(ts.T(), err, "Error creating test user model")
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
+
+	// Create corresponding identity
+	i, err := ts.API.createNewIdentity(ts.API.db, u, "email", map[string]interface{}{
+		"sub":   u.ID.String(),
+		"email": u.GetEmail(),
+	})
+	require.NoError(ts.T(), err, "Error creating test identity for test user model")
+	require.NotNil(ts.T(), i)
 }
 
 func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -60,6 +60,7 @@ var ActionLogTypeMap = map[AuditAction]auditLogType{
 	TokenRefreshedAction:            token,
 	UserModifiedAction:              user,
 	UserRecoveryRequestedAction:     user,
+	UserRecoveryDeniedAction:        user,
 	UserConfirmationRequestedAction: user,
 	UserRepeatedSignUpAction:        user,
 	GenerateRecoveryCodesAction:     user,

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -25,6 +25,7 @@ const (
 	UserDeletedAction               AuditAction = "user_deleted"
 	UserModifiedAction              AuditAction = "user_modified"
 	UserRecoveryRequestedAction     AuditAction = "user_recovery_requested"
+	UserRecoveryDeniedAction        AuditAction = "user_recovery_denied"
 	UserReauthenticateAction        AuditAction = "user_reauthenticate_requested"
 	UserConfirmationRequestedAction AuditAction = "user_confirmation_requested"
 	UserRepeatedSignUpAction        AuditAction = "user_repeated_signup"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* No longer allow password resets for user's without an email identity.
* Previously, it was possible to request for a password reset if you have an oauth identity. This is because the oauth identity is always guaranteed to have an email and the password reset would be allowed. This means that the user will now be able to login with email + password if the reset was successful even though no email identity is created for them. The password reset acts as a backdoor access to the user's account in the event the user loses access to their oauth account. However, the user should attempt to regain their access to the account by liaising with the oauth provider rather than initiate a password recovery to gain access to the account.   