### PR TITLE
feat: add `provider_id` JWT claim containing the originating provider of the session

### DIFF
--- a/api/audit_test.go
+++ b/api/audit_test.go
@@ -49,7 +49,7 @@ func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
 	u.Role = "supabase_admin"
 
 	var token string
-	token, err = generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+	token, err = generateAccessToken(ts.API.db, u, nil, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}

--- a/api/external.go
+++ b/api/external.go
@@ -147,6 +147,8 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 		providerRefreshToken = oAuthResponseData.refreshToken
 	}
 
+	grantParams.ProviderID = &providerType
+
 	var user *models.User
 	var token *AccessTokenResponse
 	err := db.Transaction(func(tx *storage.Connection) error {

--- a/api/samlacs.go
+++ b/api/samlacs.go
@@ -232,6 +232,9 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 
 	var grantParams models.GrantParams
 
+	providerID := "sso:" + ssoProvider.ID.String()
+	grantParams.ProviderID = &providerID
+
 	if !notAfter.IsZero() {
 		grantParams.SessionNotAfter = &notAfter
 	}

--- a/api/signup.go
+++ b/api/signup.go
@@ -70,6 +70,8 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	var grantParams models.GrantParams
 	params.Aud = a.requestAud(ctx, r)
 
+	grantParams.ProviderID = &params.Provider
+
 	switch params.Provider {
 	case "email":
 		if !config.External.Email.Enabled {

--- a/migrations/20221129150322_add_provider_id_to_session.up.sql
+++ b/migrations/20221129150322_add_provider_id_to_session.up.sql
@@ -1,0 +1,4 @@
+alter table only {{ index .Options "Namespace" }}.sessions
+  add column if not exists provider_id text default null;
+
+comment on column {{ index .Options "Namespace" }}.sessions.provider_id is 'Auth: ID of the provider on which basis this session was issued. Example: google, apple, facebook, twitter, email, phone, sso:<uuid>, ...';

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -40,6 +40,7 @@ func (RefreshToken) TableName() string {
 type GrantParams struct {
 	FactorID *uuid.UUID
 
+	ProviderID      *string
 	SessionNotAfter *time.Time
 }
 
@@ -140,6 +141,10 @@ func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshTok
 
 		if params.SessionNotAfter != nil {
 			session.NotAfter = params.SessionNotAfter
+		}
+
+		if params.ProviderID != nil {
+			session.ProviderID = params.ProviderID
 		}
 
 		if err := tx.Create(session); err != nil {

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -55,14 +55,15 @@ func (s sortAMREntries) Swap(i, j int) {
 }
 
 type Session struct {
-	ID        uuid.UUID  `json:"-" db:"id"`
-	UserID    uuid.UUID  `json:"user_id" db:"user_id"`
-	NotAfter  *time.Time `json:"not_after,omitempty" db:"not_after"`
-	CreatedAt time.Time  `json:"created_at" db:"created_at"`
-	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
-	FactorID  *uuid.UUID `json:"factor_id" db:"factor_id"`
-	AMRClaims []AMRClaim `json:"amr,omitempty" has_many:"amr_claims"`
-	AAL       *string    `json:"aal" db:"aal"`
+	ID         uuid.UUID  `json:"-" db:"id"`
+	UserID     uuid.UUID  `json:"user_id" db:"user_id"`
+	NotAfter   *time.Time `json:"not_after,omitempty" db:"not_after"`
+	CreatedAt  time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at" db:"updated_at"`
+	FactorID   *uuid.UUID `json:"factor_id" db:"factor_id"`
+	AMRClaims  []AMRClaim `json:"amr,omitempty" has_many:"amr_claims"`
+	AAL        *string    `json:"aal" db:"aal"`
+	ProviderID *string    `json:"provider_id" db:"provider_id"`
 }
 
 func (Session) TableName() string {


### PR DESCRIPTION
JWTs issued by GoTrue will now contain a `provider_id` claim containing the ID of the provider that originated the session. Example IDs: 

- `google` for sessions issued via Sign in with Google
- `apple` for sessions issued via Sign in with Apple
- `email` for sessions issued based off of email (OTP, password, magic link)
- `phone` for sessions issued based off of phone (SMS or password)
- `sso:4b7fd660-afa8-4035-84a3-865ed89470e9` for sessions issued off an SSO provider, the UUID being the `sso_providers.id` column