### PR TITLE
fix: update from oauth_pkce to pkce

### DIFF
--- a/internal/api/external_github_test.go
+++ b/internal/api/external_github_test.go
@@ -137,7 +137,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGitHub_PKCE() {
 				"code_verifier": codeVerifier,
 				"auth_code":     authCode,
 			}))
-			req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=oauth_pkce", &buffer)
+			req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=pkce", &buffer)
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 			ts.API.handler.ServeHTTP(w, req)

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -173,8 +173,8 @@ func (a *API) Token(w http.ResponseWriter, r *http.Request) error {
 		return a.RefreshTokenGrant(ctx, w, r)
 	case "id_token":
 		return a.IdTokenGrant(ctx, w, r)
-	case "oauth_pkce":
-		return a.OAuthPKCE(ctx, w, r)
+	case "pkce":
+		return a.PKCE(ctx, w, r)
 	default:
 		return oauthError("unsupported_grant_type", "")
 	}
@@ -587,7 +587,7 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 	return sendJSON(w, http.StatusOK, token)
 }
 
-func (a *API) OAuthPKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+func (a *API) PKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	db := a.db.WithContext(ctx)
 	var grantParams models.GrantParams
 

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -176,7 +176,7 @@ func (ts *TokenTestSuite) TestTokenPKCEGrantFailure() {
 				"code_verifier": v.codeVerifier,
 				"auth_code":     v.authCode,
 			}))
-			req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=oauth_pkce", &buffer)
+			req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=pkce", &buffer)
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 			ts.API.handler.ServeHTTP(w, req)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -72,7 +72,7 @@ paths:
               - password
               - refresh_token
               - id_token
-              - oauth_pkce
+              - pkce
       security:
         - APIKeyAuth: []
       requestBody:
@@ -86,7 +86,7 @@ paths:
               grant_type=refresh_token:
                 value:
                   refresh_token: 4nYUCw0wZR_DNOTSDbSGMQ
-              grant_type=oauth_pkce:
+              grant_type=pkce:
                 value:
                   auth_code: 009e5066-fc11-4eca-8c8c-6fd82aa263f2
                   code_verifier: ktPNXpR65N6JtgzQA8_5HHtH6PBSAahMNoLKRzQEa0Tzgl.vdV~b6lPk004XOd.4lR0inCde.NoQx5K63xPfzL8o7tJAjXncnhw5Niv9ycQ.QRV9JG.y3VapqbgLfIrJ


### PR DESCRIPTION
## What kind of change does this PR introduce?

After further thought, the `/token?grant_type=oauth_pkce` need not be constrained for use to only `oauth` flows. All PKCE implementations perform the same checks can re-use the same  generic `grant_type=pkce` route as the route is generally agnostic to the flow taken to get there (e.g. via magic link, recovery)

It's worth noting that we need to track the flow type in order to store the corresponding AAL claim 
 [through the refresh token](https://github.com/supabase/gotrue/blob/master/internal/api/token.go#L630) (e.g. OAuth, OTP, etc)

This can be done via the introduction of a database column `authentication_method_reference` which will store the login flow used to get an auth code. 

As the addition of a column is potentially permanent, I've left it out and am instead including it in the PKCE magic link PR so that this is easier to review since the change is less binding. 


Please feel free to let me know if people prefer that the file be included and I can do that as well.

Thanks



Corresponding [GoTrue-js PR](https://github.com/supabase/gotrue-js/pull/637)
