### PR TITLE
fix: remove foreign key constraint on `refresh_tokens`.`parent`

### DIFF
--- a/migrations/20221114143410_remove_parent_foreign_key_refresh_tokens.up.sql
+++ b/migrations/20221114143410_remove_parent_foreign_key_refresh_tokens.up.sql
@@ -1,0 +1,2 @@
+alter table only {{ index .Options "Namespace" }}.refresh_tokens
+  drop constraint refresh_tokens_parent_fkey;


### PR DESCRIPTION
Removing the foreign key constraint as it's causing some issues when deletes cascade. PotgreSQL is having trouble deleting refresh tokens with parents since it has to recursively keep track.
