### PR TITLE
feat(saml): add `not_after` column to `sessions` table (not used)

### DIFF
--- a/migrations/20221114143122_add_session_not_after_column.up.sql
+++ b/migrations/20221114143122_add_session_not_after_column.up.sql
@@ -1,0 +1,4 @@
+alter table only {{ index .Options "Namespace" }}.sessions
+  add column if not exists not_after timestamptz;
+
+comment on column {{ index .Options "Namespace" }}.sessions.not_after is 'Auth: Not after is a nullable column that contains a timestamp after which the session should be regarded as expired.';

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -57,6 +57,7 @@ func (s sortAMREntries) Swap(i, j int) {
 type Session struct {
 	ID        uuid.UUID  `json:"-" db:"id"`
 	UserID    uuid.UUID  `json:"user_id" db:"user_id"`
+	NotAfter  *time.Time `json:"not_after,omitempty" db:"not_after"`
 	CreatedAt time.Time  `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
 	FactorID  *uuid.UUID `json:"factor_id" db:"factor_id"`


### PR DESCRIPTION
Prepares the database for the introduction of expiring sessions (as first used by SAML). 