### PR TITLE
fix: add separate config for sms rate limits

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -100,6 +100,7 @@ type GlobalConfiguration struct {
 	SMTP                  SMTPConfiguration
 	RateLimitHeader       string  `split_words:"true"`
 	RateLimitEmailSent    float64 `split_words:"true" default:"30"`
+	RateLimitSmsSent      float64 `split_words:"true" default:"30"`
 	RateLimitVerify       float64 `split_words:"true" default:"30"`
 	RateLimitTokenRefresh float64 `split_words:"true" default:"30"`
 	RateLimitSso          float64 `split_words:"true" default:"30"`


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Separate the email and sms rate limits by introducing a new env var `GOTRUE_RATE_LIMIT_SMS_SENT`
* This env var controls the global limit on the total number of sms-es that can be sent per hour. It is a global rate limit that defaults to 30 sms-es per hour