### PR TITLE
fix: handle error properly for redirects

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -192,7 +192,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 			return internalServerError("Failed to set JWT cookie. %s", err)
 		}
 	} else {
-		rurl = a.prepErrorRedirectURL(unauthorizedError("Unverified email with %v", providerType), r, rurl)
+		rurl = a.prepErrorRedirectURL(unauthorizedError("Unverified email with %v", providerType), w, r, rurl)
 	}
 
 	http.Redirect(w, r, rurl, http.StatusFound)


### PR DESCRIPTION
## What kind of change does this PR introduce?
* For endpoints which redirect the request on an error, if the error is an internal server error, the internal message isn't getting logged properly. This change helps to fix that. 