### PR TITLE
feat: add `provider` claim to `amr` when the method is `sso/saml`

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -571,7 +571,10 @@ func generateAccessToken(tx *storage.Connection, user *models.User, sessionId *u
 		if terr != nil {
 			return "", terr
 		}
-		aal, amr = session.CalculateAALAndAMR()
+		aal, amr, terr = session.CalculateAALAndAMR(tx)
+		if terr != nil {
+			return "", terr
+		}
 	}
 
 	claims := &GoTrueClaims{
@@ -672,7 +675,11 @@ func (a *API) updateMFASessionAndClaims(r *http.Request, tx *storage.Connection,
 		if terr != nil {
 			return terr
 		}
-		aal, _ := session.CalculateAALAndAMR()
+		aal, _, terr := session.CalculateAALAndAMR(tx)
+		if terr != nil {
+			return terr
+		}
+
 		if err := session.UpdateAssociatedFactor(tx, grantParams.FactorID); err != nil {
 			return err
 		}

--- a/models/identity.go
+++ b/models/identity.go
@@ -72,10 +72,10 @@ func FindIdentityByIdAndProvider(tx *storage.Connection, providerId, provider st
 	return identity, nil
 }
 
-// FindIdentitiesByUser returns all identities associated to a user
-func FindIdentitiesByUser(tx *storage.Connection, user *User) ([]*Identity, error) {
+// FindIdentitiesByUserID returns all identities associated to a user ID.
+func FindIdentitiesByUserID(tx *storage.Connection, userID uuid.UUID) ([]*Identity, error) {
 	identities := []*Identity{}
-	if err := tx.Q().Where("user_id = ?", user.ID).All(&identities); err != nil {
+	if err := tx.Q().Where("user_id = ?", userID).All(&identities); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return identities, nil
 		}

--- a/models/identity_test.go
+++ b/models/identity_test.go
@@ -53,7 +53,7 @@ func (ts *IdentityTestSuite) TestNewIdentity() {
 
 func (ts *IdentityTestSuite) TestFindUserIdentities() {
 	u := ts.createUserWithIdentity("test@supabase.io")
-	identities, err := FindIdentitiesByUser(ts.db, u)
+	identities, err := FindIdentitiesByUserID(ts.db, u.ID)
 	require.NoError(ts.T(), err)
 
 	require.Len(ts.T(), identities, 1)

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -57,7 +57,8 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	session, err = FindSessionByID(ts.db, session.ID)
 	require.NoError(ts.T(), err)
 
-	aal, amr := session.CalculateAALAndAMR()
+	aal, amr, err := session.CalculateAALAndAMR(ts.db)
+	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), AAL2.String(), aal)
 	require.Equal(ts.T(), totalDistinctClaims, len(amr))
 
@@ -67,7 +68,8 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	session, err = FindSessionByID(ts.db, session.ID)
 	require.NoError(ts.T(), err)
 
-	aal, amr = session.CalculateAALAndAMR()
+	aal, amr, err = session.CalculateAALAndAMR(ts.db)
+	require.NoError(ts.T(), err)
 
 	require.Equal(ts.T(), AAL2.String(), aal)
 	require.Equal(ts.T(), totalDistinctClaims, len(amr))


### PR DESCRIPTION
When the authentication method reference ends with (i.e. the initial authentication method is) `sso/saml`, an additional sub-claim `provider` is added that contains the UUID of the SSO provider that originated the authentication. This is extracted from the single row under the `identities` table.