### PR TITLE
fix: enforce code challenge validity across endpoints

### DIFF
--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -70,7 +70,9 @@ func validatePKCEParams(codeChallengeMethod, codeChallenge string) error {
 	case codeChallenge != "" && codeChallengeMethod == "":
 		return badRequestError(InvalidPKCEParamsErrorMessage)
 	case codeChallenge != "" && codeChallengeMethod != "":
-		break
+		if valid, err := isValidCodeChallenge(codeChallenge); !valid {
+			return err
+		}
 	case codeChallenge == "" && codeChallengeMethod == "":
 		break
 	default:

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -72,7 +72,7 @@ func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
 			desc: "PKCE Flow",
 			body: map[string]interface{}{
 				"email":                 testEmail,
-				"code_challenge":        "6b151854-cc15-4e29-8db7-3d3a9f15b306",
+				"code_challenge":        "6b151854-cc15-4e29-8db7-3d3a9f15b3066b151854-cc15-4e29-8db7-3d3a9f15b306",
 				"code_challenge_method": models.SHA256.String(),
 			},
 			isPKCE: true,


### PR DESCRIPTION
Currently, code challenge validity is only enforced on the OAuth endpoint. We move this check to the validate params method. There will be a FLUP which refactors the oauth endpoint to use the validate params method.