### PR TITLE
fix: backfill email identities for invited users

### DIFF
--- a/migrations/20230125174531_backfill_invite_identities.up.sql
+++ b/migrations/20230125174531_backfill_invite_identities.up.sql
@@ -1,0 +1,6 @@
+-- backfills the missing email identity for invited users
+
+insert into auth.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
+select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2023-01-25' as created_at, '2023-01-25' as updated_at
+from auth.users as users
+where invited_at is not null;

--- a/migrations/20230125174531_backfill_invite_identities.up.sql
+++ b/migrations/20230125174531_backfill_invite_identities.up.sql
@@ -1,6 +1,0 @@
--- backfills the missing email identity for invited users
-
-insert into auth.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
-select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2023-01-25' as created_at, '2023-01-25' as updated_at
-from auth.users as users
-where invited_at is not null;

--- a/migrations/20230131181311_backfill_invite_identities.up.sql
+++ b/migrations/20230131181311_backfill_invite_identities.up.sql
@@ -1,0 +1,6 @@
+-- backfills the missing email identity for invited users
+
+insert into {{ index .Options "Namespace" }}.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
+select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2023-01-25' as created_at, '2023-01-25' as updated_at
+from {{ index .Options "Namespace" }}.users as users
+where invited_at is not null and not exists (select user_id from {{ index .Options "Namespace" }}.identities where user_id = users.id );

--- a/migrations/20230131181311_backfill_invite_identities.up.sql
+++ b/migrations/20230131181311_backfill_invite_identities.up.sql
@@ -3,4 +3,4 @@
 insert into {{ index .Options "Namespace" }}.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
 select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2023-01-25' as created_at, '2023-01-25' as updated_at
 from {{ index .Options "Namespace" }}.users as users
-where invited_at is not null and not exists (select user_id from {{ index .Options "Namespace" }}.identities where user_id = users.id );
+where invited_at is not null and not exists (select user_id from {{ index .Options "Namespace" }}.identities where user_id = users.id and provider = 'email');


### PR DESCRIPTION
## What kind of change does this PR introduce?
* With #895, invited users will now have an email identity created upon invite. However, previously invited users will need to be reinvited again for this change to persist. This migration to backfill the `auth.identities` table helps to ensure that previously invited users won't have to be reinvited again.