### PR TITLE
feat: add `is_sso_user` column to `users` which allows duplicate emails to exist on those rows

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -269,7 +269,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 			Data:     identityData,
 		}
 
-		user, terr = a.signupNewUser(ctx, tx, params)
+		user, terr = a.signupNewUser(ctx, tx, params, false /* <-duplicateEmail */)
 		if terr != nil {
 			return nil, terr
 		}

--- a/api/invite.go
+++ b/api/invite.go
@@ -54,7 +54,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 				Aud:      aud,
 				Provider: "email",
 			}
-			user, err = a.signupNewUser(ctx, tx, &signupParams)
+			user, err = a.signupNewUser(ctx, tx, &signupParams, false /* <- duplicateEmails */)
 			if err != nil {
 				return err
 			}

--- a/api/mail.go
+++ b/api/mail.go
@@ -113,7 +113,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 					Provider: "email",
 					Aud:      aud,
 				}
-				user, terr = a.signupNewUser(ctx, tx, signupParams)
+				user, terr = a.signupNewUser(ctx, tx, signupParams, false /* <- duplicateEmails */)
 				if terr != nil {
 					return terr
 				}
@@ -158,7 +158,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 					Provider: "email",
 					Aud:      aud,
 				}
-				user, terr = a.signupNewUser(ctx, tx, signupParams)
+				user, terr = a.signupNewUser(ctx, tx, signupParams, false /* <- duplicateEmails */)
 				if terr != nil {
 					return terr
 				}

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -69,6 +69,10 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("invalid body: unable to parse JSON").WithInternalError(err)
 	}
 
+	if user.IsSSOUser {
+		return unprocessableEntityError("MFA enrollment only supported for non-SSO users at this time")
+	}
+
 	factorType := params.FactorType
 	if factorType != models.TOTP {
 		return badRequestError("factor_type needs to be totp")

--- a/api/samlacs.go
+++ b/api/samlacs.go
@@ -242,6 +242,7 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 		var terr error
 		var user *models.User
 
+		// accounts potentially created via SAML can contain non-unique email addresses in the auth.users table
 		if user, terr = a.createAccountFromExternalIdentity(tx, r, &userProvidedData, "sso:"+ssoProvider.ID.String()); terr != nil {
 			return terr
 		}

--- a/api/signup.go
+++ b/api/signup.go
@@ -106,7 +106,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 
 			// do not update the user because we can't be sure of their claimed identity
 		} else {
-			user, terr = a.signupNewUser(ctx, tx, params)
+			user, terr = a.signupNewUser(ctx, tx, params, false /* <- duplicateEmails */)
 			if terr != nil {
 				return terr
 			}
@@ -279,7 +279,7 @@ func sanitizeUser(u *models.User, params *SignupParams) (*models.User, error) {
 	return u, nil
 }
 
-func (a *API) signupNewUser(ctx context.Context, conn *storage.Connection, params *SignupParams) (*models.User, error) {
+func (a *API) signupNewUser(ctx context.Context, conn *storage.Connection, params *SignupParams, isSSOUser bool) (*models.User, error) {
 	config := a.config
 
 	var user *models.User
@@ -293,6 +293,8 @@ func (a *API) signupNewUser(ctx context.Context, conn *storage.Connection, param
 		// handles external provider case
 		user, err = models.NewUser("", params.Email, params.Password, params.Aud, params.Data)
 	}
+
+	user.IsSSOUser = isSSOUser
 
 	if err != nil {
 		return nil, internalServerError("Database error creating user").WithInternalError(err)

--- a/api/token.go
+++ b/api/token.go
@@ -474,7 +474,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 					Data:     claims,
 				}
 
-				user, terr = a.signupNewUser(ctx, tx, signupParams)
+				user, terr = a.signupNewUser(ctx, tx, signupParams, false /* <- duplicateEmails */)
 				if terr != nil {
 					return terr
 				}

--- a/api/user.go
+++ b/api/user.go
@@ -59,6 +59,12 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	log := observability.GetLogEntry(r)
 	log.Debugf("Checking params for token %v", params)
 
+	if user.IsSSOUser {
+		if (params.Password != nil && *params.Password != "") || params.Email != "" || params.Phone != "" || params.Nonce != "" {
+			return unprocessableEntityError("Updating email, phone, password of a SSO account only possible via SSO")
+		}
+	}
+
 	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		if params.Password != nil {

--- a/migrations/20221121110412_modify_users_email_unique_index.up.sql
+++ b/migrations/20221121110412_modify_users_email_unique_index.up.sql
@@ -1,0 +1,16 @@
+-- this change is relatively temporary
+-- it is meant to keep database consistency guarantees until there is proper
+-- introduction of account linking / merging / delinking APIs, at which point
+-- rows in the users table will allow duplicates but with programmatic control
+
+alter table only {{ index .Options "Namespace" }}.users
+  add column if not exists is_sso_user boolean not null default false;
+
+comment on column {{ index .Options "Namespace" }}.users.is_sso_user is 'Auth: Set this column to true when the account comes from SSO. These accounts can have duplicate emails.';
+
+create unique index if not exists users_email_partial_key on {{ index .Options "Namespace" }}.users (email) where (is_sso_user = false);
+
+comment on index {{ index .Options "Namespace" }}.users_email_key is 'Auth: A partial unique index that applies only when is_sso_user is false';
+
+alter table only {{ index .Options "Namespace" }}.users
+  drop constraint if exists users_email_key;

--- a/models/user.go
+++ b/models/user.go
@@ -17,12 +17,14 @@ import (
 type User struct {
 	ID uuid.UUID `json:"id" db:"id"`
 
-	Aud               string             `json:"aud" db:"aud"`
-	Role              string             `json:"role" db:"role"`
-	Email             storage.NullString `json:"email" db:"email"`
-	EncryptedPassword string             `json:"-" db:"encrypted_password"`
-	EmailConfirmedAt  *time.Time         `json:"email_confirmed_at,omitempty" db:"email_confirmed_at"`
-	InvitedAt         *time.Time         `json:"invited_at,omitempty" db:"invited_at"`
+	Aud       string             `json:"aud" db:"aud"`
+	Role      string             `json:"role" db:"role"`
+	Email     storage.NullString `json:"email" db:"email"`
+	IsSSOUser bool               `json:"-" db:"is_sso_user"`
+
+	EncryptedPassword string     `json:"-" db:"encrypted_password"`
+	EmailConfirmedAt  *time.Time `json:"email_confirmed_at,omitempty" db:"email_confirmed_at"`
+	InvitedAt         *time.Time `json:"invited_at,omitempty" db:"invited_at"`
 
 	Phone            storage.NullString `json:"phone" db:"phone"`
 	PhoneConfirmedAt *time.Time         `json:"phone_confirmed_at,omitempty" db:"phone_confirmed_at"`
@@ -377,7 +379,7 @@ func findUser(tx *storage.Connection, query string, args ...interface{}) (*User,
 
 // FindUserByConfirmationToken finds users with the matching confirmation token.
 func FindUserByConfirmationToken(tx *storage.Connection, token string) (*User, error) {
-	user, err := findUser(tx, "confirmation_token = ?", token)
+	user, err := findUser(tx, "confirmation_token = ? and is_sso_user = false", token)
 	if err != nil {
 		return nil, ConfirmationTokenNotFoundError{}
 	}
@@ -386,12 +388,12 @@ func FindUserByConfirmationToken(tx *storage.Connection, token string) (*User, e
 
 // FindUserByEmailAndAudience finds a user with the matching email and audience.
 func FindUserByEmailAndAudience(tx *storage.Connection, email, aud string) (*User, error) {
-	return findUser(tx, "instance_id = ? and LOWER(email) = ? and aud = ?", uuid.Nil, strings.ToLower(email), aud)
+	return findUser(tx, "instance_id = ? and LOWER(email) = ? and aud = ? and is_sso_user = false", uuid.Nil, strings.ToLower(email), aud)
 }
 
 // FindUserByPhoneAndAudience finds a user with the matching email and audience.
 func FindUserByPhoneAndAudience(tx *storage.Connection, phone, aud string) (*User, error) {
-	return findUser(tx, "instance_id = ? and phone = ? and aud = ?", uuid.Nil, phone, aud)
+	return findUser(tx, "instance_id = ? and phone = ? and aud = ? and is_sso_user = false", uuid.Nil, phone, aud)
 }
 
 // FindUserByID finds a user matching the provided ID.
@@ -401,12 +403,12 @@ func FindUserByID(tx *storage.Connection, id uuid.UUID) (*User, error) {
 
 // FindUserByRecoveryToken finds a user with the matching recovery token.
 func FindUserByRecoveryToken(tx *storage.Connection, token string) (*User, error) {
-	return findUser(tx, "recovery_token = ?", token)
+	return findUser(tx, "recovery_token = ? and is_sso_user = false", token)
 }
 
 // FindUserByEmailChangeToken finds a user with the matching email change token.
 func FindUserByEmailChangeToken(tx *storage.Connection, token string) (*User, error) {
-	return findUser(tx, "email_change_token_current = ? or email_change_token_new = ?", token, token)
+	return findUser(tx, "is_sso_user = false and (email_change_token_current = ? or email_change_token_new = ?)", token, token)
 }
 
 // FindUserWithRefreshToken finds a user from the provided refresh token.
@@ -476,7 +478,7 @@ func FindUsersInAudience(tx *storage.Connection, aud string, pageParams *Paginat
 func FindUserByEmailChangeCurrentAndAudience(tx *storage.Connection, email, token, aud string) (*User, error) {
 	return findUser(
 		tx,
-		"instance_id = ? and LOWER(email) = ? and email_change_token_current = ? and aud = ?",
+		"instance_id = ? and LOWER(email) = ? and email_change_token_current = ? and aud = ? and is_sso_user = false",
 		uuid.Nil, strings.ToLower(email), token, aud,
 	)
 }
@@ -485,7 +487,7 @@ func FindUserByEmailChangeCurrentAndAudience(tx *storage.Connection, email, toke
 func FindUserByEmailChangeNewAndAudience(tx *storage.Connection, email, token, aud string) (*User, error) {
 	return findUser(
 		tx,
-		"instance_id = ? and LOWER(email_change) = ? and email_change_token_new = ? and aud = ?",
+		"instance_id = ? and LOWER(email_change) = ? and email_change_token_new = ? and aud = ? and is_sso_user = false",
 		uuid.Nil, strings.ToLower(email), token, aud,
 	)
 }
@@ -504,7 +506,7 @@ func FindUserForEmailChange(tx *storage.Connection, email, token, aud string, se
 
 // FindUserByPhoneChangeAndAudience finds a user with the matching phone change and audience.
 func FindUserByPhoneChangeAndAudience(tx *storage.Connection, phone, aud string) (*User, error) {
-	return findUser(tx, "instance_id = ? and phone_change = ? and aud = ?", uuid.Nil, phone, aud)
+	return findUser(tx, "instance_id = ? and phone_change = ? and aud = ? and is_sso_user = false", uuid.Nil, phone, aud)
 }
 
 // IsDuplicatedEmail returns whether a user exists with a matching email and audience.


### PR DESCRIPTION
Adds a new `duplicated_emails` boolean column on `auth.users`. This column in combination with a partial unique index will allow rows in the table to contain duplicate emails.

This is a somewhat temporary measure that ensures database consistency until full programmatic support is available for account merging / linking / delinking through APIs and hooks. 

Cases such as SAML, which do not obey the email-similarity account linking rule, may create distinct user accounts that may have the same email address. In fact, this is the only time the `duplicated_emails` column is set to `true`.