### PR TITLE
fix: fill `last_sign_in_at` with a non-null value on backfilled email identities

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
       version: ${{ steps.semantic.outputs.new_release_version }}
 
     runs-on: ubuntu-20.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v3
       - name: Release on GitHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
       - master
       - mfa
       - zerosessionidfix
+      - lastsigninatfix
 
 jobs:
   release:

--- a/.releaserc
+++ b/.releaserc
@@ -2,6 +2,10 @@
   "branches": [
     "master",
     {
+        "name": "lastsigninatfix",
+        "prerelease": true
+    },
+    {
         "name": "mfa",
         "prerelease": true
     }

--- a/migrations/20221208132122_backfill_email_last_sign_in_at.up.sql
+++ b/migrations/20221208132122_backfill_email_last_sign_in_at.up.sql
@@ -1,0 +1,10 @@
+-- previous backfill migration left last_sign_in_at to be null, which broke some projects
+
+update {{ index .Options "Namespace" }}.identities
+  set last_sign_in_at = '2022-11-25'
+  where
+    last_sign_in_at is null and
+    created_at = '2022-11-25' and
+    updated_at = '2022-11-25' and
+    provider = 'email' and
+    id = user_id::text;


### PR DESCRIPTION
With the email identities backfill migration, new `email` identities were created where `last_sign_in_at` was set to null. Even though the database allows this, the types in gotrue-js do not, which crashes strongly-typed derivations of the library like Flutter projects.