### PR TITLE
refactor: move param validation to function

### DIFF
--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -28,6 +28,16 @@ type SmsParams struct {
 	Data    map[string]interface{} `json:"data"`
 }
 
+func (p *OtpParams) Validate() error {
+	if p.Email != "" && p.Phone != "" {
+		return badRequestError("Only an email address or phone number should be provided")
+	}
+	if p.Email != "" && p.Channel != "" {
+		return badRequestError("Channel should only be specified with Phone OTP")
+	}
+	return nil
+}
+
 // Otp returns the MagicLink or SmsOtp handler based on the request body params
 func (a *API) Otp(w http.ResponseWriter, r *http.Request) error {
 	params := &OtpParams{
@@ -45,11 +55,8 @@ func (a *API) Otp(w http.ResponseWriter, r *http.Request) error {
 	if err = json.Unmarshal(body, params); err != nil {
 		return badRequestError("Could not read verification params: %v", err)
 	}
-	if params.Email != "" && params.Phone != "" {
-		return badRequestError("Only an email address or phone number should be provided")
-	}
-	if params.Email != "" && params.Channel != "" {
-		return badRequestError("Channel should only be specified with Phone OTP")
+	if err := params.Validate(); err != nil {
+		return err
 	}
 
 	if ok, err := a.shouldCreateUser(r, params); !ok {

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -93,8 +93,8 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 
 	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
-		if err := params.Validate(); err != nil {
-			return err
+		if terr := params.Validate(); terr != nil {
+			return terr
 		}
 
 		params.Token = strings.ReplaceAll(params.Token, "-", "")

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -52,6 +52,17 @@ type VerifyParams struct {
 	RedirectTo string `json:"redirect_to"`
 }
 
+func (p *VerifyParams) Validate() error {
+	if p.Token == "" {
+		return badRequestError("Verify requires a token")
+	}
+
+	if p.Type == "" {
+		return badRequestError("Verify requires a verification type")
+	}
+	return nil
+}
+
 // Verify exchanges a confirmation or recovery token to a refresh token
 func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	switch r.Method {
@@ -82,14 +93,11 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 
 	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
-		if params.Token == "" {
-			return badRequestError("Verify requires a token")
+		if err := params.Validate(); err != nil {
+			return err
 		}
-		params.Token = strings.ReplaceAll(params.Token, "-", "")
 
-		if params.Type == "" {
-			return badRequestError("Verify requires a verification type")
-		}
+		params.Token = strings.ReplaceAll(params.Token, "-", "")
 		aud := a.requestAud(ctx, r)
 		user, terr = a.verifyEmailLink(ctx, tx, params, aud)
 		if terr != nil {
@@ -165,14 +173,11 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read verification params: %v", err)
 	}
 
-	if params.Token == "" {
-		return badRequestError("Verify requires a token")
+	if err := params.Validate(); err != nil {
+		return err
 	}
-	params.Token = strings.ReplaceAll(params.Token, "-", "")
 
-	if params.Type == "" {
-		return badRequestError("Verify requires a verification type")
-	}
+	params.Token = strings.ReplaceAll(params.Token, "-", "")
 
 	var (
 		user        *models.User


### PR DESCRIPTION
Move validation to a `.Validate()` method for `OtpParams` and `VerifyParams`  similar to how validation is done on the `/resend` endpoint


Refactor for magic link and SMSOTP coming in a FLUP