### PR TITLE
fix: update settings & route for SAML

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -205,7 +205,6 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			r.Post("/generate_link", api.GenerateLink)
 
 			r.Route("/sso", func(r *router) {
-				r.Use(api.requireSAMLEnabled)
 				r.Route("/providers", func(r *router) {
 					r.Get("/", api.adminSSOProvidersList)
 					r.Post("/", api.adminSSOProvidersCreate)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -153,27 +153,26 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			})
 		})
 
-		if api.config.SAML.Enabled {
-			r.Route("/sso", func(r *router) {
+		r.Route("/sso", func(r *router) {
+			r.Use(api.requireSAMLEnabled)
+			r.With(api.limitHandler(
+				// Allow requests at the specified rate per 5 minutes.
+				tollbooth.NewLimiter(api.config.RateLimitSso/(60*5), &limiter.ExpirableOptions{
+					DefaultExpirationTTL: time.Hour,
+				}).SetBurst(30),
+			)).With(api.verifyCaptcha).Post("/", api.SingleSignOn)
+
+			r.Route("/saml", func(r *router) {
+				r.Get("/metadata", api.SAMLMetadata)
+
 				r.With(api.limitHandler(
 					// Allow requests at the specified rate per 5 minutes.
-					tollbooth.NewLimiter(api.config.RateLimitSso/(60*5), &limiter.ExpirableOptions{
+					tollbooth.NewLimiter(api.config.SAML.RateLimitAssertion/(60*5), &limiter.ExpirableOptions{
 						DefaultExpirationTTL: time.Hour,
 					}).SetBurst(30),
-				)).With(api.verifyCaptcha).Post("/", api.SingleSignOn)
-
-				r.Route("/saml", func(r *router) {
-					r.Get("/metadata", api.SAMLMetadata)
-
-					r.With(api.limitHandler(
-						// Allow requests at the specified rate per 5 minutes.
-						tollbooth.NewLimiter(api.config.SAML.RateLimitAssertion/(60*5), &limiter.ExpirableOptions{
-							DefaultExpirationTTL: time.Hour,
-						}).SetBurst(30),
-					)).Post("/acs", api.SAMLACS)
-				})
+				)).Post("/acs", api.SAMLACS)
 			})
-		}
+		})
 
 		r.Route("/admin", func(r *router) {
 			r.Use(api.requireAdminCredentials)
@@ -205,22 +204,22 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 			r.Post("/generate_link", api.GenerateLink)
 
-			if api.config.SAML.Enabled {
-				r.Route("/sso", func(r *router) {
-					r.Route("/providers", func(r *router) {
-						r.Get("/", api.adminSSOProvidersList)
-						r.Post("/", api.adminSSOProvidersCreate)
+			r.Route("/sso", func(r *router) {
+				r.Use(api.requireSAMLEnabled)
+				r.Route("/providers", func(r *router) {
+					r.Get("/", api.adminSSOProvidersList)
+					r.Post("/", api.adminSSOProvidersCreate)
 
-						r.Route("/{idp_id}", func(r *router) {
-							r.Use(api.loadSSOProvider)
+					r.Route("/{idp_id}", func(r *router) {
+						r.Use(api.loadSSOProvider)
 
-							r.Get("/", api.adminSSOProvidersGet)
-							r.Put("/", api.adminSSOProvidersUpdate)
-							r.Delete("/", api.adminSSOProvidersDelete)
-						})
+						r.Get("/", api.adminSSOProvidersGet)
+						r.Put("/", api.adminSSOProvidersUpdate)
+						r.Delete("/", api.adminSSOProvidersDelete)
 					})
 				})
-			}
+			})
+
 		})
 	})
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -178,3 +178,11 @@ func isIgnoreCaptchaRoute(req *http.Request) bool {
 	}
 	return false
 }
+
+func (a *API) requireSAMLEnabled(w http.ResponseWriter, req *http.Request) (context.Context, error) {
+	ctx := req.Context()
+	if !a.config.SAML.Enabled {
+		return nil, notFoundError("SAML 2.0 is disabled")
+	}
+	return ctx, nil
+}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -198,6 +198,36 @@ func (ts *MiddlewareTestSuite) TestLimitEmailOrPhoneSentHandler() {
 	}
 }
 
+func (ts *MiddlewareTestSuite) TestRequireSAMLEnabled() {
+	cases := []struct {
+		desc        string
+		isEnabled   bool
+		expectedErr error
+	}{
+		{
+			desc:        "SAML not enabled",
+			isEnabled:   false,
+			expectedErr: notFoundError("SAML 2.0 is disabled"),
+		},
+		{
+			desc:        "SAML enabled",
+			isEnabled:   true,
+			expectedErr: nil,
+		},
+	}
+
+	for _, c := range cases {
+		ts.Run(c.desc, func() {
+			ts.Config.SAML.Enabled = c.isEnabled
+			req := httptest.NewRequest("GET", "http://localhost", nil)
+			w := httptest.NewRecorder()
+
+			_, err := ts.API.requireSAMLEnabled(w, req)
+			require.Equal(ts.T(), c.expectedErr, err)
+		})
+	}
+}
+
 func TestFunctionHooksUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		in string

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -21,7 +21,6 @@ type ProviderSettings struct {
 	Twitter   bool `json:"twitter"`
 	Email     bool `json:"email"`
 	Phone     bool `json:"phone"`
-	SAML      bool `json:"saml"`
 	Zoom      bool `json:"zoom"`
 }
 
@@ -32,6 +31,7 @@ type Settings struct {
 	PhoneAutoconfirm  bool             `json:"phone_autoconfirm"`
 	SmsProvider       string           `json:"sms_provider"`
 	MFAEnabled        bool             `json:"mfa_enabled"`
+	SAMLEnabled       bool             `json:"saml_enabled"`
 }
 
 func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
@@ -65,5 +65,6 @@ func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
 		PhoneAutoconfirm:  config.Sms.Autoconfirm,
 		SmsProvider:       config.Sms.Provider,
 		MFAEnabled:        config.MFA.Enabled,
+		SAMLEnabled:       config.SAML.Enabled,
 	})
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1628,7 +1628,11 @@ paths:
                   mfa_enabled:
                     type: boolean
                     example: true
-                    description: Whether MFA is enabled on this API server. Typically true.
+                    description: Whether MFA is enabled on this API server. Defaults to false.
+                  saml_enabled:
+                    type: boolean
+                    example: true
+                    description: Whether SAML is enabled on this API server. Defaults to false.
                   external:
                     type: object
                     description: Which external identity providers are enabled.


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Moves the `SAML_ENABLED` check to a middleware function 
* Display information about whether SAML is enabled in the `/settings` endpoint