### PR TITLE
rename package to `supabase` from `netlify`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,24 +5,24 @@ ENV GOOS=linux
 
 RUN apk add --no-cache make git
 
-WORKDIR /go/src/github.com/netlify/gotrue
+WORKDIR /go/src/github.com/supabase/gotrue
 
 # Pulling dependencies
 COPY ./Makefile ./go.* ./
 RUN make deps
 
 # Building stuff
-COPY . /go/src/github.com/netlify/gotrue
+COPY . /go/src/github.com/supabase/gotrue
 RUN make build
 
 FROM alpine:3.15
-RUN adduser -D -u 1000 netlify
+RUN adduser -D -u 1000 gotrue
 
 RUN apk add --no-cache ca-certificates
-COPY --from=build /go/src/github.com/netlify/gotrue/gotrue /usr/local/bin/gotrue
-COPY --from=build /go/src/github.com/netlify/gotrue/migrations /usr/local/etc/gotrue/migrations/
+COPY --from=build /go/src/github.com/supabase/gotrue/gotrue /usr/local/bin/gotrue
+COPY --from=build /go/src/github.com/supabase/gotrue/migrations /usr/local/etc/gotrue/migrations/
 
 ENV GOTRUE_DB_MIGRATIONS_PATH /usr/local/etc/gotrue/migrations
 
-USER netlify
+USER gotrue
 CMD ["gotrue"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,7 @@ ENV GOOS=linux
 
 RUN apk add --no-cache make git bash
 
-WORKDIR /go/src/github.com/netlify/gotrue
+WORKDIR /go/src/github.com/supabase/gotrue
 
 # Pulling dependencies
 COPY ./Makefile ./go.* ./

--- a/Dockerfile.postgres.dev
+++ b/Dockerfile.postgres.dev
@@ -1,4 +1,4 @@
-FROM postgres:14
+FROM postgres:15
 WORKDIR /
 RUN pwd
 COPY init_postgres.sh /docker-entrypoint-initdb.d/init.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build deps dev-deps image migrate test vet sec format unused
 CHECK_FILES?=./...
-FLAGS?=-ldflags "-X github.com/netlify/gotrue/utilities.Version=`git describe --tags`" -buildvcs=false
+FLAGS?=-ldflags "-X github.com/supabase/gotrue/utilities.Version=`git describe --tags`" -buildvcs=false
 DEV_DOCKER_COMPOSE:=docker-compose-dev.yml
 
 help: ## Show this help.

--- a/api/admin.go
+++ b/api/admin.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/storage"
 	"github.com/sethvargo/go-password/password"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/storage"
 )
 
 type AdminUserParams struct {

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type AdminTestSuite struct {

--- a/api/api.go
+++ b/api/api.go
@@ -9,13 +9,13 @@ import (
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"
 	"github.com/go-chi/chi"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/mailer"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/storage"
 	"github.com/rs/cors"
 	"github.com/sebest/xff"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/mailer"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/storage"
 )
 
 const (

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/crypto"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/crypto"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/storage/test"
 )
 
 const (

--- a/api/audit.go
+++ b/api/audit.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/netlify/gotrue/models"
+	"github.com/supabase/gotrue/models"
 )
 
 var filterColumnMap = map[string][]string{

--- a/api/audit_test.go
+++ b/api/audit_test.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type AuditTestSuite struct {

--- a/api/auth.go
+++ b/api/auth.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 // requireAuthentication checks incoming requests for tokens presented using the Authorization header

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type AuthTestSuite struct {

--- a/api/context.go
+++ b/api/context.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/models"
+	"github.com/supabase/gotrue/models"
 )
 
 type contextKey string

--- a/api/errors.go
+++ b/api/errors.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/utilities"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/utilities"
 )
 
 // Common error messages during signup flow

--- a/api/external.go
+++ b/api/external.go
@@ -12,12 +12,12 @@ import (
 	"github.com/fatih/structs"
 	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/api/provider"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/utilities"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/api/provider"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/utilities"
 	"golang.org/x/oauth2"
 )
 

--- a/api/external_github_test.go
+++ b/api/external_github_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/models"
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalGithub() {

--- a/api/external_oauth.go
+++ b/api/external_oauth.go
@@ -6,10 +6,10 @@ import (
 	"net/url"
 
 	"github.com/mrjones/oauth"
-	"github.com/netlify/gotrue/api/provider"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/storage"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/api/provider"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/storage"
 )
 
 // OAuthProviderData contains the userData and token returned by the oauth provider

--- a/api/external_test.go
+++ b/api/external_test.go
@@ -6,10 +6,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type ExternalTestSuite struct {

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -10,11 +10,11 @@ import (
 	"net/url"
 
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/utilities"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/utilities"
 )
 
 func addRequestID(globalConfig *conf.GlobalConfiguration) middlewareHandler {

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage/test"
 )
 
 // withFunctionHooks adds the provided function hooks to the context.

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -18,9 +18,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 type HookEvent string

--- a/api/invite.go
+++ b/api/invite.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 // InviteParams are the parameters the Signup endpoint accepts

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type InviteTestSuite struct {

--- a/api/logout.go
+++ b/api/logout.go
@@ -3,8 +3,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 // Logout is the endpoint for logging out a user and thereby revoking any refresh tokens

--- a/api/logout_test.go
+++ b/api/logout_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type LogoutTestSuite struct {

--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
 	"github.com/sethvargo/go-password/password"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 // MagicLinkParams holds the parameters for a magic link request

--- a/api/mail.go
+++ b/api/mail.go
@@ -10,14 +10,14 @@ import (
 	"time"
 
 	"github.com/fatih/structs"
-	"github.com/netlify/gotrue/api/provider"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/crypto"
-	"github.com/netlify/gotrue/mailer"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-password/password"
+	"github.com/supabase/gotrue/api/provider"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/crypto"
+	"github.com/supabase/gotrue/mailer"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 var (

--- a/api/mail_test.go
+++ b/api/mail_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type MailTestSuite struct {

--- a/api/mfa.go
+++ b/api/mfa.go
@@ -12,11 +12,11 @@ import (
 	svg "github.com/ajstarks/svgo"
 	"github.com/boombuler/barcode/qr"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/metering"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/utilities"
 	"github.com/pquerna/otp/totp"
+	"github.com/supabase/gotrue/metering"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/utilities"
 )
 
 const DefaultQRSize = 3

--- a/api/mfa_test.go
+++ b/api/mfa_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/utilities"
 	"github.com/pquerna/otp"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/utilities"
 
 	"github.com/jackc/pgx/v4"
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/security"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/security"
 
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/conf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
 )
 
 const (

--- a/api/opentelemetry-tracer_test.go
+++ b/api/opentelemetry-tracer_test.go
@@ -5,11 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"

--- a/api/opentracer_test.go
+++ b/api/opentracer_test.go
@@ -5,13 +5,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
 )
 
 type OpenTracerTestSuite struct {

--- a/api/otp.go
+++ b/api/otp.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/netlify/gotrue/api/sms_provider"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
 	"github.com/sethvargo/go-password/password"
+	"github.com/supabase/gotrue/api/sms_provider"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 // OtpParams contains the request body params for the otp endpoint

--- a/api/otp_test.go
+++ b/api/otp_test.go
@@ -7,11 +7,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type OtpTestSuite struct {

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/netlify/gotrue/models"
+	"github.com/supabase/gotrue/models"
 )
 
 const defaultPerPage = 50

--- a/api/phone.go
+++ b/api/phone.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/netlify/gotrue/api/sms_provider"
-	"github.com/netlify/gotrue/crypto"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/api/sms_provider"
+	"github.com/supabase/gotrue/crypto"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 const e164Format = `^[1-9]\d{1,14}$`

--- a/api/phone_test.go
+++ b/api/phone_test.go
@@ -11,12 +11,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type PhoneTestSuite struct {

--- a/api/provider/apple.go
+++ b/api/provider/apple.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/golang-jwt/jwt"
 	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/azure.go
+++ b/api/provider/azure.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/bitbucket.go
+++ b/api/provider/bitbucket.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/discord.go
+++ b/api/provider/discord.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/facebook.go
+++ b/api/provider/facebook.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/github.go
+++ b/api/provider/github.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/gitlab.go
+++ b/api/provider/gitlab.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/google.go
+++ b/api/provider/google.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/keycloak.go
+++ b/api/provider/keycloak.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/linkedin.go
+++ b/api/provider/linkedin.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/notion.go
+++ b/api/provider/notion.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/slack.go
+++ b/api/provider/slack.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/spotify.go
+++ b/api/provider/spotify.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/twitch.go
+++ b/api/provider/twitch.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/twitter.go
+++ b/api/provider/twitter.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/mrjones/oauth"
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/workos.go
+++ b/api/provider/workos.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/provider/zoom.go
+++ b/api/provider/zoom.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 	"golang.org/x/oauth2"
 )
 

--- a/api/reauthenticate.go
+++ b/api/reauthenticate.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/netlify/gotrue/api/sms_provider"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/api/sms_provider"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 const InvalidNonceMessage = "Nonce has expired or is invalid"

--- a/api/recover.go
+++ b/api/recover.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 // RecoverParams holds the parameters for a password recovery request

--- a/api/recover_test.go
+++ b/api/recover_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type RecoverTestSuite struct {

--- a/api/saml_test.go
+++ b/api/saml_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 
 	"github.com/crewjam/saml"
-	"github.com/netlify/gotrue/conf"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/conf"
 )
 
 func TestSAMLMetadataWithAPI(t *tst.T) {

--- a/api/samlacs.go
+++ b/api/samlacs.go
@@ -12,11 +12,11 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/fatih/structs"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/api/provider"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/utilities"
+	"github.com/supabase/gotrue/api/provider"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/utilities"
 )
 
 func (a *API) samlDestroyRelayState(ctx context.Context, relayState *models.SAMLRelayState) error {

--- a/api/samlassertion.go
+++ b/api/samlassertion.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/crewjam/saml"
-	"github.com/netlify/gotrue/models"
+	"github.com/supabase/gotrue/models"
 )
 
 type SAMLAssertion struct {

--- a/api/samlassertion_test.go
+++ b/api/samlassertion_test.go
@@ -6,8 +6,8 @@ import (
 	"encoding/xml"
 
 	"github.com/crewjam/saml"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/models"
 )
 
 func TestSAMLAssertionUserID(t *tst.T) {

--- a/api/signup.go
+++ b/api/signup.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/fatih/structs"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/api/provider"
-	"github.com/netlify/gotrue/api/sms_provider"
-	"github.com/netlify/gotrue/metering"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/api/provider"
+	"github.com/supabase/gotrue/api/sms_provider"
+	"github.com/supabase/gotrue/metering"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 // SignupParams are the parameters the Signup endpoint accepts

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type SignupTestSuite struct {

--- a/api/sms_provider/messagebird.go
+++ b/api/sms_provider/messagebird.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 )
 
 const (

--- a/api/sms_provider/sms_provider.go
+++ b/api/sms_provider/sms_provider.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 )
 
 var defaultTimeout time.Duration = time.Second * 10

--- a/api/sms_provider/sms_provider_test.go
+++ b/api/sms_provider/sms_provider_test.go
@@ -7,10 +7,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/netlify/gotrue/conf"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
 	"gopkg.in/h2non/gock.v1"
 )
 

--- a/api/sms_provider/textlocal.go
+++ b/api/sms_provider/textlocal.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 )
 
 const (

--- a/api/sms_provider/twilio.go
+++ b/api/sms_provider/twilio.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 )
 
 const (

--- a/api/sms_provider/vonage.go
+++ b/api/sms_provider/vonage.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/netlify/gotrue/conf"
+	"github.com/supabase/gotrue/conf"
 )
 
 const (

--- a/api/sorting.go
+++ b/api/sorting.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/netlify/gotrue/models"
+	"github.com/supabase/gotrue/models"
 )
 
 func sort(r *http.Request, allowedFields map[string]bool, defaultSort []models.SortField) (*models.SortParams, error) {

--- a/api/sso.go
+++ b/api/sso.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/crewjam/saml"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/utilities"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/utilities"
 )
 
 type SingleSignOnParams struct {

--- a/api/sso_test.go
+++ b/api/sso_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type SSOTestSuite struct {

--- a/api/ssoadmin.go
+++ b/api/ssoadmin.go
@@ -12,9 +12,9 @@ import (
 	"github.com/crewjam/saml/samlsp"
 	"github.com/go-chi/chi"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/storage"
 )
 
 // loadSSOProvider looks for an idp_id parameter in the URL route and loads the SSO provider

--- a/api/token.go
+++ b/api/token.go
@@ -14,10 +14,10 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/gofrs/uuid"
 	"github.com/golang-jwt/jwt"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/metering"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/metering"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 // GoTrueClaims is a struct thats used for JWT claims

--- a/api/token_test.go
+++ b/api/token_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type TokenTestSuite struct {

--- a/api/user.go
+++ b/api/user.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/netlify/gotrue/api/sms_provider"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/api/sms_provider"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/storage"
 )
 
 // UserUpdateParams parameters for updating a user

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type UserTestSuite struct {

--- a/api/verify.go
+++ b/api/verify.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/storage"
 	"github.com/sethvargo/go-password/password"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/storage"
 )
 
 var (

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type VerifyTestSuite struct {

--- a/cmd/admin_cmd.go
+++ b/cmd/admin_cmd.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
-	"github.com/netlify/gotrue/storage"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
+	"github.com/supabase/gotrue/storage"
 )
 
 var autoconfirm, isAdmin bool

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"context"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/observability"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/observability"
 )
 
 var configFile = ""

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"net"
 
-	"github.com/netlify/gotrue/api"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/utilities"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/supabase/gotrue/api"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/utilities"
 )
 
 var serveCmd = cobra.Command{

--- a/cmd/version_cmd.go
+++ b/cmd/version_cmd.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/netlify/gotrue/utilities"
 	"github.com/spf13/cobra"
+	"github.com/supabase/gotrue/utilities"
 )
 
 var versionCmd = cobra.Command{

--- a/crypto/password.go
+++ b/crypto/password.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/netlify/gotrue/observability"
+	"github.com/supabase/gotrue/observability"
 	"go.opentelemetry.io/otel/attribute"
 	metricinstrument "go.opentelemetry.io/otel/metric/instrument"
 	"golang.org/x/crypto/bcrypt"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -11,10 +11,10 @@ services:
       - '9999:9999'
       - '9100:9100'
     environment:
-      - GOTRUE_DB_MIGRATIONS_PATH=/go/src/github.com/netlify/gotrue/migrations
+      - GOTRUE_DB_MIGRATIONS_PATH=/go/src/github.com/supabase/gotrue/migrations
     volumes:
-      - ./:/go/src/github.com/netlify/gotrue
-    command: CompileDaemon --build="make build" --directory=/go/src/github.com/netlify/gotrue --recursive=true -pattern="(.+\.go|.+\.env)" -exclude=gotrue -exclude=gotrue-arm64 -exclude=.env --command="/go/src/github.com/netlify/gotrue/gotrue -c=.env.docker"
+      - ./:/go/src/github.com/supabase/gotrue
+    command: CompileDaemon --build="make build" --directory=/go/src/github.com/supabase/gotrue --recursive=true -pattern="(.+\.go|.+\.env)" -exclude=gotrue -exclude=gotrue-arm64 -exclude=.env --command="/go/src/github.com/supabase/gotrue/gotrue -c=.env.docker"
   postgres:
     build:
       context: .
@@ -29,6 +29,6 @@ services:
       - POSTGRES_PASSWORD=root
       - POSTGRES_DB=postgres
       # sets the schema name, this should match the `NAMESPACE` env var set in your .env file
-      - DB_NAMESPACE=auth 
+      - DB_NAMESPACE=auth
 volumes:
   postgres_data:

--- a/docs/admin.go
+++ b/docs/admin.go
@@ -2,7 +2,7 @@
 package docs
 
 import (
-	"github.com/netlify/gotrue/api"
+	"github.com/supabase/gotrue/api"
 )
 
 // swagger:route GET /admin/users admin admin-list-users

--- a/docs/health.go
+++ b/docs/health.go
@@ -1,7 +1,7 @@
 //lint:file-ignore U1000 ignore go-swagger template
 package docs
 
-import "github.com/netlify/gotrue/api"
+import "github.com/supabase/gotrue/api"
 
 // swagger:route GET /health health health
 // The healthcheck endpoint for gotrue. Returns the current gotrue version.

--- a/docs/invite.go
+++ b/docs/invite.go
@@ -1,7 +1,7 @@
 //lint:file-ignore U1000 ignore go-swagger template
 package docs
 
-import "github.com/netlify/gotrue/api"
+import "github.com/supabase/gotrue/api"
 
 // swagger:route POST /invite invite invite
 // Sends an invite link to the user.

--- a/docs/otp.go
+++ b/docs/otp.go
@@ -1,7 +1,7 @@
 //lint:file-ignore U1000 ignore go-swagger template
 package docs
 
-import "github.com/netlify/gotrue/api"
+import "github.com/supabase/gotrue/api"
 
 // swagger:route POST /otp otp otp
 // Passwordless sign-in method for email or phone.

--- a/docs/recover.go
+++ b/docs/recover.go
@@ -1,7 +1,7 @@
 //lint:file-ignore U1000 ignore go-swagger template
 package docs
 
-import "github.com/netlify/gotrue/api"
+import "github.com/supabase/gotrue/api"
 
 // swagger:route POST /recover recovery recovery
 // Sends a password recovery email link to the user's email.

--- a/docs/settings.go
+++ b/docs/settings.go
@@ -1,7 +1,7 @@
 //lint:file-ignore U1000 ignore go-swagger template
 package docs
 
-import "github.com/netlify/gotrue/api"
+import "github.com/supabase/gotrue/api"
 
 // swagger:route GET /settings settings settings
 // Returns the configuration settings for the gotrue server.

--- a/docs/signup.go
+++ b/docs/signup.go
@@ -2,7 +2,7 @@
 package docs
 
 import (
-	"github.com/netlify/gotrue/api"
+	"github.com/supabase/gotrue/api"
 )
 
 // swagger:route POST /signup signup signup

--- a/docs/token.go
+++ b/docs/token.go
@@ -2,7 +2,7 @@
 package docs
 
 import (
-	"github.com/netlify/gotrue/api"
+	"github.com/supabase/gotrue/api"
 )
 
 // swagger:route POST /token?grant_type=password token token-password

--- a/docs/user.go
+++ b/docs/user.go
@@ -2,8 +2,8 @@
 package docs
 
 import (
-	"github.com/netlify/gotrue/api"
-	"github.com/netlify/gotrue/models"
+	"github.com/supabase/gotrue/api"
+	"github.com/supabase/gotrue/models"
 )
 
 // swagger:route GET /user user user-get

--- a/docs/verify.go
+++ b/docs/verify.go
@@ -2,7 +2,7 @@
 package docs
 
 import (
-	"github.com/netlify/gotrue/api"
+	"github.com/supabase/gotrue/api"
 )
 
 // swagger:route GET /verify verify verify-get

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/netlify/gotrue
+module github.com/supabase/gotrue
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -3,10 +3,10 @@ package mailer
 import (
 	"net/url"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
 	"github.com/netlify/mailme"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 	"gopkg.in/gomail.v2"
 )
 

--- a/mailer/template.go
+++ b/mailer/template.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/badoux/checkmail"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/models"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/models"
 )
 
 type MailClient interface {

--- a/main.go
+++ b/main.go
@@ -7,10 +7,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/netlify/gotrue/api"
-	"github.com/netlify/gotrue/cmd"
-	"github.com/netlify/gotrue/observability"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/api"
+	"github.com/supabase/gotrue/cmd"
+	"github.com/supabase/gotrue/observability"
 )
 
 func init() {

--- a/models/amr.go
+++ b/models/amr.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/storage"
 )
 
 type AMRClaim struct {

--- a/models/audit_log_entry.go
+++ b/models/audit_log_entry.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/observability"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/observability"
+	"github.com/supabase/gotrue/storage"
 )
 
 type AuditAction string

--- a/models/challenge.go
+++ b/models/challenge.go
@@ -3,8 +3,8 @@ package models
 import (
 	"database/sql"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/storage"
 	"time"
 )
 

--- a/models/connection.go
+++ b/models/connection.go
@@ -2,7 +2,7 @@ package models
 
 import (
 	"github.com/gobuffalo/pop/v5"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/storage"
 )
 
 type Pagination struct {

--- a/models/db_test.go
+++ b/models/db_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/pop/v5"
-	"github.com/netlify/gotrue/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/supabase/gotrue/models"
 )
 
 func TestTableNameNamespacing(t *testing.T) {

--- a/models/factor.go
+++ b/models/factor.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/storage"
 )
 
 type FactorState int

--- a/models/factor_test.go
+++ b/models/factor_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/storage/test"
 )
 
 type FactorTestSuite struct {

--- a/models/identity.go
+++ b/models/identity.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/storage"
 )
 
 type Identity struct {

--- a/models/identity_test.go
+++ b/models/identity_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/storage/test"
 )
 
 type IdentityTestSuite struct {

--- a/models/linking.go
+++ b/models/linking.go
@@ -3,7 +3,7 @@ package models
 import (
 	"strings"
 
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/storage"
 )
 
 // GetAccountLinkingDomain returns a string that describes the account linking

--- a/models/linking_test.go
+++ b/models/linking_test.go
@@ -3,11 +3,11 @@ package models
 import (
 	"testing"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/storage/test"
 )
 
 type AccountLinkingTestSuite struct {

--- a/models/refresh_token.go
+++ b/models/refresh_token.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/crypto"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/crypto"
+	"github.com/supabase/gotrue/storage"
 )
 
 // RefreshToken is the database model for refresh tokens.

--- a/models/refresh_token_test.go
+++ b/models/refresh_token_test.go
@@ -4,11 +4,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/storage/test"
 )
 
 type RefreshTokenTestSuite struct {

--- a/models/sessions.go
+++ b/models/sessions.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/storage"
 )
 
 type AuthenticatorAssuranceLevel int

--- a/models/sessions_test.go
+++ b/models/sessions_test.go
@@ -1,11 +1,11 @@
 package models
 
 import (
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/storage/test"
 	"testing"
 	"time"
 )

--- a/models/sso.go
+++ b/models/sso.go
@@ -10,8 +10,8 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/storage"
 )
 
 type SSOProvider struct {

--- a/models/sso_test.go
+++ b/models/sso_test.go
@@ -3,11 +3,11 @@ package models
 import (
 	tst "testing"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/storage/test"
 )
 
 type SSOTestSuite struct {

--- a/models/user.go
+++ b/models/user.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/netlify/gotrue/crypto"
-	"github.com/netlify/gotrue/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/crypto"
+	"github.com/supabase/gotrue/storage"
 )
 
 // User respresents a registered user with email/password authentication

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -3,13 +3,13 @@ package models
 import (
 	"testing"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/crypto"
-	"github.com/netlify/gotrue/storage"
-	"github.com/netlify/gotrue/storage/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/crypto"
+	"github.com/supabase/gotrue/storage"
+	"github.com/supabase/gotrue/storage/test"
 )
 
 const modelsTestConfig = "../hack/test.env"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,0 @@
-[build]
-  publish = "www"
-  command = "exit 0"
-
-[[redirects]]
-from = "/*"
-to = "https://github.com/netlify/gotrue"
-status = 302
-force = true

--- a/observability/logging.go
+++ b/observability/logging.go
@@ -7,8 +7,8 @@ import (
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gobuffalo/pop/v5/logging"
-	"github.com/netlify/gotrue/conf"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/conf"
 	"go.opentelemetry.io/otel"
 )
 

--- a/observability/metrics.go
+++ b/observability/metrics.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/conf"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"

--- a/observability/request-logger.go
+++ b/observability/request-logger.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	chimiddleware "github.com/go-chi/chi/middleware"
-	"github.com/netlify/gotrue/utilities"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/utilities"
 )
 
 func NewStructuredLogger(logger *logrus.Logger) func(next http.Handler) http.Handler {

--- a/observability/tracing.go
+++ b/observability/tracing.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/utilities"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/utilities"
 
 	"github.com/opentracing/opentracing-go"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"

--- a/security/hcaptcha.go
+++ b/security/hcaptcha.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/netlify/gotrue/utilities"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/utilities"
 )
 
 type GotrueRequest struct {

--- a/storage/dial.go
+++ b/storage/dial.go
@@ -11,9 +11,9 @@ import (
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gobuffalo/pop/v5/columns"
 	"github.com/jmoiron/sqlx"
-	"github.com/netlify/gotrue/conf"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/conf"
 )
 
 // Connection is the interface a storage provider must implement.

--- a/storage/test/db_setup.go
+++ b/storage/test/db_setup.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"github.com/netlify/gotrue/conf"
-	"github.com/netlify/gotrue/storage"
+	"github.com/supabase/gotrue/conf"
+	"github.com/supabase/gotrue/storage"
 )
 
 func SetupDBConnection(globalConfig *conf.GlobalConfiguration) (*storage.Connection, error) {


### PR DESCRIPTION
After forking the repo from https://github.com/netlify/gotrue, we need to change the Go package name to point to this repository.