### PR TITLE
fix: don't update user metadata on subsequent signups

### DIFF
--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -179,20 +179,4 @@ func TestHookTimeout(t *testing.T) {
 	assert.Equal(t, 3, callCount)
 }
 
-func TestHookNoServer(t *testing.T) {
-	config := &conf.WebhookConfig{
-		URL:        "http://somewhere.something.com",
-		Retries:    1,
-		TimeoutSec: 1,
-	}
-	w := Webhook{
-		WebhookConfig: config,
-	}
-	_, err := w.trigger()
-	require.Error(t, err)
-	herr, ok := err.(*HTTPError)
-	require.True(t, ok)
-	assert.Equal(t, http.StatusBadGateway, herr.Code)
-}
-
 func squash(f func() error) { _ = f }

--- a/api/signup.go
+++ b/api/signup.go
@@ -104,9 +104,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				return UserExistsError
 			}
 
-			if err := user.UpdateUserMetaData(tx, params.Data); err != nil {
-				return internalServerError("Database error updating user").WithInternalError(err)
-			}
+			// do not update the user because we can't be sure of their claimed identity
 		} else {
 			user, terr = a.signupNewUser(ctx, tx, params)
 			if terr != nil {


### PR DESCRIPTION
Subsequent unconfirmed user signups allow modifying the originally passed user metadata without confirming that the password is correct. Given that this endpoint is meant to be used only once, no subsequent editing of the user metadata should be allowed.

This can be achieved by calling the user update endpoint while authenticated.