### PR TITLE
feat: remove `id_token` flow with freeform provider

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -70,8 +70,6 @@ type IdTokenGrantParams struct {
 	IdToken  string `json:"id_token"`
 	Nonce    string `json:"nonce"`
 	Provider string `json:"provider"`
-	ClientID string `json:"client_id"`
-	Issuer   string `json:"issuer"`
 }
 
 const useCookieHeader = "x-use-cookie"
@@ -123,16 +121,6 @@ func (p *IdTokenGrantParams) getVerifier(ctx context.Context, config *conf.Globa
 	}
 
 	return provider.Verifier(&oidc.Config{ClientID: oAuthProviderClientId}), nil
-}
-
-func (p *IdTokenGrantParams) getVerifierFromClientIDandIssuer(ctx context.Context) (*oidc.IDTokenVerifier, error) {
-	var provider *oidc.Provider
-	var err error
-	provider, err = oidc.NewProvider(ctx, p.Issuer)
-	if err != nil {
-		return nil, fmt.Errorf("issuer %s doesn't support the id_token grant flow", p.Issuer)
-	}
-	return provider.Verifier(&oidc.Config{ClientID: p.ClientID}), nil
 }
 
 func getEmailVerified(v interface{}) bool {
@@ -404,18 +392,11 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 		return oauthError("invalid request", "id_token required")
 	}
 
-	if params.Provider == "" && (params.ClientID == "" || params.Issuer == "") {
-		return oauthError("invalid request", "provider or client_id and issuer required")
+	if params.Provider == "" {
+		return oauthError("invalid request", "provider required")
 	}
 
-	var verifier *oidc.IDTokenVerifier
-	if params.Provider != "" {
-		verifier, err = params.getVerifier(ctx, a.config)
-	} else if params.ClientID != "" && params.Issuer != "" {
-		verifier, err = params.getVerifierFromClientIDandIssuer(ctx)
-	} else {
-		return badRequestError("%v", err)
-	}
+	verifier, err := params.getVerifier(ctx, a.config)
 	if err != nil {
 		return err
 	}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -90,7 +90,7 @@ paths:
               description: |-
                 For the refresh token flow, supply only `refresh_token`.
                 For the email/phone with password flow, supply `email`, `phone` and `password` with an optional `gotrue_meta_security`.
-                For the OIDC ID token flow, supply `id_token`, `nonce`, `provider`, `client_id`, `issuer` with an optional `gotrue_meta_security`.
+                For the OIDC ID token flow, supply `id_token`, `nonce`, `provider` with an optional `gotrue_meta_security`.
               properties:
                 refresh_token:
                   type: string
@@ -111,10 +111,6 @@ paths:
                   enum:
                     - google
                     - apple
-                client_id:
-                  type: string
-                issuer:
-                  type: string
                 gotrue_meta_security:
                   $ref: '#/components/schemas/GoTrueMetaSecurity'
       responses:


### PR DESCRIPTION
The `POST /token?grant_type=id_token` implementation allowed any OpenID Connect compliant issuer to be used for authentication, albeit in a very limited and broken way. Given we are not supporting this at this time, the implementation is being removed.

Existing OIDC providers, importantly `google` and `apple` continue to be supported.