### PR TITLE
fix: make migration idempotent

### DIFF
--- a/migrations/20221011041400_add_mfa_indexes.up.sql
+++ b/migrations/20221011041400_add_mfa_indexes.up.sql
@@ -5,8 +5,9 @@ do $$
 begin
   if not exists
      (select constraint_name
-      from information_schema.check_constraints
-      where constraint_schema = '{{ index .Options "Namespace" }}'
+      from information_schema.table_constraints
+      where table_schema = '{{ index .Options "Namespace" }}'
+      and table_name = 'mfa_amr_claims'
       and constraint_name = 'amr_id_pk')
   then
     alter table {{ index .Options "Namespace" }}.mfa_amr_claims add constraint amr_id_pk primary key(id);


### PR DESCRIPTION
## What kind of change does this PR introduce?
* the `information_schema.check_constraints` view doesn't show information about the primary key on the `mfa_amr_claims` table so we should use the `information_schema.table_constraints` view instead