### PR TITLE
chore: bump postgres to 15  and ubuntu version to 22.04 in test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         go-version: [1.19.x]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgres:13
+        image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: root


### PR DESCRIPTION
see title

- need to check that we do indeed use 22.04 in prod