### PR TITLE
feat(saml): add session expiration (not after timestamp) support (disabled by default)

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -113,7 +113,7 @@ func (a *API) maybeLoadUserOrSession(ctx context.Context) (context.Context, erro
 		if err != nil {
 			return ctx, err
 		}
-		session, err = models.FindSessionById(db, sessionId)
+		session, err = models.FindSessionByID(db, sessionId)
 		if err != nil && !models.IsNotFoundError(err) {
 			return ctx, err
 		}

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -75,9 +75,12 @@ func (ts *AuthTestSuite) TestMaybeLoadUserOrSession() {
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
-	var s *models.Session
-	s, err = models.CreateSession(ts.API.db, u, &uuid.Nil)
+	s, err := models.NewSession()
 	require.NoError(ts.T(), err)
+	s.UserID = u.ID
+	require.NoError(ts.T(), ts.API.db.Create(s))
+
+	require.NoError(ts.T(), ts.API.db.Load(s))
 
 	cases := []struct {
 		Desc            string

--- a/api/samlacs.go
+++ b/api/samlacs.go
@@ -228,6 +228,14 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 	// refreshTokenParams.NotBefore = assertion.NotBefore()
 	// refreshTokenParams.NotAfter = assertion.NotAfter()
 
+	notAfter := assertion.NotAfter()
+
+	var grantParams models.GrantParams
+
+	if !notAfter.IsZero() {
+		grantParams.SessionNotAfter = &notAfter
+	}
+
 	var token *AccessTokenResponse
 
 	if err := db.Transaction(func(tx *storage.Connection) error {
@@ -238,7 +246,7 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 
-		token, terr = a.issueRefreshToken(ctx, tx, user, models.SSOSAML, models.GrantParams{})
+		token, terr = a.issueRefreshToken(ctx, tx, user, models.SSOSAML, grantParams)
 
 		if terr != nil {
 			return internalServerError("Unable to issue refresh token from SAML Assertion").WithInternalError(terr)

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -39,6 +39,8 @@ func (RefreshToken) TableName() string {
 // refresh token to authenticated users.
 type GrantParams struct {
 	FactorID *uuid.UUID
+
+	SessionNotAfter *time.Time
 }
 
 // GrantAuthenticatedUser creates a refresh token for the provided user.
@@ -125,14 +127,25 @@ func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshTok
 	}
 
 	if token.SessionId == nil {
-		// Existing refresh tokens may have a null session_id if they were created before v2.15.3
-		var session *Session
-		var err error
-		session, err = CreateSession(tx, user, params.FactorID)
-
+		session, err := NewSession()
 		if err != nil {
-			return nil, errors.Wrap(err, "Error generated unique session id")
+			return nil, errors.Wrap(err, "error instantiating new session object")
 		}
+
+		session.UserID = user.ID
+
+		if params.FactorID != nil {
+			session.FactorID = params.FactorID
+		}
+
+		if params.SessionNotAfter != nil {
+			session.NotAfter = params.SessionNotAfter
+		}
+
+		if err := tx.Create(session); err != nil {
+			return nil, errors.Wrap(err, "error creating new session")
+		}
+
 		token.SessionId = &session.ID
 	}
 

--- a/models/refresh_token_test.go
+++ b/models/refresh_token_test.go
@@ -52,7 +52,7 @@ func (ts *RefreshTokenTestSuite) TestGrantRefreshTokenSwap() {
 	s, err := GrantRefreshTokenSwap(&http.Request{}, ts.db, u, r)
 	require.NoError(ts.T(), err)
 
-	_, nr, err := FindUserWithRefreshToken(ts.db, r.Token)
+	_, nr, _, err := FindUserWithRefreshToken(ts.db, r.Token)
 	require.NoError(ts.T(), err)
 
 	require.Equal(ts.T(), r.ID, nr.ID)
@@ -68,7 +68,7 @@ func (ts *RefreshTokenTestSuite) TestLogout() {
 	require.NoError(ts.T(), err)
 
 	require.NoError(ts.T(), Logout(ts.db, u.ID))
-	u, r, err = FindUserWithRefreshToken(ts.db, r.Token)
+	u, r, _, err = FindUserWithRefreshToken(ts.db, r.Token)
 	require.Errorf(ts.T(), err, "expected error when there are no refresh tokens to authenticate. user: %v token: %v", u, r)
 
 	require.True(ts.T(), IsNotFoundError(err), "expected NotFoundError")

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -70,7 +70,7 @@ func (Session) TableName() string {
 	return tableName
 }
 
-func NewSession(user *User, factorID *uuid.UUID) (*Session, error) {
+func NewSession() (*Session, error) {
 	id, err := uuid.NewV4()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error generating unique session id")
@@ -79,27 +79,14 @@ func NewSession(user *User, factorID *uuid.UUID) (*Session, error) {
 	defaultAAL := AAL1.String()
 
 	session := &Session{
-		ID:        id,
-		UserID:    user.ID,
-		FactorID:  factorID,
-		AAL:       &defaultAAL,
-		AMRClaims: []AMRClaim{},
+		ID:  id,
+		AAL: &defaultAAL,
 	}
+
 	return session, nil
 }
 
-func CreateSession(tx *storage.Connection, user *User, factorID *uuid.UUID) (*Session, error) {
-	session, err := NewSession(user, factorID)
-	if err != nil {
-		return nil, err
-	}
-	if err := tx.Create(session); err != nil {
-		return nil, errors.Wrap(err, "error creating session")
-	}
-	return session, nil
-}
-
-func FindSessionById(tx *storage.Connection, id uuid.UUID) (*Session, error) {
+func FindSessionByID(tx *storage.Connection, id uuid.UUID) (*Session, error) {
 	session := &Session{}
 	if err := tx.Eager().Q().Where("id = ?", id).First(session); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"github.com/gofrs/uuid"
 	"github.com/netlify/gotrue/conf"
 	"github.com/netlify/gotrue/storage"
 	"github.com/netlify/gotrue/storage/test"
@@ -44,8 +43,10 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	totalDistinctClaims := 2
 	u, err := FindUserByEmailAndAudience(ts.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
-	session, err := CreateSession(ts.db, u, &uuid.Nil)
+	session, err := NewSession()
 	require.NoError(ts.T(), err)
+	session.UserID = u.ID
+	require.NoError(ts.T(), ts.db.Create(session))
 
 	err = AddClaimToSession(ts.db, session, PasswordGrant)
 	require.NoError(ts.T(), err)
@@ -53,7 +54,7 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	firstClaimAddedTime := time.Now()
 	err = AddClaimToSession(ts.db, session, TOTPSignIn)
 	require.NoError(ts.T(), err)
-	session, err = FindSessionById(ts.db, session.ID)
+	session, err = FindSessionByID(ts.db, session.ID)
 	require.NoError(ts.T(), err)
 
 	aal, amr := session.CalculateAALAndAMR()
@@ -63,7 +64,7 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	err = AddClaimToSession(ts.db, session, TOTPSignIn)
 	require.NoError(ts.T(), err)
 
-	session, err = FindSessionById(ts.db, session.ID)
+	session, err = FindSessionByID(ts.db, session.ID)
 	require.NoError(ts.T(), err)
 
 	aal, amr = session.CalculateAALAndAMR()

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -151,10 +151,12 @@ func (ts *UserTestSuite) TestFindUserWithRefreshToken() {
 	r, err := GrantAuthenticatedUser(ts.db, u, GrantParams{})
 	require.NoError(ts.T(), err)
 
-	n, nr, err := FindUserWithRefreshToken(ts.db, r.Token)
+	n, nr, s, err := FindUserWithRefreshToken(ts.db, r.Token)
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), r.ID, nr.ID)
 	require.Equal(ts.T(), u.ID, n.ID)
+	require.NotNil(ts.T(), s)
+	require.Equal(ts.T(), *r.SessionId, s.ID)
 }
 
 func (ts *UserTestSuite) TestIsDuplicatedEmail() {


### PR DESCRIPTION
The SAML ACS endpoint will create sessions with a "not after" timestamp. Refresh tokens won't be refreshable past this timestamp.