### PR TITLE
Fix link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ GoTrue is a user management and authentication server written in Go that powers
 - Sign in with external providers (Google, Apple, Facebook, Discord, ...)
 
 It is originally based on the excellent
-[GoTrue](https://github.com/supabase/gotrue) codebase by
-[Netlify](https://netlify.com), however both have diverged significantly in
+[GoTrue codebase by
+Netlify](https://github.com/netlify/gotrue), however both have diverged significantly in
 features and capabilities.
 
 ## Quick Start


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes link to point to Netlify's repo rather than the forked version.

## What is the current behavior?

Links to existing repo.

## What is the new behavior?

Links to the original Netlify gotrue repo.
