### PR TITLE
fix: expose x-total-count and link

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -227,6 +227,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 	corsHandler := cors.New(cors.Options{
 		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-Client-IP", "X-Client-Info", audHeaderName, useCookieHeader},
+		ExposedHeaders:   []string{"X-Total-Count", "Link"},
 		AllowCredentials: true,
 	})
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* #980 
* expose the "x-total-count" and "link" headers which are useful for the `GET /admin/users` method