### PR TITLE
Remove email scope as default

### DIFF
--- a/internal/api/provider/discord.go
+++ b/internal/api/provider/discord.go
@@ -38,7 +38,6 @@ func NewDiscordProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAu
 	apiPath := chooseHost(ext.URL, defaultDiscordAPIBase) + "/api"
 
 	oauthScopes := []string{
-		"email",
 		"identify",
 	}
 


### PR DESCRIPTION
See #956. This needs to be tested in order to ensure that flow doesn't break with the removal of scope