### PR TITLE
fix: update password should logout all other sessions

### DIFF
--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -29,6 +29,7 @@ const (
 	UserReauthenticateAction        AuditAction = "user_reauthenticate_requested"
 	UserConfirmationRequestedAction AuditAction = "user_confirmation_requested"
 	UserRepeatedSignUpAction        AuditAction = "user_repeated_signup"
+	UserUpdatePasswordAction        AuditAction = "user_updated_password"
 	TokenRevokedAction              AuditAction = "token_revoked"
 	TokenRefreshedAction            AuditAction = "token_refreshed"
 	GenerateRecoveryCodesAction     AuditAction = "generate_recovery_codes"
@@ -63,6 +64,7 @@ var ActionLogTypeMap = map[AuditAction]auditLogType{
 	UserRecoveryDeniedAction:        user,
 	UserConfirmationRequestedAction: user,
 	UserRepeatedSignUpAction:        user,
+	UserUpdatePasswordAction:        user,
 	GenerateRecoveryCodesAction:     user,
 	EnrollFactorAction:              factor,
 	UnenrollFactorAction:            factor,

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -152,8 +152,14 @@ func Logout(tx *storage.Connection, userId uuid.UUID) error {
 	return tx.RawQuery("DELETE FROM "+(&pop.Model{Value: Session{}}).TableName()+" WHERE user_id = ?", userId).Exec()
 }
 
+// LogoutSession deletes the current session for a user
 func LogoutSession(tx *storage.Connection, sessionId uuid.UUID) error {
 	return tx.RawQuery("DELETE FROM "+(&pop.Model{Value: Session{}}).TableName()+" WHERE id = ?", sessionId).Exec()
+}
+
+// LogoutAllExceptMe deletes all sessions for a user except the current one
+func LogoutAllExceptMe(tx *storage.Connection, sessionId uuid.UUID, userID uuid.UUID) error {
+	return tx.RawQuery("DELETE FROM "+(&pop.Model{Value: Session{}}).TableName()+" WHERE id != ? AND user_id = ?", sessionId, userID).Exec()
 }
 
 func (s *Session) UpdateAssociatedFactor(tx *storage.Connection, factorID *uuid.UUID) error {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Previously, updating a password would allow other sessions to remain logged in. However, this change fixes that by ensuring that all other sessions are forcefully logged out upon a password update