### PR TITLE
feat: use correct provider name with freeform OIDC token flow

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -475,7 +475,12 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 		var terr error
 		var identity *models.Identity
 
-		if identity, terr = models.FindIdentityByIdAndProvider(tx, sub, params.Provider); terr != nil {
+		provider := params.Provider
+		if provider == "" {
+			provider = params.Issuer
+		}
+
+		if identity, terr = models.FindIdentityByIdAndProvider(tx, sub, provider); terr != nil {
 			// create new identity & user if identity is not found
 			if models.IsNotFoundError(terr) {
 				if config.DisableSignup {
@@ -493,7 +498,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 				if terr != nil {
 					return terr
 				}
-				if _, terr = a.createNewIdentity(tx, user, params.Provider, claims); terr != nil {
+				if _, terr = a.createNewIdentity(tx, user, provider, claims); terr != nil {
 					return terr
 				}
 			} else {

--- a/migrations/20230207170521_backfill_empty_identity_provider.up.sql
+++ b/migrations/20230207170521_backfill_empty_identity_provider.up.sql
@@ -1,0 +1,7 @@
+update {{ index .Options "Namespace" }}.identities
+  set
+    provider = identity_data->>'iss'
+  where
+    provider = '' and 
+    identity_data->>'iss' is not null and 
+    identity_data->>'iss' != '';


### PR DESCRIPTION
Adds a migration that will back-fill `provider` in `identities` with the `iss` field in `identity_data` if available. New OIDC ID token flows with a freeform issuer will use the issuer as the provider ID in the `identities` table.