### PR TITLE
chore: bump mirror action version

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -25,7 +25,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: akhilerm/tag-push-action@v2.0.0
+      - uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: docker.io/supabase/gotrue:${{ inputs.version }}
           dst: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

followup #844 

## What is the current behavior?

nodejs 12 outdated warning https://github.com/supabase/gotrue/actions/runs/3599385295

## Additional context

Add any other context or screenshots.
