### PR TITLE
feat: add saml metadata force update every 24 hours

### DIFF
--- a/internal/api/sso_test.go
+++ b/internal/api/sso_test.go
@@ -183,7 +183,7 @@ func (ts *SSOTestSuite) TestIsStaleSAMLMetadata() {
 			provider.UpdatedAt = currentTime.Add(-time.Minute * 59)
 		}
 
-		require.Equal(ts.T(), example.IsStale, IsMetadataStale(metadata, provider))
+		require.Equal(ts.T(), example.IsStale, IsSAMLMetadataStale(metadata, provider))
 	}
 
 }


### PR DESCRIPTION
If the SAML Metadata defined via a URL does not publish validity or cache duration information, forcefully try to update it every 24 hours.