### PR TITLE
feat: make phone data type alter backward compatible

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -740,6 +740,7 @@ func obfuscateEmail(u *User, email string) string {
 }
 
 func obfuscatePhone(u *User, phone string) string {
+        // Field converted from VARCHAR(15) to text
 	return obfuscateValue(u.ID, phone)[:15]
 }
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
-	"fmt"
+	"encoding/base64"
 	"strings"
 	"time"
 
@@ -643,10 +643,10 @@ func (u *User) RemoveUnconfirmedIdentities(tx *storage.Connection) error {
 
 // SoftDeleteUser performs a soft deletion on the user by obfuscating and clearing certain fields
 func (u *User) SoftDeleteUser(tx *storage.Connection) error {
-	u.Email = storage.NullString(obfuscateFieldForSoftDelete(u.GetEmail()))
-	u.Phone = storage.NullString(obfuscateFieldForSoftDelete(u.GetPhone()))
-	u.EmailChange = obfuscateFieldForSoftDelete(u.EmailChange)
-	u.PhoneChange = obfuscateFieldForSoftDelete(u.PhoneChange)
+	u.Email = storage.NullString(obfuscateEmail(u, u.GetEmail()))
+	u.Phone = storage.NullString(obfuscatePhone(u, u.GetPhone()))
+	u.EmailChange = obfuscateEmail(u, u.EmailChange)
+	u.PhoneChange = obfuscatePhone(u, u.PhoneChange)
 	u.EncryptedPassword = ""
 	u.ConfirmationToken = ""
 	u.RecoveryToken = ""
@@ -720,7 +720,7 @@ func (u *User) SoftDeleteUserIdentities(tx *storage.Connection) error {
 			"update "+
 				(&pop.Model{Value: Identity{}}).TableName()+
 				" set id = ? where id = ? and provider = ?",
-			obfuscateFieldForSoftDelete(identity.ID),
+			obfuscateIdentityId(identity),
 			identity.ID,
 			identity.Provider,
 		).Exec(); err != nil {
@@ -730,10 +730,19 @@ func (u *User) SoftDeleteUserIdentities(tx *storage.Connection) error {
 	return nil
 }
 
-func obfuscateFieldForSoftDelete(field string) string {
-	if field != "" {
-		softDeleteId, _ := crypto.GenerateNanoId(5)
-		return fmt.Sprintf("%s-%x", softDeleteId, sha256.Sum256([]byte(field)))
-	}
-	return field
+func obfuscateValue(id uuid.UUID, value string) string {
+	hash := sha256.Sum256([]byte(id.String() + value))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+func obfuscateEmail(u *User, email string) string {
+	return obfuscateValue(u.ID, email)
+}
+
+func obfuscatePhone(u *User, phone string) string {
+	return obfuscateValue(u.ID, phone)[:15]
+}
+
+func obfuscateIdentityId(identity *Identity) string {
+	return obfuscateValue(identity.UserID, identity.Provider+":"+identity.ID)
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -740,7 +740,7 @@ func obfuscateEmail(u *User, email string) string {
 }
 
 func obfuscatePhone(u *User, phone string) string {
-        // Field converted from VARCHAR(15) to text
+	// Field converted from VARCHAR(15) to text
 	return obfuscateValue(u.ID, phone)[:15]
 }
 

--- a/migrations/20230116124310_alter_phone_type.up.sql
+++ b/migrations/20230116124310_alter_phone_type.up.sql
@@ -1,5 +1,12 @@
 -- alter phone field column type to accomodate for soft deletion 
 
-alter table auth.users
-alter column phone type text,
-alter column phone_change type text;
+do $$
+begin
+  alter table {{ index .Options "Namespace" }}.users
+    alter column phone type text,
+    alter column phone_change type text;
+exception
+  -- dependent object: https://www.postgresql.org/docs/current/errcodes-appendix.html
+  when SQLSTATE '2BP01' then
+    raise notice 'Unable to change data type of phone, phone_change columns due to dependent objects';
+end $$;

--- a/migrations/20230116124310_alter_phone_type.up.sql
+++ b/migrations/20230116124310_alter_phone_type.up.sql
@@ -6,7 +6,9 @@ begin
     alter column phone type text,
     alter column phone_change type text;
 exception
-  -- dependent object: https://www.postgresql.org/docs/current/errcodes-appendix.html
+  -- SQLSTATE errcodes https://www.postgresql.org/docs/current/errcodes-appendix.html
+  when SQLSTATE '0A000' then
+    raise notice 'Unable to change data type of phone, phone_change columns due to use by a view or rule';
   when SQLSTATE '2BP01' then
     raise notice 'Unable to change data type of phone, phone_change columns due to dependent objects';
 end $$;


### PR DESCRIPTION
Given that with #489 we added a migration that alters the data type of `users.phone` and `users.phone_change` from `varchar(15)` to `text`, which turns out not to be a backward compatible change due to the inability for the alter to occur if there are views or triggers on the table, this PR does the following:

- Tries to change the data type if possible.
- The soft-delete code is modified to obfuscate phone numbers using Base64-URL and only the first 15 chars so they fit in `varchar(15)`.
- The obfuscation code uses a hash of the user UUID to decrease the likelihood of collisions on shorter values.