### PR TITLE
fix: linkedin provider issue with missing avatar url

### DIFF
--- a/api/external_linkedin_test.go
+++ b/api/external_linkedin_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	linkedinUser       string = `{"id":"linkedinTestId","firstName":{"localized":{"en_US":"Linkedin"},"preferredLocale":{"country":"US","language":"en"}},"lastName":{"localized":{"en_US":"Test"},"preferredLocale":{"country":"US","language":"en"}},"profilePicture":{"displayImage~":{"elements":[{"identifiers":[{"identifier":"http://example.com/avatar"}]}]}}}`
-	linkedinEmail      string = `{"elements": [{"handle": "","handle~": {"emailAddress": "linkedin@example.com"}}]}`
-	linkedinWrongEmail string = `{"elements": [{"handle": "","handle~": {"emailAddress": "other@example.com"}}]}`
+	linkedinUser             string = `{"id":"linkedinTestId","firstName":{"localized":{"en_US":"Linkedin"},"preferredLocale":{"country":"US","language":"en"}},"lastName":{"localized":{"en_US":"Test"},"preferredLocale":{"country":"US","language":"en"}},"profilePicture":{"displayImage~":{"elements":[{"identifiers":[{"identifier":"http://example.com/avatar"}]}]}}}`
+	linkedinUserNoProfilePic string = `{"id":"linkedinTestId","firstName":{"localized":{"en_US":"Linkedin"},"preferredLocale":{"country":"US","language":"en"}},"lastName":{"localized":{"en_US":"Test"},"preferredLocale":{"country":"US","language":"en"}},"profilePicture":{"displayImage~":{"elements":[]}}}`
+	linkedinEmail            string = `{"elements": [{"handle": "","handle~": {"emailAddress": "linkedin@example.com"}}]}`
+	linkedinWrongEmail       string = `{"elements": [{"handle": "","handle~": {"emailAddress": "other@example.com"}}]}`
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalLinkedin() {
@@ -155,4 +156,15 @@ func (ts *ExternalTestSuite) TestInviteTokenExternalLinkedinErrorWhenEmailDoesnt
 	u := performAuthorization(ts, "linkedin", code, "invite_token")
 
 	assertAuthorizationFailure(ts, u, "Invited email does not match emails from external provider", "invalid_request", "")
+}
+
+func (ts *ExternalTestSuite) TestSignupExternalLinkedin_MissingProfilePic() {
+	tokenCount, userCount := 0, 0
+	code := "authcode"
+	server := LinkedinTestSignupSetup(ts, &tokenCount, &userCount, code, linkedinUserNoProfilePic, linkedinEmail)
+	defer server.Close()
+
+	u := performAuthorization(ts, "linkedin", code, "")
+
+	assertAuthorizationSuccess(ts, u, tokenCount, userCount, "linkedin@example.com", "Linkedin Test", "linkedinTestId", "")
 }

--- a/api/provider/linkedin.go
+++ b/api/provider/linkedin.go
@@ -127,17 +127,22 @@ func (g linkedinProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 		})
 	}
 
+	var avatarURL string
+	if len(u.AvatarURL.DisplayImage.Elements) > 0 {
+		avatarURL = u.AvatarURL.DisplayImage.Elements[0].Identifiers[0].Identifier
+	}
+
 	return &UserProvidedData{
 		Metadata: &Claims{
 			Issuer:        g.APIPath,
 			Subject:       u.ID,
 			Name:          strings.TrimSpace(GetName(u.FirstName) + " " + GetName(u.LastName)),
-			Picture:       u.AvatarURL.DisplayImage.Elements[0].Identifiers[0].Identifier,
+			Picture:       avatarURL,
 			Email:         e.Elements[0].HandleTilde.EmailAddress,
 			EmailVerified: true,
 
 			// To be deprecated
-			AvatarURL:  u.AvatarURL.DisplayImage.Elements[0].Identifiers[0].Identifier,
+			AvatarURL:  avatarURL,
 			FullName:   strings.TrimSpace(GetName(u.FirstName) + " " + GetName(u.LastName)),
 			ProviderId: u.ID,
 		},

--- a/api/provider/linkedin.go
+++ b/api/provider/linkedin.go
@@ -37,6 +37,14 @@ type linkedinUser struct {
 	} `json:"profilePicture"`
 }
 
+func (u *linkedinUser) getAvatarUrl() string {
+	avatarURL := ""
+	if len(u.AvatarURL.DisplayImage.Elements) > 0 {
+		avatarURL = u.AvatarURL.DisplayImage.Elements[0].Identifiers[0].Identifier
+	}
+	return avatarURL
+}
+
 type linkedinName struct {
 	Localized       interface{}    `json:"localized"`
 	PreferredLocale linkedinLocale `json:"preferredLocale"`
@@ -127,10 +135,7 @@ func (g linkedinProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 		})
 	}
 
-	var avatarURL string
-	if len(u.AvatarURL.DisplayImage.Elements) > 0 {
-		avatarURL = u.AvatarURL.DisplayImage.Elements[0].Identifiers[0].Identifier
-	}
+	avatarURL := u.getAvatarUrl()
 
 	return &UserProvidedData{
 		Metadata: &Claims{

--- a/models/linking.go
+++ b/models/linking.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/netlify/gotrue/storage"
@@ -78,8 +77,6 @@ func DetermineAccountLinking(tx *storage.Connection, provider, sub string, email
 			return AccountLinkingResult{}, terr
 		}
 	}
-
-	fmt.Printf("similar identities %v\n", similarIdentities)
 
 	// TODO: determine linking behavior over phone too
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* This PR fixes the issue with a linkedin user not being able to sign-in if they don't have an avatar url.
* Fixes: https://github.com/supabase/gotrue-js/issues/488