### PR TITLE
fix: resolve nil pointer dereference issue

### DIFF
--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -61,7 +61,7 @@ func GrantRefreshTokenSwap(r *http.Request, tx *storage.Connection, user *User, 
 			return terr
 		}
 
-		newToken, terr = createRefreshToken(rtx, user, token, nil)
+		newToken, terr = createRefreshToken(rtx, user, token, &GrantParams{})
 		return terr
 	})
 	return newToken, err


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes problem where attempting to dereference a `nil` will lead to a panic causing a deadlock in postgres because gotrue panics and the transaction is left idle