### PR TITLE
fix: Change Dockerfile.dev target from netlify to Supabase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as build
+FROM golang:1.20-alpine as build
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux
@@ -16,7 +16,7 @@ COPY . /go/src/github.com/supabase/gotrue
 RUN make build
 
 FROM alpine:3.17
-RUN adduser -D -u 1000 netlify
+RUN adduser -D -u 1000 supabase
 
 RUN apk add --no-cache ca-certificates
 COPY --from=build /go/src/github.com/supabase/gotrue/gotrue /usr/local/bin/gotrue
@@ -24,5 +24,5 @@ COPY --from=build /go/src/github.com/supabase/gotrue/migrations /usr/local/etc/g
 
 ENV GOTRUE_DB_MIGRATIONS_PATH /usr/local/etc/gotrue/migrations
 
-USER netlify
+USER supabase
 CMD ["gotrue"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,7 @@ ENV GOOS=linux
 
 RUN apk add --no-cache make git bash
 
-WORKDIR /go/src/github.com/netlify/gotrue
+WORKDIR /go/src/github.com/supabase/gotrue
 
 # Pulling dependencies
 COPY ./Makefile ./go.* ./

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "Gotrue",
   "description": "",
   "website": "https://www.gotrueapi.org",
-  "repository": "https://github.com/netlify/gotrue",
+  "repository": "https://github.com/supabase/gotrue",
   "env": {
     "DATABASE_URL": {},
     "GOTRUE_DB_DRIVER": {

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,6 @@
 
 [[redirects]]
 from = "/*"
-to = "https://github.com/netlify/gotrue"
+to = "https://github.com/supabase/gotrue"
 status = 302
 force = true


### PR DESCRIPTION
Further renaming from netlify -> Supabase. Main change here is on the dev set up - if one cleans out existing image +  volumes + cache and runs `make dev` the build step will error with `"Failed to load configuration: open .env.docker: no such file or directory` as Docker will look in `/go/src/github.com/netlify/gotrue` instead of `/go/src/github.com/supabase/gotrue`