### PR TITLE
fix(saml): always request persistent NameID in authn requests

### DIFF
--- a/api/saml.go
+++ b/api/saml.go
@@ -35,6 +35,8 @@ func (a *API) getSAMLServiceProvider(identityProvider *saml.EntityDescriptor, id
 		IDPMetadata:       identityProvider,
 	})
 
+	provider.AuthnNameIDFormat = saml.PersistentNameIDFormat
+
 	return &provider
 }
 


### PR DESCRIPTION
GSuite obeys the authentication request NameID instead of the configured one. Example request from GoTrue:

```xml
<samlp:AuthnRequest
  xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
  xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
  ID="id-cf0bf40db81ac47473667730e20ae70bc87fccc1"
  Version="2.0" IssueInstant="2022-11-30T19:27:37.755Z"
  Destination="https://accounts.google.com/o/saml2/idp?idpid=CXXXXXXXXXX"
  AssertionConsumerServiceURL="https://alt.supabase.green/auth/v1/sso/saml/acs"
  ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
  <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">
    https://alt.supabase.green/auth/v1/sso/saml/metadata
  </saml:Issuer>
  <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" AllowCreate="true"/>
</samlp:AuthnRequest>
``` 

With this change the request will explicitly ask for a persistent NameID (persistent user ID at the identity provider).