### PR TITLE
fix: garbled text in sms message when message contains unicode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,7 @@ require (
 	github.com/tinylib/msgp v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
+	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
 	golang.org/x/sys v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb h1:PaBZQdo+iSDyHT053FjUCgZQ/9uqVwPOcl7KSWhKn6w=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/api/sms_provider/sms_provider_test.go
+++ b/internal/api/sms_provider/sms_provider_test.go
@@ -177,7 +177,6 @@ func (ts *SmsProviderTestSuite) TestVonageSendSms() {
 		"text":       {message},
 		"api_key":    {vonageProvider.Config.ApiKey},
 		"api_secret": {vonageProvider.Config.ApiSecret},
-		"type": 	  {"unicode"},
 	}
 
 	gock.New(vonageProvider.APIPath).Post("").MatchType("url").BodyString(body.Encode()).Reply(200).JSON(VonageResponse{

--- a/internal/api/sms_provider/sms_provider_test.go
+++ b/internal/api/sms_provider/sms_provider_test.go
@@ -7,10 +7,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/supabase/gotrue/internal/conf"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -177,6 +177,7 @@ func (ts *SmsProviderTestSuite) TestVonageSendSms() {
 		"text":       {message},
 		"api_key":    {vonageProvider.Config.ApiKey},
 		"api_secret": {vonageProvider.Config.ApiSecret},
+		"type": 	  {"unicode"},
 	}
 
 	gock.New(vonageProvider.APIPath).Post("").MatchType("url").BodyString(body.Encode()).Reply(200).JSON(VonageResponse{

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/utilities"
+	"golang.org/x/exp/utf8string"
 )
 
 const (
@@ -51,7 +52,11 @@ func (t *VonageProvider) SendSms(phone string, message string) error {
 		"text":       {message},
 		"api_key":    {t.Config.ApiKey},
 		"api_secret": {t.Config.ApiSecret},
-		"type": 	  {"unicode"},
+	}
+
+	isMessageContainUnicode := !utf8string.NewString(message).IsASCII()
+	if isMessageContainUnicode {
+		body.Set("type", "unicode")
 	}
 
 	client := &http.Client{Timeout: defaultTimeout}

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -51,6 +51,7 @@ func (t *VonageProvider) SendSms(phone string, message string) error {
 		"text":       {message},
 		"api_key":    {t.Config.ApiKey},
 		"api_secret": {t.Config.ApiSecret},
+		"type": 	  {"unicode"},
 	}
 
 	client := &http.Client{Timeout: defaultTimeout}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
When the message contains Chinese / Japanese character, the message will be displayed in garbled text.
![sms_1](https://user-images.githubusercontent.com/9113255/218958495-be0f1f71-4ef1-40c2-b8e1-22d02d263f12.png)

## What is the new behavior?
If the message contains unicode character, set 'type' to 'unicode' in the request payload before making the request to vonage api server
![sms_2](https://user-images.githubusercontent.com/9113255/218959379-468dd2a4-634f-4ec8-803a-55385c30e76b.png)

