### PR TITLE
ci: add `migrationorderfix` branch to release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
       - mfa
       - zerosessionidfix
       - lastsigninatfix
+      - migrationorderfix
 
 jobs:
   release:


### PR DESCRIPTION
So that we can release `v2.36.2-migrationorderfix.1`.