### PR TITLE
feat: deprecate and explicitly allow freeform ID token issuers

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -136,27 +136,28 @@ type EmailContentConfiguration struct {
 }
 
 type ProviderConfiguration struct {
-	Apple       OAuthProviderConfiguration `json:"apple"`
-	Azure       OAuthProviderConfiguration `json:"azure"`
-	Bitbucket   OAuthProviderConfiguration `json:"bitbucket"`
-	Discord     OAuthProviderConfiguration `json:"discord"`
-	Facebook    OAuthProviderConfiguration `json:"facebook"`
-	Github      OAuthProviderConfiguration `json:"github"`
-	Gitlab      OAuthProviderConfiguration `json:"gitlab"`
-	Google      OAuthProviderConfiguration `json:"google"`
-	Notion      OAuthProviderConfiguration `json:"notion"`
-	Keycloak    OAuthProviderConfiguration `json:"keycloak"`
-	Linkedin    OAuthProviderConfiguration `json:"linkedin"`
-	Spotify     OAuthProviderConfiguration `json:"spotify"`
-	Slack       OAuthProviderConfiguration `json:"slack"`
-	Twitter     OAuthProviderConfiguration `json:"twitter"`
-	Twitch      OAuthProviderConfiguration `json:"twitch"`
-	WorkOS      OAuthProviderConfiguration `json:"workos"`
-	Email       EmailProviderConfiguration `json:"email"`
-	Phone       PhoneProviderConfiguration `json:"phone"`
-	Zoom        OAuthProviderConfiguration `json:"zoom"`
-	IosBundleId string                     `json:"ios_bundle_id" split_words:"true"`
-	RedirectURL string                     `json:"redirect_url"`
+	Apple                 OAuthProviderConfiguration `json:"apple"`
+	Azure                 OAuthProviderConfiguration `json:"azure"`
+	Bitbucket             OAuthProviderConfiguration `json:"bitbucket"`
+	Discord               OAuthProviderConfiguration `json:"discord"`
+	Facebook              OAuthProviderConfiguration `json:"facebook"`
+	Github                OAuthProviderConfiguration `json:"github"`
+	Gitlab                OAuthProviderConfiguration `json:"gitlab"`
+	Google                OAuthProviderConfiguration `json:"google"`
+	Notion                OAuthProviderConfiguration `json:"notion"`
+	Keycloak              OAuthProviderConfiguration `json:"keycloak"`
+	Linkedin              OAuthProviderConfiguration `json:"linkedin"`
+	Spotify               OAuthProviderConfiguration `json:"spotify"`
+	Slack                 OAuthProviderConfiguration `json:"slack"`
+	Twitter               OAuthProviderConfiguration `json:"twitter"`
+	Twitch                OAuthProviderConfiguration `json:"twitch"`
+	WorkOS                OAuthProviderConfiguration `json:"workos"`
+	Email                 EmailProviderConfiguration `json:"email"`
+	Phone                 PhoneProviderConfiguration `json:"phone"`
+	Zoom                  OAuthProviderConfiguration `json:"zoom"`
+	IosBundleId           string                     `json:"ios_bundle_id" split_words:"true"`
+	RedirectURL           string                     `json:"redirect_url"`
+	AllowedIdTokenIssuers []string                   `json:"allowed_id_token_issuers" split_words:"true"`
 }
 
 type SMTPConfiguration struct {
@@ -408,6 +409,10 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 	}
 	if config.MFA.ChallengeExpiryDuration < defaultChallengeExpiryDuration {
 		config.MFA.ChallengeExpiryDuration = defaultChallengeExpiryDuration
+	}
+
+	if len(config.External.AllowedIdTokenIssuers) == 0 {
+		config.External.AllowedIdTokenIssuers = append(config.External.AllowedIdTokenIssuers, "https://appleid.apple.com", "https://accounts.google.com")
 	}
 
 	return nil


### PR DESCRIPTION
Allows the explicit configuration of the ID token flow with freeform issuers. Given this is a deprecated functionality for security reasons, a warning log is emitted.