### PR TITLE
fix: nil pointer dereference in stale SAML metadata check

### DIFF
--- a/internal/api/samlacs.go
+++ b/internal/api/samlacs.go
@@ -143,6 +143,8 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
+	samlMetadataModified := false
+
 	if ssoProvider.SAMLProvider.MetadataURL == nil {
 		if !idpMetadata.ValidUntil.IsZero() && time.Until(idpMetadata.ValidUntil) <= (30*24*60)*time.Second {
 			logentry := log.WithField("sso_provider_id", ssoProvider.ID.String())
@@ -152,11 +154,7 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 
 			logentry.Warn("SAML Metadata for identity provider will expire soon! Update its metadata_xml!")
 		}
-	}
-
-	var samlMetadataModified bool
-	samlMetadataModified = false
-	if *ssoProvider.SAMLProvider.MetadataURL != "" && IsMetadataStale(idpMetadata, ssoProvider.SAMLProvider) {
+	} else if *ssoProvider.SAMLProvider.MetadataURL != "" && IsMetadataStale(idpMetadata, ssoProvider.SAMLProvider) {
 		rawMetadata, err := fetchSAMLMetadata(ctx, *ssoProvider.SAMLProvider.MetadataURL)
 		if err != nil {
 			// Fail silently but raise warning and continue with existing metadata
@@ -169,7 +167,6 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 			ssoProvider.SAMLProvider.MetadataXML = string(rawMetadata)
 			samlMetadataModified = true
 		}
-
 	}
 
 	serviceProvider := a.getSAMLServiceProvider(idpMetadata, initiatedBy == "idp")


### PR DESCRIPTION
In #833 we added code to check if the SAML metadata needs to be updated when added via the metadata URL. However, this code crashed due to a nil pointer dereference when MetadataURL was nil.