### PR TITLE
fix: skip captcha on `POST /verify`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -120,7 +120,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			}).SetBurst(30),
 		)).Route("/verify", func(r *router) {
 			r.Get("/", api.Verify)
-			r.With(api.verifyCaptcha).Post("/", api.Verify)
+			r.Post("/", api.Verify)
 		})
 
 		r.With(api.requireAuthentication).Post("/logout", api.Logout)


### PR DESCRIPTION
Having CAPTCHA on `POST /verify` means that developers need to ask users to solve a captcha twice: one when the email / SMS is sent, and once again when the code is being verified.

Given that `GET` request already does not require CAPTCHA, and that there is a rate limiter including OTP expiration logic, it is not possible to brute-force verifications.

PR in gotrue-js: https://github.com/supabase/gotrue-js/pull/532