### PR TITLE
feat: support for whatsapp as a channel for sending OTPs 

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -20,6 +20,8 @@ var (
 	UserExistsError   error = errors.New("user already exists")
 )
 
+const InvalidChannelError = "Invalid channel, supported values are 'sms' or 'whatsapp'"
+
 var oauthErrorMap = map[int]string{
 	http.StatusBadRequest:          "invalid_request",
 	http.StatusUnauthorized:        "unauthorized_client",

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -165,7 +165,9 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = db.Transaction(func(tx *storage.Connection) error {
-		if err := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); err != nil {
+		if err := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", map[string]interface{}{
+			"channel": params.Channel,
+		}); err != nil {
 			return err
 		}
 		smsProvider, terr := sms_provider.GetSmsProvider(*config)

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -88,8 +88,12 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read sms otp params: %v", err)
 	}
-	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
+	// For backwards compatibility, we default to SMS if params Channel is not specified
+	if params.Phone != "" && params.Channel == "" {
 		params.Channel = sms_provider.SMSProvider
+	}
+	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
+		return badRequestError("Invalid Channel. Please use 'sms' or 'whatsapp'")
 	}
 
 	if params.Data == nil {

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -91,6 +91,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
 		params.Channel = sms_provider.SMSProvider
 	}
+
 	if params.Data == nil {
 		params.Data = make(map[string]interface{})
 	}
@@ -125,6 +126,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 			Phone:    params.Phone,
 			Password: password,
 			Data:     params.Data,
+			Channel:  params.Channel,
 		}
 		newBodyContent, err := json.Marshal(signUpParams)
 		if err != nil {
@@ -141,7 +143,8 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 			}
 
 			signUpParams := &SignupParams{
-				Phone: params.Phone,
+				Phone:   params.Phone,
+				Channel: params.Channel,
 			}
 			newBodyContent, err := json.Marshal(signUpParams)
 			if err != nil {

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -93,7 +93,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 		params.Channel = sms_provider.SMSProvider
 	}
 	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
-		return badRequestError("Invalid Channel. Please use 'sms' or 'whatsapp'")
+		return badRequestError(InvalidChannelError)
 	}
 
 	if params.Data == nil {

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -90,7 +90,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	}
 	// TODO(Joel): Block for non-Twilio SMS providers
 	if params.Phone != "" && params.Channel == "" {
-		params.Channel = "sms"
+		params.Channel = sms_provider.SMSProvider
 	}
 	if params.Data == nil {
 		params.Data = make(map[string]interface{})

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -88,8 +88,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	if err := json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read sms otp params: %v", err)
 	}
-	// TODO(Joel): Block for non-Twilio SMS providers
-	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel) {
+	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
 		params.Channel = sms_provider.SMSProvider
 	}
 	if params.Data == nil {

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -89,7 +89,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read sms otp params: %v", err)
 	}
 	// TODO(Joel): Block for non-Twilio SMS providers
-	if params.Phone != "" && params.Channel == "" {
+	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel) {
 		params.Channel = sms_provider.SMSProvider
 	}
 	if params.Data == nil {

--- a/internal/api/otp_test.go
+++ b/internal/api/otp_test.go
@@ -35,11 +35,12 @@ func TestOtp(t *testing.T) {
 
 func (ts *OtpTestSuite) SetupTest() {
 	models.TruncateAll(ts.API.db)
-	// Configured to allow testing of invalid channel params
-	ts.Config.External.Phone.Enabled = true
+
 }
 
 func (ts *OtpTestSuite) TestOtp() {
+	// Configured to allow testing of invalid channel params
+	ts.Config.External.Phone.Enabled = true
 	cases := []struct {
 		desc     string
 		params   OtpParams

--- a/internal/api/otp_test.go
+++ b/internal/api/otp_test.go
@@ -98,7 +98,7 @@ func (ts *OtpTestSuite) TestOtp() {
 				http.StatusBadRequest,
 				map[string]interface{}{
 					"code": float64(http.StatusBadRequest),
-					"msg":  "Invalid Channel. Please use 'sms' or 'whatsapp'",
+					"msg":  InvalidChannelError,
 				},
 			},
 		},

--- a/internal/api/otp_test.go
+++ b/internal/api/otp_test.go
@@ -35,6 +35,8 @@ func TestOtp(t *testing.T) {
 
 func (ts *OtpTestSuite) SetupTest() {
 	models.TruncateAll(ts.API.db)
+	// Configured to allow testing of invalid channel params
+	ts.Config.External.Phone.Enabled = true
 }
 
 func (ts *OtpTestSuite) TestOtp() {
@@ -78,6 +80,24 @@ func (ts *OtpTestSuite) TestOtp() {
 				map[string]interface{}{
 					"code": float64(http.StatusBadRequest),
 					"msg":  "Only an email address or phone number should be provided",
+				},
+			},
+		},
+		{
+			desc: "Test Failure invalid channel param",
+			params: OtpParams{
+				Phone:      "123456789",
+				Channel:    "invalidchannel",
+				CreateUser: true,
+			},
+			expected: struct {
+				code     int
+				response map[string]interface{}
+			}{
+				http.StatusBadRequest,
+				map[string]interface{}{
+					"code": float64(http.StatusBadRequest),
+					"msg":  "Invalid Channel. Please use 'sms' or 'whatsapp'",
 				},
 			},
 		},

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -44,7 +44,7 @@ func formatPhoneNumber(phone string) string {
 }
 
 // sendPhoneConfirmation sends an otp to the user's phone number
-func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection, user *models.User, phone, otpType string, smsProvider sms_provider.SmsProvider) error {
+func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection, user *models.User, phone, otpType string, smsProvider sms_provider.SmsProvider, channel string) error {
 	config := a.config
 
 	var token *string
@@ -87,7 +87,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 		message = strings.Replace(config.Sms.Template, "{{ .Code }}", otp, -1)
 	}
 
-	if serr := smsProvider.SendSms(phone, message); serr != nil {
+	if serr := smsProvider.SendMessage(phone, message, "sms"); serr != nil {
 		*token = oldToken
 		return serr
 	}

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -87,7 +87,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 		message = strings.Replace(config.Sms.Template, "{{ .Code }}", otp, -1)
 	}
 
-	if serr := smsProvider.SendMessage(phone, message, "sms"); serr != nil {
+	if serr := smsProvider.SendMessage(phone, message, channel); serr != nil {
 		*token = oldToken
 		return serr
 	}

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/supabase/gotrue/internal/api/sms_provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -98,7 +99,7 @@ func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
 
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
-			err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, &TestSmsProvider{}, "sms")
+			err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, &TestSmsProvider{}, sms_provider.SMSProvider)
 			require.Equal(ts.T(), c.expected, err)
 			u, err = models.FindUserByPhoneAndAudience(ts.API.db, "123456789", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/supabase/gotrue/internal/api/sms_provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/supabase/gotrue/internal/api/sms_provider"
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/models"
 )

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -29,7 +29,7 @@ type TestSmsProvider struct {
 	mock.Mock
 }
 
-func (t *TestSmsProvider) SendSms(phone string, message string) error {
+func (t *TestSmsProvider) SendMessage(phone string, message string, channel string) error {
 	return nil
 }
 
@@ -98,7 +98,7 @@ func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
 
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
-			err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, &TestSmsProvider{})
+			err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, &TestSmsProvider{}, "sms")
 			require.Equal(ts.T(), c.expected, err)
 			u, err = models.FindUserByPhoneAndAudience(ts.API.db, "123456789", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -49,7 +49,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return badRequestError("Error sending sms: %v", terr)
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, phone, phoneReauthenticationOtp, smsProvider, "sms")
+			return a.sendPhoneConfirmation(ctx, tx, user, phone, phoneReauthenticationOtp, smsProvider, sms_provider.SMSProvider)
 		}
 		return nil
 	})

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -49,7 +49,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return badRequestError("Error sending sms: %v", terr)
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, phone, phoneReauthenticationOtp, smsProvider)
+			return a.sendPhoneConfirmation(ctx, tx, user, phone, phoneReauthenticationOtp, smsProvider, "sms")
 		}
 		return nil
 	})

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -129,7 +129,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return terr
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, "sms")
+			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, sms_provider.SMSProvider)
 		case emailChangeVerification:
 			return a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, config.Mailer.OtpLength)
 		case phoneChangeVerification:

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -129,7 +129,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return terr
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider)
+			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, "sms")
 		case emailChangeVerification:
 			return a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, config.Mailer.OtpLength)
 		case phoneChangeVerification:
@@ -137,7 +137,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return terr
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider)
+			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider, "sms")
 		}
 		return nil
 	})

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -137,7 +137,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return terr
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider, "sms")
+			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider, sms_provider.SMSProvider)
 		}
 		return nil
 	})

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -66,8 +66,8 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	if params.Data == nil {
 		params.Data = make(map[string]interface{})
 	}
-	if params.Channel != "sms" && params.Channel != "whatsapp" {
-		params.Channel = "sms"
+	if params.Channel != sms_provider.SMSProvider && params.Channel != sms_provider.WhatsappProvider {
+		params.Channel = sms_provider.SMSProvider
 	}
 
 	var user *models.User

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -164,6 +164,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 			if config.Sms.Autoconfirm {
 				if terr = models.NewAuditLogEntry(r, tx, user, models.UserSignedUpAction, "", map[string]interface{}{
 					"provider": params.Provider,
+					"channel":  params.Channel,
 				}); terr != nil {
 					return terr
 				}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -66,7 +66,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	if params.Data == nil {
 		params.Data = make(map[string]interface{})
 	}
-	if !sms_provider.IsValidMessageChannel(params.Channel) {
+	if !sms_provider.IsValidMessageChannel(params.Channel, *config) {
 		params.Channel = sms_provider.SMSProvider
 	}
 

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -66,7 +66,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	if params.Data == nil {
 		params.Data = make(map[string]interface{})
 	}
-	if params.Channel != sms_provider.SMSProvider && params.Channel != sms_provider.WhatsappProvider {
+	if !sms_provider.IsValidMessageChannel(params.Channel) {
 		params.Channel = sms_provider.SMSProvider
 	}
 

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -66,8 +66,14 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	if params.Data == nil {
 		params.Data = make(map[string]interface{})
 	}
-	if params.Provider == "phone" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
+
+	// For backwards compatibility, we default to SMS if params Channel is not specified
+	if params.Phone != "" && params.Channel == "" {
 		params.Channel = sms_provider.SMSProvider
+	}
+
+	if params.Provider == "phone" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
+		return badRequestError("Invalid channel type. Please use whatsapp or sms")
 	}
 
 	var user *models.User

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -66,7 +66,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	if params.Data == nil {
 		params.Data = make(map[string]interface{})
 	}
-	if !sms_provider.IsValidMessageChannel(params.Channel, *config) {
+	if params.Provider == "phone" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
 		params.Channel = sms_provider.SMSProvider
 	}
 

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -25,6 +25,7 @@ type SignupParams struct {
 	Data     map[string]interface{} `json:"data"`
 	Provider string                 `json:"-"`
 	Aud      string                 `json:"-"`
+	Channel  string                 `json:"channel"`
 }
 
 // Signup is the endpoint for registering a new user
@@ -64,6 +65,9 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	}
 	if params.Data == nil {
 		params.Data = make(map[string]interface{})
+	}
+	if params.Channel != "sms" && params.Channel != "whatsapp" {
+		params.Channel = "sms"
 	}
 
 	var user *models.User
@@ -173,7 +177,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				if terr != nil {
 					return badRequestError("Error sending confirmation sms: %v", terr)
 				}
-				if terr = a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider); terr != nil {
+				if terr = a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, params.Channel); terr != nil {
 					return badRequestError("Error sending confirmation sms: %v", terr)
 				}
 			}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -73,7 +73,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Provider == "phone" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
-		return badRequestError("Invalid channel type. Please use whatsapp or sms")
+		return badRequestError(InvalidChannelError)
 	}
 
 	var user *models.User

--- a/internal/api/sms_provider/messagebird.go
+++ b/internal/api/sms_provider/messagebird.go
@@ -55,6 +55,15 @@ func NewMessagebirdProvider(config conf.MessagebirdProviderConfiguration) (SmsPr
 	}, nil
 }
 
+func (t *MessagebirdProvider) SendMessage(phone string, message string, messageType string) error {
+	switch messageType {
+	case "sms":
+		return t.SendSms(phone, message)
+	default:
+		return nil
+	}
+}
+
 // Send an SMS containing the OTP with Messagebird's API
 func (t *MessagebirdProvider) SendSms(phone string, message string) error {
 	body := url.Values{

--- a/internal/api/sms_provider/messagebird.go
+++ b/internal/api/sms_provider/messagebird.go
@@ -2,7 +2,6 @@ package sms_provider
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -61,7 +60,7 @@ func (t *MessagebirdProvider) SendMessage(phone string, message string, channel 
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
-		return errors.New("channel type is not supported for Vonage")
+		return fmt.Errorf("channel type %q is not supported for Messagebird", channel)
 	}
 }
 

--- a/internal/api/sms_provider/messagebird.go
+++ b/internal/api/sms_provider/messagebird.go
@@ -2,11 +2,11 @@ package sms_provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
-	"errors"
 
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/utilities"

--- a/internal/api/sms_provider/messagebird.go
+++ b/internal/api/sms_provider/messagebird.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"errors"
 
 	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/utilities"
@@ -55,12 +56,12 @@ func NewMessagebirdProvider(config conf.MessagebirdProviderConfiguration) (SmsPr
 	}, nil
 }
 
-func (t *MessagebirdProvider) SendMessage(phone string, message string, messageType string) error {
-	switch messageType {
+func (t *MessagebirdProvider) SendMessage(phone string, message string, channel string) error {
+	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
-		return nil
+		return errors.New("channel type is not supported for Vonage")
 	}
 }
 

--- a/internal/api/sms_provider/messagebird.go
+++ b/internal/api/sms_provider/messagebird.go
@@ -57,7 +57,7 @@ func NewMessagebirdProvider(config conf.MessagebirdProviderConfiguration) (SmsPr
 
 func (t *MessagebirdProvider) SendMessage(phone string, message string, messageType string) error {
 	switch messageType {
-	case "sms":
+	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
 		return nil

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -11,6 +11,9 @@ import (
 
 var defaultTimeout time.Duration = time.Second * 10
 
+const SMSProvider = "sms"
+const WhatsappProvider = "whatsapp"
+
 func init() {
 	timeoutStr := os.Getenv("GOTRUE_INTERNAL_HTTP_TIMEOUT")
 	if timeoutStr != "" {

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -45,5 +45,12 @@ func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {
 }
 
 func IsValidMessageChannel(channel string, config conf.GlobalConfiguration) bool {
-	return (channel == SMSProvider || channel == WhatsappProvider) && config.Sms.Provider == "twilio"
+	switch {
+	case channel == SMSProvider:
+		return true
+	case channel == WhatsappProvider && config.Sms.Provider == "twilio":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -44,6 +44,6 @@ func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {
 	}
 }
 
-func IsValidMessageChannel(channel string) bool {
-	return channel == SMSProvider || channel == WhatsappProvider
+func IsValidMessageChannel(channel string, config conf.GlobalConfiguration) bool {
+	return (channel == SMSProvider || channel == WhatsappProvider) && config.Sms.Provider == "twilio"
 }

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -43,3 +43,7 @@ func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {
 		return nil, fmt.Errorf("sms Provider %s could not be found", name)
 	}
 }
+
+func IsValidMessageChannel(channel string) bool {
+	return channel == SMSProvider || channel == WhatsappProvider
+}

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 type SmsProvider interface {
-	SendSms(phone, message string) error
+	SendMessage(phone, message, messageType string) error
 }
 
 func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 type SmsProvider interface {
-	SendMessage(phone, message, messageType string) error
+	SendMessage(phone, message, channel string) error
 }
 
 func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -45,11 +45,11 @@ func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {
 }
 
 func IsValidMessageChannel(channel string, config conf.GlobalConfiguration) bool {
-	switch {
-	case channel == SMSProvider:
+	switch channel {
+	case SMSProvider:
 		return true
-	case channel == WhatsappProvider && config.Sms.Provider == "twilio":
-		return true
+	case WhatsappProvider:
+		return config.Sms.Provider == "twilio"
 	default:
 		return false
 	}

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -44,8 +44,8 @@ func NewTextlocalProvider(config conf.TextlocalProviderConfiguration) (SmsProvid
 	}, nil
 }
 
-func (t *TextlocalProvider) SendMessage(phone string, message string, messageType string) error {
-	switch messageType {
+func (t *TextlocalProvider) SendMessage(phone string, message string, channel string) error {
+	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -46,7 +46,7 @@ func NewTextlocalProvider(config conf.TextlocalProviderConfiguration) (SmsProvid
 
 func (t *TextlocalProvider) SendMessage(phone string, message string, messageType string) error {
 	switch messageType {
-	case "sms":
+	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
 		return nil

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -44,6 +44,15 @@ func NewTextlocalProvider(config conf.TextlocalProviderConfiguration) (SmsProvid
 	}, nil
 }
 
+func (t *TextlocalProvider) SendMessage(phone string, message string, messageType string) error {
+	switch messageType {
+	case "sms":
+		return t.SendSms(phone, message)
+	default:
+		return nil
+	}
+}
+
 // Send an SMS containing the OTP with Textlocal's API
 func (t *TextlocalProvider) SendSms(phone string, message string) error {
 	body := url.Values{

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -49,7 +49,7 @@ func (t *TextlocalProvider) SendMessage(phone string, message string, messageTyp
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
-		return nil
+		return errors.New("channel type is not supported for textlocal")
 	}
 }
 

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -49,7 +49,7 @@ func (t *TextlocalProvider) SendMessage(phone string, message string, channel st
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
-		return errors.New("channel type is not supported for textlocal")
+		return fmt.Errorf("channel type %q is not supported for TextLocal", channel)
 	}
 }
 

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -2,7 +2,6 @@ package sms_provider
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -62,7 +61,7 @@ func (t *TwilioProvider) SendMessage(phone string, message string, channel strin
 	case WhatsappProvider:
 		return t.SendWhatsappMessage(phone, message)
 	default:
-		return errors.New("channel type is not supported for Twilio")
+		return fmt.Errorf("channel type %q is not supported for Twilio", channel)
 	}
 }
 

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -87,7 +87,7 @@ func (t *TwilioProvider) SendWhatsappMessage(phone string, message string) error
 	if err != nil {
 		return err
 	}
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		resp := &twilioErrResponse{}
 		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
 			return err

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -54,6 +54,60 @@ func NewTwilioProvider(config conf.TwilioProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
+func (t *TwilioProvider) SendMessage(phone string, message string, messageType string) error {
+	switch messageType {
+	case "sms":
+		return t.SendSms(phone, message)
+	case "whatsapp":
+		return t.SendWhatsappMessage(phone, message)
+	default:
+		return nil
+	}
+}
+
+// Send a Whatsapp message containing the OTP with Twilio's API
+func (t *TwilioProvider) SendWhatsappMessage(phone string, message string) error {
+	body := url.Values{
+		"To":      {"whatsapp:" + "+" + phone}, // twilio api requires "+" extension to be included
+		"Channel": {"whatsapp"},
+		"From":    {"whatsapp:" + t.Config.MessageServiceSid},
+		"Body":    {message},
+	}
+
+	client := &http.Client{Timeout: defaultTimeout}
+	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
+	if err != nil {
+		return err
+	}
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.SetBasicAuth(t.Config.AccountSid, t.Config.AuthToken)
+	res, err := client.Do(r)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode/100 != 2 {
+		resp := &twilioErrResponse{}
+		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
+			return err
+		}
+		return resp
+	}
+	defer utilities.SafeClose(res.Body)
+
+	// validate sms status
+	resp := &SmsStatus{}
+	derr := json.NewDecoder(res.Body).Decode(resp)
+	if derr != nil {
+		return derr
+	}
+
+	if resp.Status == "failed" || resp.Status == "undelivered" {
+		return fmt.Errorf("twilio error: %v %v", resp.ErrorMessage, resp.ErrorCode)
+	}
+
+	return nil
+}
+
 // Send an SMS containing the OTP with Twilio's API
 func (t *TwilioProvider) SendSms(phone string, message string) error {
 	body := url.Values{

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -66,6 +66,7 @@ func (t *TwilioProvider) SendMessage(phone string, message string, channel strin
 }
 
 // Send a Whatsapp message containing the OTP with Twilio's API
+// TODO (J0) Merge with SendSms once stable
 func (t *TwilioProvider) SendWhatsappMessage(phone string, message string) error {
 	body := url.Values{
 		"To":      {"whatsapp:" + "+" + phone}, // twilio api requires "+" extension to be included

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -56,9 +56,9 @@ func NewTwilioProvider(config conf.TwilioProviderConfiguration) (SmsProvider, er
 
 func (t *TwilioProvider) SendMessage(phone string, message string, messageType string) error {
 	switch messageType {
-	case "sms":
+	case SMSProvider:
 		return t.SendSms(phone, message)
-	case "whatsapp":
+	case WhatsappProvider:
 		return t.SendWhatsappMessage(phone, message)
 	default:
 		return nil

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -55,8 +55,8 @@ func NewTwilioProvider(config conf.TwilioProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
-func (t *TwilioProvider) SendMessage(phone string, message string, messageType string) error {
-	switch messageType {
+func (t *TwilioProvider) SendMessage(phone string, message string, channel string) error {
+	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	case WhatsappProvider:

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -44,6 +44,15 @@ func NewVonageProvider(config conf.VonageProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
+func (t *VonageProvider) SendMessage(phone string, message string, messageType string) error {
+	switch messageType {
+	case "sms":
+		return t.SendSms(phone, message)
+	default:
+		return nil
+	}
+}
+
 // Send an SMS containing the OTP with Vonage's API
 func (t *VonageProvider) SendSms(phone string, message string) error {
 	body := url.Values{

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -44,12 +44,12 @@ func NewVonageProvider(config conf.VonageProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
-func (t *VonageProvider) SendMessage(phone string, message string, messageType string) error {
-	switch messageType {
+func (t *VonageProvider) SendMessage(phone string, message string, channel string) error {
+	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
-		return nil
+		return errors.New("channel type is not supported for Vonage")
 	}
 }
 

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -49,7 +49,7 @@ func (t *VonageProvider) SendMessage(phone string, message string, channel strin
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
-		return errors.New("channel type is not supported for Vonage")
+		return fmt.Errorf("channel type %q is not supported for Vonage", channel)
 	}
 }
 

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -46,7 +46,7 @@ func NewVonageProvider(config conf.VonageProviderConfiguration) (SmsProvider, er
 
 func (t *VonageProvider) SendMessage(phone string, message string, messageType string) error {
 	switch messageType {
-	case "sms":
+	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
 		return nil

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -75,7 +75,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			return unprocessableEntityError(DuplicateEmailMsg)
 		}
 	}
-	if params.Channel == "phone" && (params.Channel != sms_provider.WhatsappProvider && params.Channel != sms_provider.SMSProvider) {
+	if params.Channel == "phone" && !sms_provider.IsValidMessageChannel(params.Channel) {
 		params.Channel = sms_provider.SMSProvider
 	}
 

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -75,7 +75,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			return unprocessableEntityError(DuplicateEmailMsg)
 		}
 	}
-	if params.Channel == "phone" && !sms_provider.IsValidMessageChannel(params.Channel) {
+	if params.Channel == "phone" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
 		params.Channel = sms_provider.SMSProvider
 	}
 

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -75,8 +75,11 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			return unprocessableEntityError(DuplicateEmailMsg)
 		}
 	}
-	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
+	if params.Phone != "" && params.Channel == "" {
 		params.Channel = sms_provider.SMSProvider
+	}
+	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
+		return badRequestError("Invalid Channel. Please use 'sms' or 'whatsapp'")
 	}
 
 	if params.Phone != "" && params.Phone != user.GetPhone() {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -193,7 +193,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				if terr != nil {
 					return badRequestError("Error sending sms: %v", terr)
 				}
-				if terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider); terr != nil {
+				if terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider, "sms"); terr != nil {
 					return internalServerError("Error sending phone change otp").WithInternalError(terr)
 				}
 			}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -83,7 +83,6 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if params.Phone != "" && params.Phone != user.GetPhone() {
-
 		params.Phone, err = validatePhone(params.Phone)
 		if err != nil {
 			return err

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -79,7 +79,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		params.Channel = sms_provider.SMSProvider
 	}
 	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
-		return badRequestError("Invalid Channel. Please use 'sms' or 'whatsapp'")
+		return badRequestError(InvalidChannelError)
 	}
 
 	if params.Phone != "" && params.Phone != user.GetPhone() {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -20,6 +20,7 @@ type UserUpdateParams struct {
 	Data     map[string]interface{} `json:"data"`
 	AppData  map[string]interface{} `json:"app_metadata,omitempty"`
 	Phone    string                 `json:"phone"`
+	Channel  string                 `json:"channel"`
 }
 
 // UserGet returns a user
@@ -74,8 +75,12 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			return unprocessableEntityError(DuplicateEmailMsg)
 		}
 	}
+	if params.Channel == "phone" && (params.Channel != "whatsapp" || params.Channel == "sms") {
+		params.Channel = "sms"
+	}
 
 	if params.Phone != "" && params.Phone != user.GetPhone() {
+
 		params.Phone, err = validatePhone(params.Phone)
 		if err != nil {
 			return err
@@ -193,7 +198,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				if terr != nil {
 					return badRequestError("Error sending sms: %v", terr)
 				}
-				if terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider, "sms"); terr != nil {
+				if terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider, params.Channel); terr != nil {
 					return internalServerError("Error sending phone change otp").WithInternalError(terr)
 				}
 			}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -75,7 +75,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			return unprocessableEntityError(DuplicateEmailMsg)
 		}
 	}
-	if params.Channel == "phone" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
+	if params.Phone != "" && !sms_provider.IsValidMessageChannel(params.Channel, *config) {
 		params.Channel = sms_provider.SMSProvider
 	}
 

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -75,8 +75,8 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			return unprocessableEntityError(DuplicateEmailMsg)
 		}
 	}
-	if params.Channel == "phone" && (params.Channel != "whatsapp" || params.Channel == "sms") {
-		params.Channel = "sms"
+	if params.Channel == "phone" && (params.Channel != sms_provider.WhatsappProvider && params.Channel != sms_provider.SMSProvider) {
+		params.Channel = sms_provider.SMSProvider
 	}
 
 	if params.Phone != "" && params.Phone != user.GetPhone() {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -489,6 +489,9 @@ paths:
                   format: phone
                 channel:
                   type: string
+                  enum:
+                    - sms
+                    - whatsapp
                 create_user:
                   type: boolean
                 data:
@@ -557,6 +560,9 @@ paths:
                   type: object
                 channel:
                   type: string
+                  enum:
+                    - sms
+                    - whatsapp
       responses:
         200:
           description: User's updated account information.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -294,6 +294,11 @@ paths:
                 value:
                   phone: "+1234567890"
                   password: password1
+              "phone+password+whatsapp":
+                value:
+                  phone: "+1234567890"
+                  password: password1
+                  channel: whatsapp
             schema:
               type: object
               properties:
@@ -303,6 +308,8 @@ paths:
                 phone:
                   type: string
                   format: phone
+                channel:
+                  type: string
                 password:
                   type: string
                 data:
@@ -477,6 +484,8 @@ paths:
                 phone:
                   type: string
                   format: phone
+                channel:
+                  type: string
                 create_user:
                   type: boolean
                 data:
@@ -543,6 +552,8 @@ paths:
                   type: object
                 app_metadata:
                   type: object
+                channel:
+                  type: string
       responses:
         200:
           description: User's updated account information.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -310,6 +310,9 @@ paths:
                   format: phone
                 channel:
                   type: string
+                  enum:
+                    - sms
+                    - whatsapp
                 password:
                   type: string
                 data:


### PR DESCRIPTION
## What kind of change does this PR introduce?

We wish to support WhatsApp as a channel for sending OTPs due to the added security provided and more. For this first pass, we will only support Twilio. 

Companion PR:
- Frontend:  https://github.com/supabase/gotrue-js/pull/616

For now, we only support Twilio API. We can slowly ungate more providers as needed. There should be no change to the API guarantees otherwise - if the user does not specify `whatsapp` the API will default to SMS.


I've excluded `reauthenticate` and `resend` methods from whatsapp support as we don't currently use them in the client library. I'm not sure whether we plan on supporting them long term so have  left them with SMS as default in order to reduce complexity. Let me know if anyone feels otherwise and we can consider amending.

For now, we also expose the `updateUser` endpoint only on the API level and not at the client library so as to minimize potential breaking changes

**Uncertainties**
- For Supabase, I'll need to check if users can (and want to) use the same Whatsapp and SMS number for sending via Twilio. Otherwise, we may need to introduce additional configuration variables as a last resort.

Testing
- This was manually test and and an existing check for testing channel parameters was added