### PR TITLE
fix: set emailChange to email

### DIFF
--- a/api/mail.go
+++ b/api/mail.go
@@ -340,6 +340,7 @@ func (a *API) sendEmailChange(tx *storage.Connection, config *conf.GlobalConfigu
 	if err != nil {
 		return err
 	}
+	u.EmailChange = email
 	u.EmailChangeTokenNew = fmt.Sprintf("%x", sha256.Sum224([]byte(u.EmailChange+otpNew)))
 
 	otpCurrent := ""
@@ -353,7 +354,7 @@ func (a *API) sendEmailChange(tx *storage.Connection, config *conf.GlobalConfigu
 			return err
 		}
 	}
-	u.EmailChange = email
+
 	u.EmailChangeConfirmStatus = zeroConfirmation
 	now := time.Now()
 	if err := mailer.EmailChangeMail(u, otpNew, otpCurrent, referrerURL); err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #897 
* Previously, the `u.EmailChange` field would be empty and we'd be hashing an empty string together with the OTP. This results in `verifyOtp` failing since it expects the token hash value to be `hash(emailChange+OTP)` instead of `hash(""+OTP)`  