### PR TITLE
feat: modify email duplicate lookup to use `identities`

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -275,9 +275,9 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		if exists, err := models.IsDuplicatedEmail(db, params.Email, aud); err != nil {
+		if user, err := models.IsDuplicatedEmail(db, params.Email, aud); err != nil {
 			return internalServerError("Database error checking email").WithInternalError(err)
-		} else if exists {
+		} else if user != nil {
 			return unprocessableEntityError("Email address already registered by another user")
 		}
 	}

--- a/api/mail.go
+++ b/api/mail.go
@@ -182,9 +182,9 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return unprocessableEntityError("The new email address provided is invalid")
 			}
-			if exists, terr := models.IsDuplicatedEmail(tx, params.NewEmail, user.Aud); terr != nil {
+			if duplicateUser, terr := models.IsDuplicatedEmail(tx, params.NewEmail, user.Aud); terr != nil {
 				return internalServerError("Database error checking email").WithInternalError(terr)
-			} else if exists {
+			} else if duplicateUser != nil {
 				return unprocessableEntityError(DuplicateEmailMsg)
 			}
 			now := time.Now()

--- a/api/signup.go
+++ b/api/signup.go
@@ -79,7 +79,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		user, err = models.FindUserByEmailAndAudience(db, params.Email, params.Aud)
+		user, err = models.IsDuplicatedEmail(db, params.Email, params.Aud)
 	case "phone":
 		if !config.External.Phone.Enabled {
 			return badRequestError("Phone signups are disabled")

--- a/api/user.go
+++ b/api/user.go
@@ -123,10 +123,10 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 
-			var exists bool
-			if exists, terr = models.IsDuplicatedEmail(tx, params.Email, user.Aud); terr != nil {
+			var duplicateUser *models.User
+			if duplicateUser, terr = models.IsDuplicatedEmail(tx, params.Email, user.Aud); terr != nil {
 				return internalServerError("Database error checking email").WithInternalError(terr)
-			} else if exists {
+			} else if duplicateUser != nil {
 				return unprocessableEntityError(DuplicateEmailMsg)
 			}
 

--- a/cmd/admin_cmd.go
+++ b/cmd/admin_cmd.go
@@ -73,7 +73,7 @@ func adminCreateUser(config *conf.GlobalConfiguration, args []string) {
 	defer db.Close()
 
 	aud := getAudience(config)
-	if exists, err := models.IsDuplicatedEmail(db, args[0], aud); exists {
+	if user, err := models.IsDuplicatedEmail(db, args[0], aud); user != nil {
 		logrus.Fatalf("Error creating new user: user already exists")
 	} else if err != nil {
 		logrus.Fatalf("Error checking user email: %+v", err)

--- a/migrations/20221125141029_add_identities_email_column.up.sql
+++ b/migrations/20221125141029_add_identities_email_column.up.sql
@@ -1,0 +1,15 @@
+update
+  {{ index .Options "Namespace" }}.identities as identities
+set
+  identity_data = identity_data || jsonb_build_object('email', (select email from {{ index .Options "Namespace" }}.users where id = identities.user_id)),
+  updated_at = '2022-11-25'
+where identities.provider = 'email' and identity_data->>'email' is null;
+
+alter table only {{ index .Options "Namespace" }}.identities
+  add column if not exists email text generated always as (lower(identity_data->>'email')) stored;
+
+comment on column {{ index .Options "Namespace" }}.identities.email is 'Auth: Email is a generated column that references the optional email property in the identity_data';
+
+create index if not exists identities_email_idx on {{ index .Options "Namespace" }}.identities (email text_pattern_ops);
+
+comment on index {{ index .Options "Namespace" }}.identities_email_idx is 'Auth: Ensures indexed queries on the email column';

--- a/models/identity.go
+++ b/models/identity.go
@@ -56,6 +56,10 @@ func (i *Identity) BeforeUpdate(tx *pop.Connection) error {
 	return nil
 }
 
+func (i *Identity) IsForSSOProvider() bool {
+	return strings.HasPrefix(i.Provider, "sso:")
+}
+
 // FindIdentityById searches for an identity with the matching provider_id and provider given.
 func FindIdentityByIdAndProvider(tx *storage.Connection, providerId, provider string) (*Identity, error) {
 	identity := &Identity{}

--- a/models/user.go
+++ b/models/user.go
@@ -508,15 +508,43 @@ func FindUserByPhoneChangeAndAudience(tx *storage.Connection, phone, aud string)
 }
 
 // IsDuplicatedEmail returns whether a user exists with a matching email and audience.
-func IsDuplicatedEmail(tx *storage.Connection, email, aud string) (bool, error) {
-	_, err := FindUserByEmailAndAudience(tx, email, aud)
-	if err != nil {
-		if IsNotFoundError(err) {
-			return false, nil
+func IsDuplicatedEmail(tx *storage.Connection, email, aud string) (*User, error) {
+	var identities []Identity
+
+	if err := tx.Eager().Q().Where("email = ?", strings.ToLower(email)).All(&identities); err != nil {
+		if errors.Cause(err) == sql.ErrNoRows {
+			return nil, nil
 		}
-		return false, err
+
+		return nil, errors.Wrap(err, "unable to find identity by email for duplicates")
 	}
-	return true, nil
+
+	userIDs := make(map[string]uuid.UUID)
+	for _, identity := range identities {
+		if !identity.IsForSSOProvider() {
+			userIDs[identity.UserID.String()] = identity.UserID
+		}
+	}
+
+	for _, userID := range userIDs {
+		user, err := FindUserByID(tx, userID)
+		if err != nil && !IsNotFoundError(err) {
+			return nil, errors.Wrap(err, "unable to find user from email identity for duplicates")
+		}
+
+		if user.Aud == aud {
+			return user, nil
+		}
+	}
+
+	// out of an abundance of caution, if nothing was found via the
+	// identities table we also do a final check on the users table
+	user, err := FindUserByEmailAndAudience(tx, email, aud)
+	if err != nil && !IsNotFoundError(err) {
+		return nil, errors.Wrap(err, "unable to find user email addres for duplicates")
+	}
+
+	return user, nil
 }
 
 // IsDuplicatedPhone checks if the phone number already exists in the users table

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -164,19 +164,19 @@ func (ts *UserTestSuite) TestIsDuplicatedEmail() {
 
 	e, err := IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "test")
 	require.NoError(ts.T(), err)
-	require.True(ts.T(), e, "expected email to be duplicated")
+	require.NotNil(ts.T(), e, "expected email to be duplicated")
 
 	e, err = IsDuplicatedEmail(ts.db, "davidcalavera@netlify.com", "test")
 	require.NoError(ts.T(), err)
-	require.False(ts.T(), e, "expected email to not be duplicated")
+	require.Nil(ts.T(), e, "expected email to not be duplicated")
 
 	e, err = IsDuplicatedEmail(ts.db, "david@netlify.com", "test")
 	require.NoError(ts.T(), err)
-	require.False(ts.T(), e, "expected same email to not be duplicated")
+	require.Nil(ts.T(), e, "expected same email to not be duplicated")
 
 	e, err = IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "other-aud")
 	require.NoError(ts.T(), err)
-	require.False(ts.T(), e, "expected same email to not be duplicated")
+	require.Nil(ts.T(), e, "expected same email to not be duplicated")
 }
 
 func (ts *UserTestSuite) createUser() *User {
@@ -186,9 +186,14 @@ func (ts *UserTestSuite) createUser() *User {
 func (ts *UserTestSuite) createUserWithEmail(email string) *User {
 	user, err := NewUser("", email, "secret", "test", nil)
 	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(user))
 
-	err = ts.db.Create(user)
+	identity, err := NewIdentity(user, "email", map[string]interface{}{
+		"sub":   user.ID.String(),
+		"email": email,
+	})
 	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identity))
 
 	return user
 }


### PR DESCRIPTION
Modifies the `IsDuplicateEmail` method to use email addresses within the `identities` table and not the primary user email address in `users`. 

It now also returns the duplicate user it found, so that it can be reused in signup and update user.