### PR TITLE
chore: bump gofmt and go version to 1.20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
     types: [completed]
     branches:
       - master
-      - mfa
       - zerosessionidfix
       - lastsigninatfix
 
@@ -40,7 +39,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.19.0" # The Go version to download (if necessary) and use.
+          go-version: "^1.20.0" # The Go version to download (if necessary) and use.
 
       - run: make deps
       - run: make all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
     runs-on: ubuntu-20.04
     services:
       postgres:

--- a/cmd/admin_cmd.go
+++ b/cmd/admin_cmd.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 var autoconfirm, isAdmin bool

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"context"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/observability"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/observability"
 )
 
 var configFile = ""

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"net"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/supabase/gotrue/internal/api"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/utilities"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 var serveCmd = cobra.Command{

--- a/cmd/version_cmd.go
+++ b/cmd/version_cmd.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/supabase/gotrue/internal/utilities"
 	"github.com/spf13/cobra"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 var versionCmd = cobra.Command{

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -11,11 +11,11 @@ import (
 	"github.com/fatih/structs"
 	"github.com/go-chi/chi"
 	"github.com/gofrs/uuid"
+	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/gotrue/internal/api/provider"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/sethvargo/go-password/password"
 )
 
 type AdminUserParams struct {

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type AdminTestSuite struct {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -9,13 +9,13 @@ import (
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"
 	"github.com/go-chi/chi"
+	"github.com/rs/cors"
+	"github.com/sebest/xff"
+	"github.com/sirupsen/logrus"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/mailer"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/rs/cors"
-	"github.com/sebest/xff"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/storage/test"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type AuditTestSuite struct {

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type AuthTestSuite struct {

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"runtime/debug"
 
+	"github.com/pkg/errors"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/utilities"
-	"github.com/pkg/errors"
 )
 
 // Common error messages during signup flow

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -12,12 +12,12 @@ import (
 	"github.com/fatih/structs"
 	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
+	"github.com/sirupsen/logrus"
 	"github.com/supabase/gotrue/internal/api/provider"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/utilities"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 

--- a/internal/api/external_github_test.go
+++ b/internal/api/external_github_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalGithub() {

--- a/internal/api/external_oauth.go
+++ b/internal/api/external_oauth.go
@@ -6,10 +6,10 @@ import (
 	"net/url"
 
 	"github.com/mrjones/oauth"
+	"github.com/sirupsen/logrus"
 	"github.com/supabase/gotrue/internal/api/provider"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/sirupsen/logrus"
 )
 
 // OAuthProviderData contains the userData and token returned by the oauth provider

--- a/internal/api/external_test.go
+++ b/internal/api/external_test.go
@@ -6,10 +6,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type ExternalTestSuite struct {

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -10,11 +10,11 @@ import (
 	"net/url"
 
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/utilities"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func addRequestID(globalConfig *conf.GlobalConfiguration) middlewareHandler {

--- a/internal/api/hook_test.go
+++ b/internal/api/hook_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // withFunctionHooks adds the provided function hooks to the context.

--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type InviteTestSuite struct {

--- a/internal/api/logout_test.go
+++ b/internal/api/logout_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type LogoutTestSuite struct {

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/sethvargo/go-password/password"
 )
 
 // MagicLinkParams holds the parameters for a magic link request

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/badoux/checkmail"
 	"github.com/fatih/structs"
+	"github.com/pkg/errors"
+	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/gotrue/internal/api/provider"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/mailer"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/pkg/errors"
-	"github.com/sethvargo/go-password/password"
 )
 
 var (

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt"
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type MailTestSuite struct {

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -12,11 +12,11 @@ import (
 	svg "github.com/ajstarks/svgo"
 	"github.com/boombuler/barcode/qr"
 	"github.com/gofrs/uuid"
+	"github.com/pquerna/otp/totp"
 	"github.com/supabase/gotrue/internal/metering"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/utilities"
-	"github.com/pquerna/otp/totp"
 )
 
 const DefaultQRSize = 3

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pquerna/otp"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/utilities"
-	"github.com/pquerna/otp"
 
 	"github.com/jackc/pgx/v4"
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/supabase/gotrue/internal/conf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
 )
 
 const (

--- a/internal/api/opentelemetry-tracer_test.go
+++ b/internal/api/opentelemetry-tracer_test.go
@@ -5,11 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/storage"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"

--- a/internal/api/opentracer_test.go
+++ b/internal/api/opentracer_test.go
@@ -5,13 +5,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/storage"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/storage"
 )
 
 type OpenTracerTestSuite struct {

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/gotrue/internal/api/sms_provider"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/sethvargo/go-password/password"
 )
 
 // OtpParams contains the request body params for the otp endpoint

--- a/internal/api/otp_test.go
+++ b/internal/api/otp_test.go
@@ -7,11 +7,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type OtpTestSuite struct {

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/supabase/gotrue/internal/api/sms_provider"
 	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/pkg/errors"
 )
 
 const e164Format = `^[1-9]\d{1,14}$`

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -11,12 +11,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type PhoneTestSuite struct {

--- a/internal/api/recover_test.go
+++ b/internal/api/recover_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type RecoverTestSuite struct {

--- a/internal/api/resend_test.go
+++ b/internal/api/resend_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type ResendTestSuite struct {

--- a/internal/api/saml_test.go
+++ b/internal/api/saml_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 
 	"github.com/crewjam/saml"
-	"github.com/supabase/gotrue/internal/conf"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/internal/conf"
 )
 
 func TestSAMLMetadataWithAPI(t *tst.T) {

--- a/internal/api/samlassertion_test.go
+++ b/internal/api/samlassertion_test.go
@@ -6,8 +6,8 @@ import (
 	"encoding/xml"
 
 	"github.com/crewjam/saml"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 func TestSAMLAssertionUserID(t *tst.T) {

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/fatih/structs"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/supabase/gotrue/internal/api/provider"
 	"github.com/supabase/gotrue/internal/api/sms_provider"
 	"github.com/supabase/gotrue/internal/metering"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/pkg/errors"
 )
 
 // SignupParams are the parameters the Signup endpoint accepts

--- a/internal/api/signup_test.go
+++ b/internal/api/signup_test.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type SignupTestSuite struct {

--- a/internal/api/sms_provider/sms_provider_test.go
+++ b/internal/api/sms_provider/sms_provider_test.go
@@ -7,10 +7,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/supabase/gotrue/internal/conf"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
 	"gopkg.in/h2non/gock.v1"
 )
 

--- a/internal/api/sso_test.go
+++ b/internal/api/sso_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 const dateInPast = "2001-02-03T04:05:06.789"

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type TokenTestSuite struct {

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type UserTestSuite struct {

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/sethvargo/go-password/password"
 )
 
 var (

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type VerifyTestSuite struct {

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -3,10 +3,10 @@ package mailer
 import (
 	"net/url"
 
-	"github.com/supabase/gotrue/internal/conf"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/netlify/mailme"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/models"
 	"gopkg.in/gomail.v2"
 )
 

--- a/internal/models/amr.go
+++ b/internal/models/amr.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/supabase/gotrue/internal/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/internal/storage"
 )
 
 type AMRClaim struct {

--- a/internal/models/audit_log_entry.go
+++ b/internal/models/audit_log_entry.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"github.com/supabase/gotrue/internal/observability"
-	"github.com/supabase/gotrue/internal/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/internal/observability"
+	"github.com/supabase/gotrue/internal/storage"
 )
 
 type AuditAction string

--- a/internal/models/challenge.go
+++ b/internal/models/challenge.go
@@ -3,8 +3,8 @@ package models
 import (
 	"database/sql"
 	"github.com/gofrs/uuid"
-	"github.com/supabase/gotrue/internal/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/internal/storage"
 	"time"
 )
 

--- a/internal/models/db_test.go
+++ b/internal/models/db_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/pop/v5"
-	"github.com/supabase/gotrue/internal/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 func TestTableNameNamespacing(t *testing.T) {

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/supabase/gotrue/internal/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/internal/storage"
 )
 
 type FactorState int

--- a/internal/models/factor_test.go
+++ b/internal/models/factor_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/storage/test"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type FactorTestSuite struct {

--- a/internal/models/identity.go
+++ b/internal/models/identity.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/supabase/gotrue/internal/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/internal/storage"
 )
 
 type Identity struct {

--- a/internal/models/identity_test.go
+++ b/internal/models/identity_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/storage/test"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type IdentityTestSuite struct {

--- a/internal/models/linking_test.go
+++ b/internal/models/linking_test.go
@@ -3,11 +3,11 @@ package models
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/storage/test"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type AccountLinkingTestSuite struct {

--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/pkg/errors"
 )
 
 // RefreshToken is the database model for refresh tokens.

--- a/internal/models/refresh_token_test.go
+++ b/internal/models/refresh_token_test.go
@@ -4,11 +4,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/storage/test"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type RefreshTokenTestSuite struct {

--- a/internal/models/sessions.go
+++ b/internal/models/sessions.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
-	"github.com/supabase/gotrue/internal/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/internal/storage"
 )
 
 type AuthenticatorAssuranceLevel int

--- a/internal/models/sessions_test.go
+++ b/internal/models/sessions_test.go
@@ -1,11 +1,11 @@
 package models
 
 import (
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/storage/test"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
 )

--- a/internal/models/sso.go
+++ b/internal/models/sso.go
@@ -10,8 +10,8 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/gofrs/uuid"
-	"github.com/supabase/gotrue/internal/storage"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/internal/storage"
 )
 
 type SSOProvider struct {

--- a/internal/models/sso_test.go
+++ b/internal/models/sso_test.go
@@ -3,11 +3,11 @@ package models
 import (
 	tst "testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/storage/test"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type SSOTestSuite struct {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/storage"
-	"github.com/pkg/errors"
 )
 
 // User respresents a registered user with email/password authentication

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -3,13 +3,13 @@ package models
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/storage/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 const modelsTestConfig = "../../hack/test.env"

--- a/internal/observability/logging.go
+++ b/internal/observability/logging.go
@@ -7,8 +7,8 @@ import (
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gobuffalo/pop/v5/logging"
-	"github.com/supabase/gotrue/internal/conf"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/internal/conf"
 	"go.opentelemetry.io/otel"
 )
 

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/supabase/gotrue/internal/conf"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/internal/conf"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"

--- a/internal/observability/request-logger.go
+++ b/internal/observability/request-logger.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	chimiddleware "github.com/go-chi/chi/middleware"
-	"github.com/supabase/gotrue/internal/utilities"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 func NewStructuredLogger(logger *logrus.Logger) func(next http.Handler) http.Handler {

--- a/internal/observability/tracing.go
+++ b/internal/observability/tracing.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/utilities"
-	"github.com/sirupsen/logrus"
 
 	"github.com/opentracing/opentracing-go"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"

--- a/internal/security/hcaptcha.go
+++ b/internal/security/hcaptcha.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/supabase/gotrue/internal/utilities"
 	"github.com/pkg/errors"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 type GotrueRequest struct {

--- a/internal/storage/dial.go
+++ b/internal/storage/dial.go
@@ -11,9 +11,9 @@ import (
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gobuffalo/pop/v5/columns"
 	"github.com/jmoiron/sqlx"
-	"github.com/supabase/gotrue/internal/conf"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/internal/conf"
 )
 
 // Connection is the interface a storage provider must implement.

--- a/main.go
+++ b/main.go
@@ -7,10 +7,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/supabase/gotrue/cmd"
 	"github.com/supabase/gotrue/internal/api"
 	"github.com/supabase/gotrue/internal/observability"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {


### PR DESCRIPTION
new version of gofmt was released on 14th  which seems to enforce lexicographic import are formatte and so it seems like running gofmt will now enforce lexicographic ordering on imports