### PR TITLE
refactor: move flow state expiry check to function

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -612,7 +612,7 @@ func (a *API) OAuthPKCE(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	} else if err != nil {
 		return err
 	}
-	if flowState.CreatedAt.After(time.Now().Add(a.config.External.FlowStateExpiryDuration)) {
+	if flowState.IsExpired(a.config.External.FlowStateExpiryDuration) {
 		return forbiddenError("invalid oauth state, oauth state has expired")
 	}
 

--- a/internal/models/flow_state.go
+++ b/internal/models/flow_state.go
@@ -108,3 +108,7 @@ func (f *FlowState) VerifyPKCE(codeChallenge, codeVerifier string) error {
 	}
 	return nil
 }
+
+func (f *FlowState) IsExpired(expiryDuration time.Duration) bool {
+	return f.CreatedAt.After(time.Now().Add(expiryDuration))
+}


### PR DESCRIPTION
see title, allows expiry check to be re-used. 

Should probably do the same with MFA and convert the config var to a `time.Duration` - probably after LW