### PR TITLE
fix: add `email` as verification type for email OTPs

### DIFF
--- a/api/verify.go
+++ b/api/verify.go
@@ -31,6 +31,8 @@ const (
 	emailChangeVerification = "email_change"
 	smsVerification         = "sms"
 	phoneChangeVerification = "phone_change"
+	// includes signupVerification and magicLinkVerification
+	emailOTPVerification = "email"
 )
 
 const (
@@ -490,6 +492,17 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 
 	var isValid bool
 	switch params.Type {
+	case emailOTPVerification:
+		// if the type is emailOTPVerification, we'll check both the confirmation_token and recovery_token columns
+		if isOtpValid(tokenHash, user.ConfirmationToken, user.ConfirmationSentAt, config.Mailer.OtpExp) {
+			isValid = true
+			params.Type = signupVerification
+		} else if isOtpValid(tokenHash, user.RecoveryToken, user.RecoverySentAt, config.Mailer.OtpExp) {
+			isValid = true
+			params.Type = magicLinkVerification
+		} else {
+			isValid = false
+		}
 	case signupVerification, inviteVerification:
 		isValid = isOtpValid(tokenHash, user.ConfirmationToken, user.ConfirmationSentAt, config.Mailer.OtpExp)
 	case recoveryVerification, magicLinkVerification:

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -659,6 +659,17 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			expected: expectedResponse,
 		},
 		{
+			desc:     "Valid Email OTP",
+			sentTime: time.Now(),
+			body: map[string]interface{}{
+				"type":      emailOTPVerification,
+				"tokenHash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+				"token":     "123456",
+				"email":     u.GetEmail(),
+			},
+			expected: expectedResponse,
+		},
+		{
 			desc:     "Valid Email Change OTP",
 			sentTime: time.Now(),
 			body: map[string]interface{}{


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds a new verification type for email OTPs called `email`. Currently, it's impossible to tell whether the verification type should be set to "signup" or "magiclink" when a user enters an OTP. As such, developers have to resort to trying `magiclink` first, then catching the error and trying with `signup` next. 
* Deprecate `signup`, `magiclink` types for `POST /verify` 
* Also remove references to the v1 OTP format since it's no longer used and any existing v1 OTPs should have expired by now.

Example request:
```bash
curl -X POST 'http://localhost:9999/verify' -H 'Content-Type: application/json' -d '{"email": "foo@example.com", "token": "123456", "type": "email"}'
```