### PR TITLE
feat: add PKCE POC

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -90,6 +90,10 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		r.Get("/", api.ExternalProviderCallback)
 		r.Post("/", api.ExternalProviderCallback)
 	})
+	// Add route for step 2: Takes in Auth Code + Verifier -> Returns token
+	// r.Route("/oauth", func(r *router, api.TokenVerifier) {
+	//    r.Route("/verifier")
+	// })
 
 	r.Route("/", func(r *router) {
 		r.UseBypass(logger)

--- a/api/external.go
+++ b/api/external.go
@@ -124,6 +124,7 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	config := a.config
 
 	providerType := getExternalProviderType(ctx)
+	// isImplicit := getFlowType(ctx)
 	var userData *provider.UserProvidedData
 	var providerAccessToken string
 	var providerRefreshToken string
@@ -177,6 +178,8 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	}
 
 	rurl := a.getExternalRedirectURL(r)
+	// if isImplict  {
+	// Do everything below
 	if token != nil {
 		q := url.Values{}
 		q.Set("provider_token", providerAccessToken)
@@ -194,10 +197,38 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	} else {
 		rurl = a.prepErrorRedirectURL(unauthorizedError("Unverified email with %v", providerType), w, r, rurl)
 	}
-
+	// }  till here - otherwise you can ignore
+	// Change this line to return a JSON response with AuthCode
 	http.Redirect(w, r, rurl, http.StatusFound)
 	return nil
 }
+
+// Logic for PKCE token verifier, we do not support `plain` unless there are special requests from enterprise customers
+// func (a *API) TokenVerifier() {
+//  Decode inputParams
+//  if(SHA256(params.CodeChallenge)) != base64.StdEncoding.EncodeToString(Sum256(ASCII(params.code_verifier))) {
+//     return forbiddenError("code verifier does not match code challenge")
+//  }
+// 	if token != nil {
+// 		q := url.Values{}
+// 		q.Set("provider_token", providerAccessToken)
+// 		// Because not all providers give out a refresh token
+// 		// See corresponding OAuth2 spec: <https://www.rfc-editor.org/rfc/rfc6749.html#section-5.1>
+// 		if providerRefreshToken != "" {
+// 			q.Set("provider_refresh_token", providerRefreshToken)
+// 		}
+
+// 		rurl = token.AsRedirectURL(rurl, q)
+
+// 		if err := a.setCookieTokens(config, token, false, w); err != nil {
+// 			return internalServerError("Failed to set JWT cookie. %s", err)
+// 		}
+// 	} else {
+// 		rurl = a.prepErrorRedirectURL(unauthorizedError("Unverified email with %v", providerType), w, r, rurl)
+// 	}
+// 	http.Redirect(w, r, rurl, http.StatusFound)
+//	return nil
+// }
 
 func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.Request, userData *provider.UserProvidedData, providerType string) (*models.User, error) {
 	ctx := r.Context()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds POC for [PKCE on Server Side](https://www.rfc-editor.org/rfc/rfc7636). Note that we will only support `SHA256` encoding as per the spec.

## What is the current behavior?

We use the implicit flow.

## What is the new behavior?

We will use the PKCE flow.

## Additional context

None.