### PR TITLE
feat: revert "remove `id_token` flow with freeform provider"

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -90,7 +90,7 @@ paths:
               description: |-
                 For the refresh token flow, supply only `refresh_token`.
                 For the email/phone with password flow, supply `email`, `phone` and `password` with an optional `gotrue_meta_security`.
-                For the OIDC ID token flow, supply `id_token`, `nonce`, `provider` with an optional `gotrue_meta_security`.
+                For the OIDC ID token flow, supply `id_token`, `nonce`, `provider`, `client_id`, `issuer` with an optional `gotrue_meta_security`.
               properties:
                 refresh_token:
                   type: string
@@ -111,6 +111,10 @@ paths:
                   enum:
                     - google
                     - apple
+                client_id:
+                  type: string
+                issuer:
+                  type: string
                 gotrue_meta_security:
                   $ref: '#/components/schemas/GoTrueMetaSecurity'
       responses:


### PR DESCRIPTION
Reverts supabase/gotrue#927 due to identifying that some users do actually use this API but only for Apple and Google. I'll come back with another PR that blocks non-Apple and Google issuers only.