### PR TITLE
fix: add missing namespace prefix to index targets

### DIFF
--- a/migrations/20210927181326_add_refresh_token_parent.up.sql
+++ b/migrations/20210927181326_add_refresh_token_parent.up.sql
@@ -19,6 +19,6 @@ BEGIN
       ALTER TABLE "{{ index .Options "Namespace" }}"."refresh_tokens" ADD CONSTRAINT refresh_tokens_parent_fkey FOREIGN KEY (parent) REFERENCES {{ index .Options "Namespace" }}.refresh_tokens("token");
   END IF;
 
-  CREATE INDEX IF NOT EXISTS refresh_tokens_parent_idx ON refresh_tokens USING btree (parent);
+  CREATE INDEX IF NOT EXISTS refresh_tokens_parent_idx ON "{{ index .Options "Namespace" }}"."refresh_tokens" USING btree (parent);
 END $$;
 

--- a/migrations/20211122151130_create_user_id_idx.up.sql
+++ b/migrations/20211122151130_create_user_id_idx.up.sql
@@ -1,3 +1,3 @@
 -- create index on identities.user_id
 
-CREATE INDEX IF NOT EXISTS identities_user_id_idx ON identities using btree (user_id);
+CREATE INDEX IF NOT EXISTS identities_user_id_idx ON "{{ index .Options "Namespace" }}".identities using btree (user_id);

--- a/migrations/20220114185221_update_user_idx.up.sql
+++ b/migrations/20220114185221_update_user_idx.up.sql
@@ -1,4 +1,4 @@
 -- updates users_instance_id_email_idx definition
 
 DROP INDEX IF EXISTS users_instance_id_email_idx;
-CREATE INDEX IF NOT EXISTS users_instance_id_email_idx on users using btree (instance_id, lower(email));
+CREATE INDEX IF NOT EXISTS users_instance_id_email_idx on "{{ index .Options "Namespace" }}".users using btree (instance_id, lower(email));


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes some errors on inital database migrations.

## What is the current behavior?

On database initialization following errors occur:

- `add_refresh_token_parent`:
   ```
   {"level":"fatal","msg":"running db migrations: error executing /usr/local/etc/gotrue/migrations/20210927181326_add_refresh_token_parent.up.sql, sql: -- adds parent column\n\nALTER TABLE auth.refresh_tokens\nADD COLUMN IF NOT EXISTS parent varchar(255) NULL;\n\nDO $$\nBEGIN\n  IF NOT EXISTS(SELECT *\n    FROM information_schema.constraint_column_usage\n    WHERE table_schema = 'auth' and table_name='refresh_tokens' and constraint_name='refresh_tokens_token_unique')\n  THEN\n      ALTER TABLE \"auth\".\"refresh_tokens\" ADD CONSTRAINT refresh_tokens_token_unique UNIQUE (\"token\");\n  END IF;\n\n  IF NOT EXISTS(SELECT *\n    FROM information_schema.constraint_column_usage\n    WHERE table_schema = 'auth' and table_name='refresh_tokens' and constraint_name='refresh_tokens_parent_fkey')\n  THEN\n      ALTER TABLE \"auth\".\"refresh_tokens\" ADD CONSTRAINT refresh_tokens_parent_fkey FOREIGN KEY (parent) REFERENCES auth.refresh_tokens(\"token\");\n  END IF;\n\n  CREATE INDEX IF NOT EXISTS refresh_tokens_parent_idx ON refresh_tokens USING btree (parent);\nEND $$;\n\n: ERROR: relation \"refresh_tokens\" does not exist (SQLSTATE 42P01)","time":"2023-01-16T10:56:21Z"}
   ```
- `create_user_id_idx`:
   ```
   {"level":"fatal","msg":"running db migrations: error executing /usr/local/etc/gotrue/migrations/20211122151130_create_user_id_idx.up.sql, sql: -- create index on identities.user_id\n\nCREATE INDEX IF NOT EXISTS identities_user_id_idx ON identities using btree (user_id);\n: ERROR: relation \"identities\" does not exist (SQLSTATE 42P01)","time":"2023-01-16T11:04:38Z"}
   ```
- `update_user_idx`:
   ```
   {"level":"fatal","msg":"running db migrations: error executing /usr/local/etc/gotrue/migrations/20220114185221_update_user_idx.up.sql, sql: -- updates users_instance_id_email_idx definition\n\nDROP INDEX IF EXISTS users_instance_id_email_idx;\nCREATE INDEX IF NOT EXISTS users_instance_id_email_idx on users using btree (instance_id, lower(email));\n: ERROR: relation \"users\" does not exist (SQLSTATE 42P01)","time":"2023-01-16T11:07:11Z"}
   ```

This is probably caused due to some missing changes in PR #669 where some indices where not prefixed and thus cause errors on initial migration.

## What is the new behavior?

This PR fixes the above mentioned errors.