### PR TITLE
feat: allow more than one verified factor per user

### DIFF
--- a/api/mfa.go
+++ b/api/mfa.go
@@ -97,19 +97,6 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 	if len(factors) >= int(config.MFA.MaxEnrolledFactors) {
 		return forbiddenError("Enrolled factors exceed allowed limit, unenroll to continue")
 	}
-	numVerifiedFactors := 0
-
-	// TODO: Remove this at v2
-	for _, factor := range factors {
-		if factor.Status == models.FactorStateVerified {
-			numVerifiedFactors += 1
-		}
-
-	}
-	if numVerifiedFactors >= 1 {
-		return forbiddenError("number of enrolled factors exceeds the allowed value, unenroll to continue")
-
-	}
 
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      issuer,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Lifts the restriction on # of verified factors per user.

For this PR to go through, a few side tasks need to be completed.

- [ ] Unverified factors must be periodically cleaned up so that the database does not get clogged
- [ ] Session related Downgrade/ unenroll behavior needs to be adequately tested. (e.g. when unenrolling one factor the AAL level of the session of another should not be downgraded). We should either add a manual test or an automated test. TBD.
- [ ] We introduce a new env var which allows users to cap the total number of verified factors. Note that a user with only max one verified factor can't have recovery codes as recovery codes are counted as factors.

## What is the current behavior?
Users can only have one verified factor

## What is the new behavior?
Users can opt to have more than one verified factor.

## Additional context

None