### PR TITLE
feat: use lowercase emails to determine account linking

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -219,7 +219,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 
 	for _, email := range userData.Emails {
 		if email.Verified || config.Mailer.Autoconfirm {
-			emails = append(emails, email.Email)
+			emails = append(emails, strings.ToLower(email.Email))
 		}
 	}
 


### PR DESCRIPTION
Although the `auth.identities.email` column is a lowercase column, the input coming from the user's identity at the identity provider may use an email address that contains capital letters. Because the account linking algorithm uses `in` this will be a case-sensitive search.