### PR TITLE
fix: add migration to backfill email identities

### DIFF
--- a/migrations/20221125140132_backfill_email_identity.up.sql
+++ b/migrations/20221125140132_backfill_email_identity.up.sql
@@ -1,0 +1,7 @@
+-- backfill the auth.identities column by adding an email identity 
+-- for all auth.users with an email and password 
+
+insert into auth.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
+select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2022-11-25' as created_at, '2022-11-25' as updated_at
+from auth.users as users
+where encrypted_password != '' and email is not null and not exists(select user_id from auth.identities where user_id = users.id);


### PR DESCRIPTION
## What kind of change does this PR introduce?
* This migration is responsible for backfilling all email-password or email-passwordless based users that don't have a corresponding email identity.
* The `created_at` and `updated_at` timestamps are deliberately hard-coded so we can roll back the migration by deleting those identities easily
