### PR TITLE
refactor: update validateEmail & validatePhone

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -148,14 +148,14 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Email != "" {
-		params.Email, err = a.validateEmail(ctx, params.Email)
+		params.Email, err = validateEmail(params.Email)
 		if err != nil {
 			return err
 		}
 	}
 
 	if params.Phone != "" {
-		params.Phone, err = a.validatePhone(params.Phone)
+		params.Phone, err = validatePhone(params.Phone)
 		if err != nil {
 			return err
 		}
@@ -275,7 +275,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Email != "" {
-		params.Email, err = a.validateEmail(ctx, params.Email)
+		params.Email, err = validateEmail(params.Email)
 		if err != nil {
 			return err
 		}
@@ -287,7 +287,7 @@ func (a *API) adminUserCreate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Phone != "" {
-		params.Phone, err = a.validatePhone(params.Phone)
+		params.Phone, err = validatePhone(params.Phone)
 		if err != nil {
 			return err
 		}

--- a/api/invite.go
+++ b/api/invite.go
@@ -33,7 +33,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read Invite params: %v", err)
 	}
 
-	params.Email, err = a.validateEmail(ctx, params.Email)
+	params.Email, err = validateEmail(params.Email)
 	if err != nil {
 		return err
 	}

--- a/api/magic_link.go
+++ b/api/magic_link.go
@@ -43,7 +43,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	if params.Email == "" {
 		return unprocessableEntityError("Password recovery requires an email")
 	}
-	params.Email, err = a.validateEmail(ctx, params.Email)
+	params.Email, err = validateEmail(params.Email)
 	if err != nil {
 		return err
 	}

--- a/api/otp.go
+++ b/api/otp.go
@@ -87,7 +87,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 		params.Data = make(map[string]interface{})
 	}
 
-	params.Phone, err = a.validatePhone(params.Phone)
+	params.Phone, err = validatePhone(params.Phone)
 	if err != nil {
 		return err
 	}
@@ -179,13 +179,13 @@ func (a *API) shouldCreateUser(r *http.Request, params *OtpParams) (bool, error)
 		aud := a.requestAud(ctx, r)
 		var err error
 		if params.Email != "" {
-			params.Email, err = a.validateEmail(ctx, params.Email)
+			params.Email, err = validateEmail(params.Email)
 			if err != nil {
 				return false, err
 			}
 			_, err = models.FindUserByEmailAndAudience(db, params.Email, aud)
 		} else if params.Phone != "" {
-			params.Phone, err = a.validatePhone(params.Phone)
+			params.Phone, err = validatePhone(params.Phone)
 			if err != nil {
 				return false, err
 			}

--- a/api/phone.go
+++ b/api/phone.go
@@ -23,23 +23,23 @@ const (
 	phoneReauthenticationOtp = "reauthentication"
 )
 
-func (a *API) validatePhone(phone string) (string, error) {
-	phone = a.formatPhoneNumber(phone)
-	if isValid := a.validateE164Format(phone); !isValid {
+func validatePhone(phone string) (string, error) {
+	phone = formatPhoneNumber(phone)
+	if isValid := validateE164Format(phone); !isValid {
 		return "", unprocessableEntityError("Invalid phone number format")
 	}
 	return phone, nil
 }
 
 // validateE164Format checks if phone number follows the E.164 format
-func (a *API) validateE164Format(phone string) bool {
+func validateE164Format(phone string) bool {
 	// match should never fail as long as regexp is valid
 	matched, _ := regexp.Match(e164Format, []byte(phone))
 	return matched
 }
 
 // formatPhoneNumber removes "+" and whitespaces in a phone number
-func (a *API) formatPhoneNumber(phone string) string {
+func formatPhoneNumber(phone string) string {
 	return strings.ReplaceAll(strings.Trim(phone, "+"), " ", "")
 }
 

--- a/api/phone_test.go
+++ b/api/phone_test.go
@@ -56,12 +56,12 @@ func (ts *PhoneTestSuite) SetupTest() {
 }
 
 func (ts *PhoneTestSuite) TestValidateE164Format() {
-	isValid := ts.API.validateE164Format("0123456789")
+	isValid := validateE164Format("0123456789")
 	assert.Equal(ts.T(), false, isValid)
 }
 
 func (ts *PhoneTestSuite) TestFormatPhoneNumber() {
-	actual := ts.API.formatPhoneNumber("+1 23456789 ")
+	actual := formatPhoneNumber("+1 23456789 ")
 	assert.Equal(ts.T(), "123456789", actual)
 }
 

--- a/api/recover.go
+++ b/api/recover.go
@@ -37,7 +37,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	var user *models.User
 	aud := a.requestAud(ctx, r)
 
-	params.Email, err = a.validateEmail(ctx, params.Email)
+	params.Email, err = validateEmail(params.Email)
 	if err != nil {
 		return err
 	}

--- a/api/signup.go
+++ b/api/signup.go
@@ -75,7 +75,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if !config.External.Email.Enabled {
 			return badRequestError("Email signups are disabled")
 		}
-		params.Email, err = a.validateEmail(ctx, params.Email)
+		params.Email, err = validateEmail(params.Email)
 		if err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if !config.External.Phone.Enabled {
 			return badRequestError("Phone signups are disabled")
 		}
-		params.Phone, err = a.validatePhone(params.Phone)
+		params.Phone, err = validatePhone(params.Phone)
 		if err != nil {
 			return err
 		}

--- a/api/token.go
+++ b/api/token.go
@@ -204,7 +204,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		if !config.External.Phone.Enabled {
 			return badRequestError("Phone logins are disabled")
 		}
-		params.Phone = a.formatPhoneNumber(params.Phone)
+		params.Phone = formatPhoneNumber(params.Phone)
 		user, err = models.FindUserByPhoneAndAudience(db, params.Phone, aud)
 	} else {
 		return oauthError("invalid_grant", InvalidLoginMessage)

--- a/api/user.go
+++ b/api/user.go
@@ -124,7 +124,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if params.Email != "" && params.Email != user.GetEmail() {
-			params.Email, terr = a.validateEmail(ctx, params.Email)
+			params.Email, terr = validateEmail(params.Email)
 			if terr != nil {
 				return terr
 			}
@@ -144,7 +144,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if params.Phone != "" && params.Phone != user.GetPhone() {
-			params.Phone, err = a.validatePhone(params.Phone)
+			params.Phone, err = validatePhone(params.Phone)
 			if err != nil {
 				return err
 			}

--- a/api/verify.go
+++ b/api/verify.go
@@ -450,7 +450,7 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 	var err error
 	var tokenHash string
 	if isPhoneOtpVerification(params) {
-		params.Phone, err = a.validatePhone(params.Phone)
+		params.Phone, err = validatePhone(params.Phone)
 		if err != nil {
 			return nil, err
 		}
@@ -464,7 +464,7 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 			return nil, badRequestError("Invalid sms verification type")
 		}
 	} else if isEmailOtpVerification(params) {
-		params.Email, err = a.validateEmail(ctx, params.Email)
+		params.Email, err = validateEmail(params.Email)
 		if err != nil {
 			return nil, unprocessableEntityError("Invalid email format").WithInternalError(err)
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* make `validateEmail` and `validatePhone` private methods in the `api` package instead of a struct method of the API struct 
* `validateEmail` used to rely on the `ValidateEmail` method in the `Mailer` interface. However, this is not necessary since we can just use the underlying lib directly 