### PR TITLE
Fix MFA deletion of unverified factors

### DIFF
--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -129,17 +129,6 @@ func DeleteUnverifiedFactors(tx *storage.Connection, user *User) error {
 	return nil
 }
 
-func FindVerifiedFactorsByUser(tx *storage.Connection, user *User) ([]*Factor, error) {
-	factors := []*Factor{}
-	if err := tx.Q().Where("user_id = ? AND status = ?", user.ID, FactorStateVerified.String()).All(&factors); err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
-			return factors, nil
-		}
-		return nil, errors.Wrap(err, "Database error when finding verified MFA factors")
-	}
-	return factors, nil
-}
-
 // UpdateFriendlyName changes the friendly name
 func (f *Factor) UpdateFriendlyName(tx *storage.Connection, friendlyName string) error {
 	f.FriendlyName = friendlyName

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -122,14 +122,7 @@ func findFactor(tx *storage.Connection, query string, args ...interface{}) (*Fac
 }
 
 func DeleteUnverifiedFactors(tx *storage.Connection, user *User) error {
-	factors := []*Factor{}
-	if err := tx.Q().Where("user_id = ? AND status = ?", user.ID, FactorStateUnverified.String()).All(&factors); err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
-			return nil
-		}
-		return errors.Wrap(err, "Database error when finding verified MFA factors")
-	}
-	if err := tx.Destroy(factors); err != nil {
+	if err := tx.RawQuery("DELETE FROM "+(&pop.Model{Value: Factor{}}).TableName()+" WHERE user_id = ? and status = ?", user.ID, FactorStateUnverified.String()).Exec(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Change deletion to a raw query.
- Removes another unused function

When verifying a factor, unverified factors are deleted. Currently this is done by passing in a `[]*Factor` which isn't handled by soda's `Destroy()` method well as it doesn't play well with pointers to a Model


There will be a FLUP with an updated end to end test  + removal of other potential deletion/update functions which involve a `[]*model`