### PR TITLE
feat: use account linking algorithm

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -275,9 +275,9 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		if exists, err := models.IsDuplicatedEmail(db, params.Email, aud); err != nil {
+		if user, err := models.IsDuplicatedEmail(db, params.Email, aud); err != nil {
 			return internalServerError("Database error checking email").WithInternalError(err)
-		} else if exists {
+		} else if user != nil {
 			return unprocessableEntityError("Email address already registered by another user")
 		}
 	}

--- a/api/external_test.go
+++ b/api/external_test.go
@@ -52,6 +52,13 @@ func (ts *ExternalTestSuite) createUser(providerId string, email string, name st
 	ts.Require().NoError(err, "Error making new user")
 	ts.Require().NoError(ts.API.db.Create(u), "Error creating user")
 
+	i, err := models.NewIdentity(u, "email", map[string]interface{}{
+		"sub":   u.ID.String(),
+		"email": email,
+	})
+	ts.Require().NoError(err)
+	ts.Require().NoError(ts.API.db.Create(i), "Error creating identity")
+
 	return u, err
 }
 

--- a/api/mail.go
+++ b/api/mail.go
@@ -182,9 +182,9 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return unprocessableEntityError("The new email address provided is invalid")
 			}
-			if exists, terr := models.IsDuplicatedEmail(tx, params.NewEmail, user.Aud); terr != nil {
+			if duplicateUser, terr := models.IsDuplicatedEmail(tx, params.NewEmail, user.Aud); terr != nil {
 				return internalServerError("Database error checking email").WithInternalError(terr)
-			} else if exists {
+			} else if duplicateUser != nil {
 				return unprocessableEntityError(DuplicateEmailMsg)
 			}
 			now := time.Now()

--- a/api/samlacs.go
+++ b/api/samlacs.go
@@ -242,7 +242,7 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 		var terr error
 		var user *models.User
 
-		if user, terr = a.createAccountFromExternalIdentity(tx, r, &userProvidedData, "sso:"+ssoProvider.ID.String(), user); terr != nil {
+		if user, terr = a.createAccountFromExternalIdentity(tx, r, &userProvidedData, "sso:"+ssoProvider.ID.String()); terr != nil {
 			return terr
 		}
 

--- a/api/signup.go
+++ b/api/signup.go
@@ -79,7 +79,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		user, err = models.FindUserByEmailAndAudience(db, params.Email, params.Aud)
+		user, err = models.IsDuplicatedEmail(db, params.Email, params.Aud)
 	case "phone":
 		if !config.External.Phone.Enabled {
 			return badRequestError("Phone signups are disabled")

--- a/api/user.go
+++ b/api/user.go
@@ -123,10 +123,10 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 
-			var exists bool
-			if exists, terr = models.IsDuplicatedEmail(tx, params.Email, user.Aud); terr != nil {
+			var duplicateUser *models.User
+			if duplicateUser, terr = models.IsDuplicatedEmail(tx, params.Email, user.Aud); terr != nil {
 				return internalServerError("Database error checking email").WithInternalError(terr)
-			} else if exists {
+			} else if duplicateUser != nil {
 				return unprocessableEntityError(DuplicateEmailMsg)
 			}
 

--- a/cmd/admin_cmd.go
+++ b/cmd/admin_cmd.go
@@ -73,7 +73,7 @@ func adminCreateUser(config *conf.GlobalConfiguration, args []string) {
 	defer db.Close()
 
 	aud := getAudience(config)
-	if exists, err := models.IsDuplicatedEmail(db, args[0], aud); exists {
+	if user, err := models.IsDuplicatedEmail(db, args[0], aud); user != nil {
 		logrus.Fatalf("Error creating new user: user already exists")
 	} else if err != nil {
 		logrus.Fatalf("Error checking user email: %+v", err)

--- a/migrations/20221120114718_add_identities_email_column.up.sql
+++ b/migrations/20221120114718_add_identities_email_column.up.sql
@@ -1,0 +1,15 @@
+update
+  {{ index .Options "Namespace" }}.identities as identities
+set
+  identity_data = identity_data || jsonb_build_object('email', (select email from {{ index .Options "Namespace" }}.users where id = identities.user_id)),
+  updated_at = now()
+where identities.provider = 'email' and identity_data->>'email' is null;
+
+alter table only {{ index .Options "Namespace" }}.identities
+  add column if not exists email text generated always as (lower(identity_data->>'email')) stored;
+
+comment on column {{ index .Options "Namespace" }}.identities.email is 'Auth: Email is a generated column that references the optional email property in the identity_data';
+
+create index if not exists identities_email_idx on {{ index .Options "Namespace" }}.identities (email text_pattern_ops);
+
+comment on index {{ index .Options "Namespace" }}.identities_email_idx is 'Auth: Ensures indexed queries on the email column';

--- a/migrations/20221124140122_add_identities_email_column.up.sql
+++ b/migrations/20221124140122_add_identities_email_column.up.sql
@@ -1,0 +1,15 @@
+update
+  {{ index .Options "Namespace" }}.identities as identities
+set
+  identity_data = identity_data || jsonb_build_object('email', (select email from {{ index .Options "Namespace" }}.users where id = identities.user_id)),
+  updated_at = '2022-11-24'
+where identities.provider = 'email' and identity_data->>'email' is null;
+
+alter table only {{ index .Options "Namespace" }}.identities
+  add column if not exists email text generated always as (lower(identity_data->>'email')) stored;
+
+comment on column {{ index .Options "Namespace" }}.identities.email is 'Auth: Email is a generated column that references the optional email property in the identity_data';
+
+create index if not exists identities_email_idx on {{ index .Options "Namespace" }}.identities (email text_pattern_ops);
+
+comment on index {{ index .Options "Namespace" }}.identities_email_idx is 'Auth: Ensures indexed queries on the email column';

--- a/models/identity.go
+++ b/models/identity.go
@@ -56,6 +56,10 @@ func (i *Identity) BeforeUpdate(tx *pop.Connection) error {
 	return nil
 }
 
+func (i *Identity) IsForSSOProvider() bool {
+	return strings.HasPrefix(i.Provider, "sso:")
+}
+
 // FindIdentityById searches for an identity with the matching provider_id and provider given.
 func FindIdentityByIdAndProvider(tx *storage.Connection, providerId, provider string) (*Identity, error) {
 	identity := &Identity{}

--- a/models/linking.go
+++ b/models/linking.go
@@ -1,0 +1,155 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/netlify/gotrue/storage"
+)
+
+// GetAccountLinkingDomain returns a string that describes the account linking
+// domain. An account linking domain describes a set of Identity entities that
+// _should_ generally fall under the same User entity. It's just a runtime
+// string, and is not typically persisted in the database. This value can vary
+// across time.
+func GetAccountLinkingDomain(provider string) string {
+	if strings.HasPrefix(provider, "sso:") {
+		// when the provider ID is a SSO provider, then the linking
+		// domain is the provider itself i.e. there can only be one
+		// user + identity per identity provider
+		return provider
+	}
+
+	// otherwise, the linking domain is the default linking domain that
+	// links all accounts
+	return "default"
+}
+
+type AccountLinkingDecision = int
+
+const (
+	AccountExists AccountLinkingDecision = iota
+	CreateAccount
+	LinkAccount
+	MultipleAccounts
+)
+
+type AccountLinkingResult struct {
+	Decision AccountLinkingDecision
+
+	User       *User
+	Identities []*Identity
+
+	LinkingDomain string
+}
+
+// DetermineAccountLinking uses the provided data and database state to compute a decision on whether:
+// - A new User should be created (CreateAccount)
+// - A new Identity should be created (LinkAccount) with a UserID pointing to an existing user account
+// - Nothing should be done (AccountExists)
+// - It's not possible to decide due to data inconsistency (MultipleAccounts) and the caller should decide
+//
+// Errors signal failure in processing only, like database access errors.
+func DetermineAccountLinking(tx *storage.Connection, provider, sub string, emails []string) (AccountLinkingResult, error) {
+	if identity, terr := FindIdentityByIdAndProvider(tx, sub, provider); terr == nil {
+		// account exists
+
+		var user *User
+		if user, terr = FindUserByID(tx, identity.UserID); terr != nil {
+			return AccountLinkingResult{}, terr
+		}
+
+		return AccountLinkingResult{
+			Decision:      AccountExists,
+			User:          user,
+			Identities:    []*Identity{identity},
+			LinkingDomain: GetAccountLinkingDomain(provider),
+		}, nil
+	} else if !IsNotFoundError(terr) {
+		return AccountLinkingResult{}, terr
+	}
+
+	// account does not exist, identity and user not immediately
+	// identifiable, look for similar identities based on email
+	var similarIdentities []*Identity
+
+	if len(emails) > 0 {
+		if terr := tx.Q().Eager().Where("email in (?)", emails).All(&similarIdentities); terr != nil {
+			return AccountLinkingResult{}, terr
+		}
+	}
+
+	fmt.Printf("similar identities %v\n", similarIdentities)
+
+	// TODO: determine linking behavior over phone too
+
+	if len(similarIdentities) == 0 {
+		// there are no similar identities, clearly we have to create a new account
+
+		return AccountLinkingResult{
+			Decision:      CreateAccount,
+			LinkingDomain: GetAccountLinkingDomain(provider),
+		}, nil
+	}
+
+	// there are some similar identities, we now need to proceed in
+	// identifying whether this supposed new identity should be assigned to
+	// an existing user or to create a new user, according to the automatic
+	// linking rules
+
+	// this is the linking domain for the new identity
+	newAccountLinkingDomain := GetAccountLinkingDomain(provider)
+
+	var linkingIdentities []*Identity
+
+	// now let's see if there are any existing and similar identities in
+	// the same linking domain
+	for _, identity := range similarIdentities {
+		if GetAccountLinkingDomain(identity.Provider) == newAccountLinkingDomain {
+			linkingIdentities = append(linkingIdentities, identity)
+		}
+	}
+
+	if len(linkingIdentities) == 0 {
+		// there are no identities in the linking domain, we have to
+		// create a new identity and new user
+		return AccountLinkingResult{
+			Decision:      CreateAccount,
+			LinkingDomain: newAccountLinkingDomain,
+		}, nil
+	}
+
+	// there is at least one identity in the linking domain let's do a
+	// sanity check to see if all of the identities in the domain share the
+	// same user ID
+
+	for _, identity := range linkingIdentities {
+		if identity.UserID != linkingIdentities[0].UserID {
+			// ok this linking domain has more than one user account
+			// caller should decide what to do
+
+			return AccountLinkingResult{
+				Decision:      MultipleAccounts,
+				Identities:    linkingIdentities,
+				LinkingDomain: newAccountLinkingDomain,
+			}, nil
+		}
+	}
+
+	// there's only one user ID in this linking domain, we can go on and
+	// create a new identity and link it to the existing account
+
+	var user *User
+	var terr error
+
+	if user, terr = FindUserByID(tx, linkingIdentities[0].UserID); terr != nil {
+		return AccountLinkingResult{}, terr
+	}
+
+	return AccountLinkingResult{
+		Decision:      LinkAccount,
+		User:          user,
+		Identities:    linkingIdentities,
+		LinkingDomain: newAccountLinkingDomain,
+	}, nil
+}

--- a/models/linking_test.go
+++ b/models/linking_test.go
@@ -1,0 +1,180 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/netlify/gotrue/conf"
+	"github.com/netlify/gotrue/storage"
+	"github.com/netlify/gotrue/storage/test"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type AccountLinkingTestSuite struct {
+	suite.Suite
+
+	db *storage.Connection
+}
+
+func (ts *AccountLinkingTestSuite) SetupTest() {
+	TruncateAll(ts.db)
+}
+
+func TestAccountLinking(t *testing.T) {
+	globalConfig, err := conf.LoadGlobal(modelsTestConfig)
+	require.NoError(t, err)
+
+	conn, err := test.SetupDBConnection(globalConfig)
+	require.NoError(t, err)
+
+	ts := &AccountLinkingTestSuite{
+		db: conn,
+	}
+	defer ts.db.Close()
+
+	suite.Run(t, ts)
+}
+
+func (ts *AccountLinkingTestSuite) TestCreateAccountDecisionNoAccounts() {
+	// when there are no accounts in the system -- conventional provider
+	decision, err := DetermineAccountLinking(ts.db, "provider", "abcdefgh", []string{"test@example.com"})
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), decision.Decision, CreateAccount)
+
+	// when there are no accounts in the system -- SSO provider
+	decision, err = DetermineAccountLinking(ts.db, "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387", "abcdefgh", []string{"test@example.com"})
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), decision.Decision, CreateAccount)
+}
+
+func (ts *AccountLinkingTestSuite) TestCreateAccountDecisionWithAccounts() {
+	userA, err := NewUser("", "test@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+	identityA, err := NewIdentity(userA, "provider", map[string]interface{}{
+		"sub":   userA.ID.String(),
+		"email": "test@example.com",
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identityA))
+
+	userB, err := NewUser("", "test@samltest.id", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userB))
+
+	identityB, err := NewIdentity(userB, "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387", map[string]interface{}{
+		"sub":   userB.ID.String(),
+		"email": "test@samltest.id",
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identityB))
+
+	// when there are no accounts in the system -- conventional provider
+	decision, err := DetermineAccountLinking(ts.db, "provider", "abcdefgh", []string{"other@example.com"})
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), decision.Decision, CreateAccount)
+
+	// when looking for an email that doesn't exist in the SSO linking domain
+	decision, err = DetermineAccountLinking(ts.db, "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387", "abcdefgh", []string{"other@samltest.id"})
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), decision.Decision, CreateAccount)
+
+	// when looking for an email that doesn't exist at all
+	decision, err = DetermineAccountLinking(ts.db, "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387", "abcdefgh", []string{"other@samltest.id"})
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), decision.Decision, CreateAccount)
+
+	// when looking for an email that doesn't exist in the SSO linking domain
+	decision, err = DetermineAccountLinking(ts.db, "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387", "abcdefgh", []string{"text@example.com"})
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), decision.Decision, CreateAccount)
+}
+
+func (ts *AccountLinkingTestSuite) TestAccountExists() {
+	userA, err := NewUser("", "test@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+	identityA, err := NewIdentity(userA, "provider", map[string]interface{}{
+		"sub":   userA.ID.String(),
+		"email": "test@example.com",
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identityA))
+
+	decision, err := DetermineAccountLinking(ts.db, "provider", userA.ID.String(), []string{"test@example.com"})
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), decision.Decision, AccountExists)
+	require.Equal(ts.T(), decision.User.ID, userA.ID)
+}
+
+func (ts *AccountLinkingTestSuite) TestLinkAccountExists() {
+	userA, err := NewUser("", "test@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+	identityA, err := NewIdentity(userA, "provider", map[string]interface{}{
+		"sub":   userA.ID.String(),
+		"email": "test@example.com",
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identityA))
+
+	// link decision because the below described identity is in the default linking domain but uses "other-provider" instead of "provder"
+	decision, err := DetermineAccountLinking(ts.db, "other-provider", userA.ID.String(), []string{"test@example.com"})
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), decision.Decision, LinkAccount)
+
+	userB, err := NewUser("", "test@samltest.id", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userB))
+
+	identityB, err := NewIdentity(userB, "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387", map[string]interface{}{
+		"sub":   userB.ID.String(),
+		"email": "test@samltest.id",
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identityB))
+
+	// no link decision because the SSO linking domain is scoped to the provider unique ID
+	decision, err = DetermineAccountLinking(ts.db, "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387", userB.ID.String(), []string{"test@samltest.id"})
+	require.NoError(ts.T(), err)
+
+	require.NotEqual(ts.T(), decision.Decision, LinkAccount)
+}
+
+func (ts *AccountLinkingTestSuite) TestMultipleAccounts() {
+	userA, err := NewUser("", "test@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userA))
+	identityA, err := NewIdentity(userA, "provider", map[string]interface{}{
+		"sub":   userA.ID.String(),
+		"email": "test@example.com",
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identityA))
+
+	userB, err := NewUser("", "test-b@example.com", "", "authenticated", nil)
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(userB))
+	identityB, err := NewIdentity(userB, "provider", map[string]interface{}{
+		"sub":   userB.ID.String(),
+		"email": "test@example.com", // intentionally same as userA
+	})
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identityB))
+
+	// decision is multiple accounts because there are two distinct
+	// identities in the same "default" linking domain with the same email
+	// address pointing to two different user accounts
+	decision, err := DetermineAccountLinking(ts.db, "provider", "abcdefgh", []string{"test@example.com"})
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), decision.Decision, MultipleAccounts)
+}

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -164,19 +164,19 @@ func (ts *UserTestSuite) TestIsDuplicatedEmail() {
 
 	e, err := IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "test")
 	require.NoError(ts.T(), err)
-	require.True(ts.T(), e, "expected email to be duplicated")
+	require.NotNil(ts.T(), e, "expected email to be duplicated")
 
 	e, err = IsDuplicatedEmail(ts.db, "davidcalavera@netlify.com", "test")
 	require.NoError(ts.T(), err)
-	require.False(ts.T(), e, "expected email to not be duplicated")
+	require.Nil(ts.T(), e, "expected email to not be duplicated")
 
 	e, err = IsDuplicatedEmail(ts.db, "david@netlify.com", "test")
 	require.NoError(ts.T(), err)
-	require.False(ts.T(), e, "expected same email to not be duplicated")
+	require.Nil(ts.T(), e, "expected same email to not be duplicated")
 
 	e, err = IsDuplicatedEmail(ts.db, "david.calavera@netlify.com", "other-aud")
 	require.NoError(ts.T(), err)
-	require.False(ts.T(), e, "expected same email to not be duplicated")
+	require.Nil(ts.T(), e, "expected same email to not be duplicated")
 }
 
 func (ts *UserTestSuite) createUser() *User {
@@ -186,9 +186,14 @@ func (ts *UserTestSuite) createUser() *User {
 func (ts *UserTestSuite) createUserWithEmail(email string) *User {
 	user, err := NewUser("", email, "secret", "test", nil)
 	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(user))
 
-	err = ts.db.Create(user)
+	identity, err := NewIdentity(user, "email", map[string]interface{}{
+		"sub":   user.ID.String(),
+		"email": email,
+	})
 	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), ts.db.Create(identity))
 
 	return user
 }


### PR DESCRIPTION
Uses the account linking algorithm described in #792 for linking accounts via external identities. This change produces equivalent results as the previous algorithm, while also supporting the SSO case.

(Depends on #826.)