### PR TITLE
fix: create identity for invited user

### DIFF
--- a/api/external.go
+++ b/api/external.go
@@ -414,6 +414,16 @@ func (a *API) processInvite(r *http.Request, ctx context.Context, tx *storage.Co
 		return nil, err
 	}
 
+	// an account with a previously unconfirmed email + password
+	// combination or phone may exist. so now that there is an
+	// OAuth identity bound to this user, and since they have not
+	// confirmed their email or phone, they are unaware that a
+	// potentially malicious door exists into their account; thus
+	// the password and phone needs to be removed.
+	if err = user.RemoveUnconfirmedIdentities(tx); err != nil {
+		return nil, internalServerError("Error updating user").WithInternalError(err)
+	}
+
 	// confirm because they were able to respond to invite email
 	if err := user.Confirm(tx); err != nil {
 		return nil, err

--- a/api/invite.go
+++ b/api/invite.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/fatih/structs"
+	"github.com/netlify/gotrue/api/provider"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
 )
@@ -58,6 +60,14 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 			if err != nil {
 				return err
 			}
+			identity, err := a.createNewIdentity(tx, user, "email", structs.Map(provider.Claims{
+				Subject: user.ID.String(),
+				Email:   user.GetEmail(),
+			}))
+			if err != nil {
+				return err
+			}
+			user.Identities = []models.Identity{*identity}
 		}
 
 		if terr := models.NewAuditLogEntry(r, tx, adminUser, models.UserInvitedAction, "", map[string]interface{}{


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Previously, inviting a user won't lead to an identity being created. This creates a bug when the following steps are executed:
  1. Invite a new user
  2. Accept the invite via email
  3. Try to sign-in with an oauth provider (i.e google) with the same email used in (1)
 This leads to an error saving the user in (3) because `DetermineAccountLinking` will not be able to find any similar identities  as shown in: https://github.com/supabase/gotrue/blob/65817282f2ed05bae19b57f85d4c09cf20b7780c/models/linking.go#L73-L79 Thus, this returns the decision to create a new account. However, attempting to create a new user will result in a unique constraint violation since a user with that email already exists.
  
