### PR TITLE
fix(saml): saml user accounts not being set as `is_sso_user`

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -269,7 +269,9 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 			Data:     identityData,
 		}
 
-		user, terr = a.signupNewUser(ctx, tx, params, false /* <-duplicateEmail */)
+		isSSOUser := strings.HasPrefix(providerType, "sso:")
+
+		user, terr = a.signupNewUser(ctx, tx, params, isSSOUser)
 		if terr != nil {
 			return nil, terr
 		}

--- a/api/invite.go
+++ b/api/invite.go
@@ -54,7 +54,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 				Aud:      aud,
 				Provider: "email",
 			}
-			user, err = a.signupNewUser(ctx, tx, &signupParams, false /* <- duplicateEmails */)
+			user, err = a.signupNewUser(ctx, tx, &signupParams, false /* <- isSSOUser */)
 			if err != nil {
 				return err
 			}

--- a/api/mail.go
+++ b/api/mail.go
@@ -113,7 +113,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 					Provider: "email",
 					Aud:      aud,
 				}
-				user, terr = a.signupNewUser(ctx, tx, signupParams, false /* <- duplicateEmails */)
+				user, terr = a.signupNewUser(ctx, tx, signupParams, false /* <- isSSOUser */)
 				if terr != nil {
 					return terr
 				}
@@ -158,7 +158,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 					Provider: "email",
 					Aud:      aud,
 				}
-				user, terr = a.signupNewUser(ctx, tx, signupParams, false /* <- duplicateEmails */)
+				user, terr = a.signupNewUser(ctx, tx, signupParams, false /* <- isSSOUser */)
 				if terr != nil {
 					return terr
 				}

--- a/api/signup.go
+++ b/api/signup.go
@@ -106,7 +106,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 
 			// do not update the user because we can't be sure of their claimed identity
 		} else {
-			user, terr = a.signupNewUser(ctx, tx, params, false /* <- duplicateEmails */)
+			user, terr = a.signupNewUser(ctx, tx, params, false /* <- isSSOUser */)
 			if terr != nil {
 				return terr
 			}

--- a/api/token.go
+++ b/api/token.go
@@ -474,7 +474,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 					Data:     claims,
 				}
 
-				user, terr = a.signupNewUser(ctx, tx, signupParams, false /* <- duplicateEmails */)
+				user, terr = a.signupNewUser(ctx, tx, signupParams, false /* <- isSSOUser */)
 				if terr != nil {
 					return terr
 				}


### PR DESCRIPTION
Due to a merge conflict in the previous PRs, SAML accounts were not assigned `is_sso_user` correctly.