### PR TITLE
feat: add `actor_via_sso` to audit log

### DIFF
--- a/internal/models/audit_log_entry.go
+++ b/internal/models/audit_log_entry.go
@@ -103,6 +103,7 @@ func NewAuditLogEntry(r *http.Request, tx *storage.Connection, actor *User, acti
 
 	payload := map[string]interface{}{
 		"actor_id":       actor.ID,
+		"actor_via_sso":  actor.IsSSOUser,
 		"actor_username": username,
 		"action":         action,
 		"log_type":       ActionLogTypeMap[action],

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1099,6 +1099,9 @@ paths:
                       properties:
                         actor_id:
                           type: string
+                        actor_via_sso:
+                          type: boolean
+                          description: Whether the actor used a SSO protocol (like SAML 2.0 or OIDC) to authenticate.
                         actor_username:
                           type: string
                         actor_name:


### PR DESCRIPTION
Adds the `actor_via_sso` boolean value to the audit log, which can be used to track audit events for actors using a SSO protocol to authenticate.