### PR TITLE
chore: remove MFA_ENABLED references

### DIFF
--- a/api/settings_test.go
+++ b/api/settings_test.go
@@ -24,9 +24,6 @@ func TestSettings_DefaultProviders(t *testing.T) {
 	resp := Settings{}
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 
-	// TODO(Joel): Reinstate once feature is stable
-	// require.False(t, resp.MFAEnabled)
-
 	p := resp.ExternalProviders
 
 	require.False(t, p.Phone)

--- a/api/token.go
+++ b/api/token.go
@@ -623,7 +623,6 @@ func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, u
 			return terr
 		}
 
-		// TODO(Joel): Replace when feature flag is lifted
 		tokenString, terr = generateAccessToken(tx, user, refreshToken.SessionId, time.Second*time.Duration(config.JWT.Exp), config.JWT.Secret)
 		if terr != nil {
 			return internalServerError("error generating jwt token").WithInternalError(terr)


### PR DESCRIPTION
- Removes `MFA_Enabled` flag references since MFA is enabled by default on all projects and we no longer use it 