### PR TITLE
fix: change add claim to session to properly enforce constraint

### DIFF
--- a/internal/models/amr.go
+++ b/internal/models/amr.go
@@ -30,7 +30,7 @@ func AddClaimToSession(tx *storage.Connection, session *Session, authenticationM
 	currentTime := time.Now()
 	return tx.RawQuery("INSERT INTO "+(&pop.Model{Value: AMRClaim{}}).TableName()+
 		`(id, session_id, created_at, updated_at, authentication_method) values (?, ?, ?, ?, ?)
-			ON CONFLICT ON CONSTRAINT mfa_amr_claims_session_id_authentication_method_pkey
+			ON CONFLICT (session_id, authentication_method)
 			DO UPDATE SET updated_at = ?;`, id, session.ID, currentTime, currentTime, authenticationMethod.String(), currentTime).Exec()
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Right now, adding claim to a session will return an error `constraint does not exist` when there is a conflict on  `(session_id, authentication_method)` . It seems like [unique indexes cannot be used ](https://dba.stackexchange.com/questions/139756/on-conflict-on-constraint-fails-saying-constraint-doesnt-exist) in  in an `on conflict on constraint` statement as a unique index does not create a constraint. 

We change the constraint to an index identifier instead.

Postgres playground:  https://www.db-fiddle.com/#&togetherjs=CIii94yGra


Seems like this method is already covered by existing tests - need to figure out why the test didn't catch it

