### PR TITLE
feat: add password security requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ Rate limit the number of emails sent per hr on the following endpoints: `/signup
 
 Minimum password length, defaults to 6.
 
+`GOTRUE_PASSWORD_COMPLEXITY_REQUIRE_LOWERCASE` - `bool`
+`GOTRUE_PASSWORD_COMPLEXITY_REQUIRE_UPPERCASE` - `bool`
+`GOTRUE_PASSWORD_COMPLEXITY_REQUIRE_NUMBER` - `bool`
+`GOTRUE_PASSWORD_COMPLEXITY_REQUIRE_SPECIAL` - `bool`
+
+Require certain character classes in passwords. Lowercase requires at least one lowercase latin character (a-z),
+uppercase requires at least one uppercase latin character (A-Z), number requires at least one digit (0-9) and special
+requires at least one character from `! @ # $ % ^ & * ( ) _ + - = [ ] { } | '`. All default to false.
+
 `GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED` - `bool`
 
 If refresh token rotation is enabled, gotrue will automatically detect malicious attempts to reuse a revoked refresh token. When a malicious attempt is detected, gotrue immediately revokes all tokens that descended from the offending token.

--- a/api/errors.go
+++ b/api/errors.go
@@ -63,10 +63,6 @@ func (e *OAuthError) Cause() error {
 	return e
 }
 
-func invalidPasswordLengthError(config *conf.GlobalConfiguration) *HTTPError {
-	return unprocessableEntityError(fmt.Sprintf("Password should be at least %d characters", config.PasswordMinLength))
-}
-
 func invalidSignupError(config *conf.GlobalConfiguration) *HTTPError {
 	var msg string
 	if config.External.Email.Enabled && config.External.Phone.Enabled {

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -2,6 +2,10 @@ package api
 
 import (
 	"net"
+	"testing"
+
+	"github.com/netlify/gotrue/conf"
+	"github.com/stretchr/testify/require"
 )
 
 func removeLocalhostFromPrivateIPBlock() *net.IPNet {
@@ -20,4 +24,104 @@ func removeLocalhostFromPrivateIPBlock() *net.IPNet {
 
 func unshiftPrivateIPBlock(address *net.IPNet) {
 	privateIPBlocks = append([]*net.IPNet{address}, privateIPBlocks...)
+}
+
+func TestCheckPasswordMeetsRequirements(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   conf.GlobalConfiguration
+		password string
+		expected *HTTPError
+	}{
+		{
+			"Password is too short",
+			conf.GlobalConfiguration{PasswordMinLength: 3},
+			"hi",
+			unprocessableEntityError("Password should be at least 3 characters"),
+		},
+		{
+			"Password is right length",
+			conf.GlobalConfiguration{PasswordMinLength: 3},
+			"hello",
+			nil,
+		},
+		{
+			"Password missing uppercase",
+			conf.GlobalConfiguration{
+				PasswordComplexity: conf.PasswordComplexityConfiguration{
+					RequireUppercase: true,
+				}},
+			"hello",
+			unprocessableEntityError("Password must contain at least one character from the set: ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+		},
+		{
+			"Password missing lowercase",
+			conf.GlobalConfiguration{
+				PasswordComplexity: conf.PasswordComplexityConfiguration{
+					RequireLowercase: true,
+				}},
+			"HELLO",
+			unprocessableEntityError("Password must contain at least one character from the set: abcdefghijklmnopqrstuvwxyz"),
+		},
+		{
+			"Password missing numbers",
+			conf.GlobalConfiguration{
+				PasswordComplexity: conf.PasswordComplexityConfiguration{
+					RequireNumber: true,
+				}},
+			"hello",
+			unprocessableEntityError("Password must contain at least one character from the set: 0123456789"),
+		},
+		{
+			"Password missing special",
+			conf.GlobalConfiguration{
+				PasswordComplexity: conf.PasswordComplexityConfiguration{
+					RequireSpecial: true,
+				}},
+			"hello",
+			unprocessableEntityError("Password must contain at least one character from the set: !@#$%%^&*()_+-=[]{}|'"),
+		},
+		{
+			"Password missing all categories",
+			conf.GlobalConfiguration{
+				PasswordComplexity: conf.PasswordComplexityConfiguration{
+					RequireLowercase: true,
+					RequireUppercase: true,
+					RequireNumber:    true,
+					RequireSpecial:   true,
+				}},
+			"",
+			unprocessableEntityError("Password must contain at least one character from the set: abcdefghijklmnopqrstuvwxyz"),
+		},
+		{
+			"Password missing some categories",
+			conf.GlobalConfiguration{
+				PasswordComplexity: conf.PasswordComplexityConfiguration{
+					RequireLowercase: true,
+					RequireUppercase: true,
+					RequireNumber:    true,
+					RequireSpecial:   true,
+				}},
+			"abcABC",
+			unprocessableEntityError("Password must contain at least one character from the set: 0123456789"),
+		},
+		{
+			"Password meeting all requirements",
+			conf.GlobalConfiguration{
+				PasswordComplexity: conf.PasswordComplexityConfiguration{
+					RequireLowercase: true,
+					RequireUppercase: true,
+					RequireNumber:    true,
+					RequireSpecial:   true,
+				}},
+			"abcABC123!",
+			nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := checkPasswordMeetsRequirements(&test.config, test.password)
+			require.Equal(t, test.expected, actual)
+		})
+	}
 }

--- a/api/mail.go
+++ b/api/mail.go
@@ -148,8 +148,8 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 				if params.Password == "" {
 					return unprocessableEntityError("Signup requires a valid password")
 				}
-				if len(params.Password) < config.PasswordMinLength {
-					return unprocessableEntityError(fmt.Sprintf("Password should be at least %d characters", config.PasswordMinLength))
+				if err := checkPasswordMeetsRequirements(config, params.Password); err != nil {
+					return err
 				}
 				signupParams := &SignupParams{
 					Email:    params.Email,

--- a/api/signup.go
+++ b/api/signup.go
@@ -51,8 +51,8 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	if params.Password == "" {
 		return unprocessableEntityError("Signup requires a valid password")
 	}
-	if len(params.Password) < config.PasswordMinLength {
-		return unprocessableEntityError(fmt.Sprintf("Password should be at least %d characters", config.PasswordMinLength))
+	if err := checkPasswordMeetsRequirements(config, params.Password); err != nil {
+		return err
 	}
 	if params.Email != "" && params.Phone != "" {
 		return unprocessableEntityError("Only an email address or phone number should be provided on signup.")

--- a/api/user.go
+++ b/api/user.go
@@ -62,8 +62,8 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		if params.Password != nil {
-			if len(*params.Password) < config.PasswordMinLength {
-				return invalidPasswordLengthError(config)
+			if perr := checkPasswordMeetsRequirements(config, *params.Password); perr != nil {
+				return perr
 			}
 
 			isPasswordUpdated := false

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -67,6 +67,14 @@ type MFAConfiguration struct {
 	MaxEnrolledFactors          float64 `split_words:"true" default:"10"`
 }
 
+// PasswordComplexityConfiguration holds settings for enforcing password complexity
+type PasswordComplexityConfiguration struct {
+	RequireUppercase bool `split_words:"true" default:"false"`
+	RequireLowercase bool `split_words:"true" default:"false"`
+	RequireNumber    bool `split_words:"true" default:"false"`
+	RequireSpecial   bool `split_words:"true" default:"false"`
+}
+
 type APIConfiguration struct {
 	Host            string
 	Port            string `envconfig:"PORT" default:"8081"`
@@ -104,18 +112,19 @@ type GlobalConfiguration struct {
 	RateLimitTokenRefresh float64 `split_words:"true" default:"30"`
 	RateLimitSso          float64 `split_words:"true" default:"30"`
 
-	SiteURL           string   `json:"site_url" split_words:"true" required:"true"`
-	URIAllowList      []string `json:"uri_allow_list" split_words:"true"`
-	URIAllowListMap   map[string]glob.Glob
-	PasswordMinLength int                      `json:"password_min_length" split_words:"true"`
-	JWT               JWTConfiguration         `json:"jwt"`
-	Mailer            MailerConfiguration      `json:"mailer"`
-	Sms               SmsProviderConfiguration `json:"sms"`
-	DisableSignup     bool                     `json:"disable_signup" split_words:"true"`
-	Webhook           WebhookConfig            `json:"webhook" split_words:"true"`
-	Security          SecurityConfiguration    `json:"security"`
-	MFA               MFAConfiguration         `json:"MFA"`
-	Cookie            struct {
+	SiteURL            string   `json:"site_url" split_words:"true" required:"true"`
+	URIAllowList       []string `json:"uri_allow_list" split_words:"true"`
+	URIAllowListMap    map[string]glob.Glob
+	PasswordMinLength  int                             `json:"password_min_length" split_words:"true"`
+	PasswordComplexity PasswordComplexityConfiguration `json:"password_complexity" split_words:"true"`
+	JWT                JWTConfiguration                `json:"jwt"`
+	Mailer             MailerConfiguration             `json:"mailer"`
+	Sms                SmsProviderConfiguration        `json:"sms"`
+	DisableSignup      bool                            `json:"disable_signup" split_words:"true"`
+	Webhook            WebhookConfig                   `json:"webhook" split_words:"true"`
+	Security           SecurityConfiguration           `json:"security"`
+	MFA                MFAConfiguration                `json:"MFA"`
+	Cookie             struct {
 		Key      string `json:"key"`
 		Domain   string `json:"domain"`
 		Duration int    `json:"duration"`


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Any password equal to or greater than the minimum length is permitted

## What is the new behavior?

Four new config settings that require at least one lowercase, uppercase, numeric and special character in the password. Trying to set a password that doesn't comply with these requirements results in a 422 error (similar to the existing behaviour for passwords that are too short).

## Additional context

This could be done in a bunch of other ways (e.g. regular expressions, some way of requiring X different sets but not necessarily caring about which ones, ...). I had a look around for other configurable password policies and the only one I could see that was clearly documented is the one for AWS IAM: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html#password-policy-details

Relevant to this change is the recent decision by the French GDPR authority in relation to Discord (see https://www.cnil.fr/en/discord-inc-fined-800-000-euros):

> At the time of the online investigation, when creating an account on DISCORD, a password of six characters including letters and numbers was accepted.
> 
> The restricted committee considered that DISCORD's password management policy was not sufficiently strong and restrictive to ensure the security of users' accounts.