### PR TITLE
feat: add idle db connection options (duration, count, healthcheck period)

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -37,8 +37,12 @@ type DBConfiguration struct {
 	URL       string `json:"url" envconfig:"DATABASE_URL" required:"true"`
 	Namespace string `json:"namespace" envconfig:"DB_NAMESPACE" default:"auth"`
 	// MaxPoolSize defaults to 0 (unlimited).
-	MaxPoolSize    int    `json:"max_pool_size" split_words:"true"`
-	MigrationsPath string `json:"migrations_path" split_words:"true" default:"./migrations"`
+	MaxPoolSize       int           `json:"max_pool_size" split_words:"true"`
+	MaxIdlePoolSize   int           `json:"max_idle_pool_size" split_words:"true"`
+	ConnMaxLifetime   time.Duration `json:"conn_max_lifetime,omitempty" split_words:"true"`
+	ConnMaxIdleTime   time.Duration `json:"conn_max_idle_time,omitempty" split_words:"true"`
+	HealthCheckPeriod time.Duration `json:"health_check_period" split_words:"true"`
+	MigrationsPath    string        `json:"migrations_path" split_words:"true" default:"./migrations"`
 }
 
 func (c *DBConfiguration) Validate() error {


### PR DESCRIPTION
Adds the following idle DB connection options:

`GOTRUE_DB_MAX_IDLE_POOL_SIZE` - maximum number of idle connections (defaults to 2, if not set or 0)
`GOTRUE_DB_CONN_MAX_LIFETIME` - maximum duration of a connection (defaults to unlimited, if not set or 0)
`GOTRUE_DB_CONN_MAX_IDLE_TIME` - maximum idle duration of a connection (defaults to unlimited, if not set or 0)
`GOTRUE_DB_HEALTH_CHECK_PERIOD` - duration between health check (pings) on the connection when idle (defaults to 1 minute, if not set or 0)

The durations are expressed as Go durations. So `1s` for 1 second, or `1m` for one minute.