### PR TITLE
fix: make add_mfa_indexes re-runnable

### DIFF
--- a/migrations/20221003041349_add_mfa_schema.up.sql
+++ b/migrations/20221003041349_add_mfa_schema.up.sql
@@ -22,7 +22,7 @@ create table if not exists {{ index .Options "Namespace" }}.mfa_factors(
 );
 comment on table {{ index .Options "Namespace" }}.mfa_factors is 'auth: stores metadata about factors';
 
-create unique index mfa_factors_user_friendly_name_unique on {{ index .Options "Namespace" }}.mfa_factors (friendly_name, user_id) where trim(friendly_name) <> '';
+create unique index if not exists mfa_factors_user_friendly_name_unique on {{ index .Options "Namespace" }}.mfa_factors (friendly_name, user_id) where trim(friendly_name) <> '';
 
 -- auth.mfa_challenges definition
 create table if not exists {{ index .Options "Namespace" }}.mfa_challenges(

--- a/migrations/20221011041400_add_mfa_indexes.up.sql
+++ b/migrations/20221011041400_add_mfa_indexes.up.sql
@@ -20,7 +20,7 @@ $$ language 'plpgsql'
 alter table {{ index .Options "Namespace" }}.mfa_amr_claims
   add column if not exists id uuid not null;
 
-create_constraint_if_not_exists("auth.mfa_amr_claims", "amr_id_pk", "ALTER TABLE auth.mfa_amr_claims add constraint amr_id_pk primary key(id)");
+select create_constraint_if_not_exists("auth.mfa_amr_claims", "amr_id_pk", "alter table auth.mfa_amr_claims add constraint amr_id_pk primary key(id)");
 alter table {{ index .Options "Namespace" }}.mfa_amr_claims add constraint if not exists amr_id_pk primary key(id);
 
 create index if not exists user_id_created_at_idx on {{ index .Options "Namespace" }}.sessions (user_id, created_at);

--- a/migrations/20221011041400_add_mfa_indexes.up.sql
+++ b/migrations/20221011041400_add_mfa_indexes.up.sql
@@ -1,17 +1,16 @@
 alter table {{ index .Options "Namespace" }}.mfa_amr_claims
   add column if not exists id uuid not null;
 
-do language plpgsql
-$$ declare
+do $$
 begin
-    if not exists ( select constraint_name
-                from    information_schema.check_constraints
-                where   constraint_schema = '{{ index .Options "Namespace" }}'
-                  and   constraint_name = 'amr_id_pk'
-              )
-    then
-        execute 'alter table {{ index .Options "Namespace" }}.mfa_amr_claims add constraint amr_id_pk primary key(id)';
-    end if;
+  if not exists
+     (select constraint_name
+      from information_schema.check_constraints
+      where constraint_schema = '{{ index .Options "Namespace" }}'
+      and constraint_name = 'amr_id_pk')
+  then
+    alter table {{ index .Options "Namespace" }}.mfa_amr_claims add constraint amr_id_pk primary key(id);
+  end if;
 end $$;
 
 create index if not exists user_id_created_at_idx on {{ index .Options "Namespace" }}.sessions (user_id, created_at);

--- a/migrations/20221011041400_add_mfa_indexes.up.sql
+++ b/migrations/20221011041400_add_mfa_indexes.up.sql
@@ -1,8 +1,27 @@
 create index if not exists refresh_token_session_id on {{ index .Options "Namespace" }}.refresh_tokens using btree(session_id);
 
+-- Taken from: https://stackoverflow.com/questions/6801919/postgres-add-constraint-if-it-doesnt-already-exist
+create or replace function create_constraint_if_not_exists (
+    t_name text, c_name text, constraint_sql text
+)
+returns void AS
+$$
+begin
+    -- Look for our constraint
+    if not exists (select constraint_name
+                   from information_schema.constraint_column_usage
+                   where table_name = t_name  and constraint_name = c_name) then
+        execute constraint_sql;
+    end if;
+end;
+
+$$ language 'plpgsql'
+
 alter table {{ index .Options "Namespace" }}.mfa_amr_claims
-  add column if not exists id uuid not null,
-  add constraint if not exists amr_id_pk primary key(id);
+  add column if not exists id uuid not null;
+
+create_constraint_if_not_exists("auth.mfa_amr_claims", "amr_id_pk", "ALTER TABLE auth.mfa_amr_claims add constraint amr_id_pk primary key(id)");
+alter table {{ index .Options "Namespace" }}.mfa_amr_claims add constraint if not exists amr_id_pk primary key(id);
 
 create index if not exists user_id_created_at_idx on {{ index .Options "Namespace" }}.sessions (user_id, created_at);
 create index if not exists factor_id_created_at_idx on {{ index .Options "Namespace" }}.mfa_factors (user_id, created_at);

--- a/migrations/20221011041400_add_mfa_indexes.up.sql
+++ b/migrations/20221011041400_add_mfa_indexes.up.sql
@@ -2,7 +2,7 @@ create index if not exists refresh_token_session_id on {{ index .Options "Namesp
 
 alter table {{ index .Options "Namespace" }}.mfa_amr_claims
   add column if not exists id uuid not null,
-  add constraint amr_id_pk primary key(id);
+  add constraint if not exists amr_id_pk primary key(id);
 
 create index if not exists user_id_created_at_idx on {{ index .Options "Namespace" }}.sessions (user_id, created_at);
 create index if not exists factor_id_created_at_idx on {{ index .Options "Namespace" }}.mfa_factors (user_id, created_at);

--- a/migrations/20221011041400_add_mfa_indexes.up.sql
+++ b/migrations/20221011041400_add_mfa_indexes.up.sql
@@ -1,27 +1,27 @@
-create index if not exists refresh_token_session_id on {{ index .Options "Namespace" }}.refresh_tokens using btree(session_id);
-
 -- Taken from: https://stackoverflow.com/questions/6801919/postgres-add-constraint-if-it-doesnt-already-exist
-create or replace function create_constraint_if_not_exists (
-    t_name text, c_name text, constraint_sql text
+create or replace function create_auth_constraint_if_not_exists (
+    c_name text, constraint_sql text
 )
 returns void AS
 $$
 begin
-    -- Look for our constraint
-    if not exists (select constraint_name
-                   from information_schema.constraint_column_usage
-                   where table_name = t_name  and constraint_name = c_name) then
+    -- Modify only auth constraint
+    if not exists ( select constraint_name
+                from    information_schema.check_constraints
+                where   constraint_schema = 'auth'
+                  and   constraint_name = c_name
+              )
+    then
         execute constraint_sql;
     end if;
 end;
-
-$$ language 'plpgsql'
+$$
+language 'plpgsql';
 
 alter table {{ index .Options "Namespace" }}.mfa_amr_claims
   add column if not exists id uuid not null;
 
-select create_constraint_if_not_exists("auth.mfa_amr_claims", "amr_id_pk", "alter table auth.mfa_amr_claims add constraint amr_id_pk primary key(id)");
-alter table {{ index .Options "Namespace" }}.mfa_amr_claims add constraint if not exists amr_id_pk primary key(id);
+select create_auth_constraint_if_not_exists('amr_id_pk', 'alter table auth.mfa_amr_claims add constraint amr_id_pk primary key(id)');
 
 create index if not exists user_id_created_at_idx on {{ index .Options "Namespace" }}.sessions (user_id, created_at);
 create index if not exists factor_id_created_at_idx on {{ index .Options "Namespace" }}.mfa_factors (user_id, created_at);

--- a/migrations/20221011041400_add_mfa_indexes.up.sql
+++ b/migrations/20221011041400_add_mfa_indexes.up.sql
@@ -1,27 +1,18 @@
--- Taken from: https://stackoverflow.com/questions/6801919/postgres-add-constraint-if-it-doesnt-already-exist
-create or replace function create_auth_constraint_if_not_exists (
-    c_name text, constraint_sql text
-)
-returns void AS
-$$
-begin
-    -- Modify only auth constraint
-    if not exists ( select constraint_name
-                from    information_schema.check_constraints
-                where   constraint_schema = 'auth'
-                  and   constraint_name = c_name
-              )
-    then
-        execute constraint_sql;
-    end if;
-end;
-$$
-language 'plpgsql';
-
 alter table {{ index .Options "Namespace" }}.mfa_amr_claims
   add column if not exists id uuid not null;
 
-select create_auth_constraint_if_not_exists('amr_id_pk', 'alter table auth.mfa_amr_claims add constraint amr_id_pk primary key(id)');
+do language plpgsql
+$$ declare
+begin
+    if not exists ( select constraint_name
+                from    information_schema.check_constraints
+                where   constraint_schema = '{{ index .Options "Namespace" }}'
+                  and   constraint_name = 'amr_id_pk'
+              )
+    then
+        execute 'alter table {{ index .Options "Namespace" }}.mfa_amr_claims add constraint amr_id_pk primary key(id)';
+    end if;
+end $$;
 
 create index if not exists user_id_created_at_idx on {{ index .Options "Namespace" }}.sessions (user_id, created_at);
 create index if not exists factor_id_created_at_idx on {{ index .Options "Namespace" }}.mfa_factors (user_id, created_at);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Noticed while doing support that `amr_id_pk` does not need currently check if the index already exists. As such, if the migration is re-run it will lead to an error.

## Additional context

See Internal support ticket