### PR TITLE
feat: remove saml beta warning

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gobwas/glob"
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
-	"github.com/sirupsen/logrus"
 )
 
 const defaultMinPasswordLength int = 6
@@ -310,8 +309,6 @@ func LoadGlobal(filename string) (*GlobalConfiguration, error) {
 	}
 
 	if config.SAML.Enabled {
-		logrus.Warn("WARNING: SAML is an incomplete feature and should not be enabled for production use!")
-
 		if err := config.SAML.PopulateFields(config.API.ExternalURL); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Removes the warning that SAML is an incomplete feature, as it has been in dogfooding and early-beta for months now.