### PR TITLE
chore: bump alpine in Dockerfile to 3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN make deps
 COPY . /go/src/github.com/netlify/gotrue
 RUN make build
 
-FROM alpine:3.15
+FROM alpine:3.17
 RUN adduser -D -u 1000 netlify
 
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
see title. Latest version of alpine is [3:17](https://hub.docker.com/_/alpine)