### PR TITLE
Refactor: remove flow_type param from oauth

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -45,9 +45,8 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 	query := r.URL.Query()
 	providerType := query.Get("provider")
 	scopes := query.Get("scopes")
-	flowType := query.Get("flow_type")
 	codeChallenge := query.Get("code_challenge")
-	codeChallengeMethodParam := query.Get("code_challenge_method")
+	codeChallengeMethod := query.Get("code_challenge_method")
 
 	p, err := a.Provider(ctx, providerType, scopes)
 	if err != nil {
@@ -68,25 +67,18 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 	redirectURL := a.getRedirectURLOrReferrer(r, query.Get("redirect_to"))
 	log := observability.GetLogEntry(r)
 	log.WithField("provider", providerType).Info("Redirecting to external provider")
+	if err := validatePKCEParams(codeChallengeMethod, codeChallenge); err != nil {
+		return err
+	}
+	flowType := getFlowFromChallenge(codeChallenge)
 
 	flowStateID := ""
-	switch true {
-	case flowType == PKCE && (codeChallenge == "" || codeChallengeMethodParam == ""):
-		return badRequestError("code challenge and code challenge method are required to perform PKCE")
-	case flowType == PKCE && codeChallenge != "" && codeChallengeMethodParam != "":
-		var codeChallengeMethod models.CodeChallengeMethod
-		switch strings.ToLower(codeChallengeMethodParam) {
-		case "plain":
-			codeChallengeMethod = models.Plain
-		case "s256":
-			codeChallengeMethod = models.SHA256
-		default:
-			return badRequestError("code challenge method is unsupported")
-		}
-		if valid, err := isValidCodeChallenge(codeChallenge); !valid {
+	var codeChallengeMethodType models.CodeChallengeMethod
+	if flowType == models.PKCEFlow {
+		if codeChallengeMethodType, err = models.ParseCodeChallengeMethod(codeChallengeMethod); err != nil {
 			return err
 		}
-		flowState, err := models.NewFlowState(providerType, codeChallenge, codeChallengeMethod, models.OAuth)
+		flowState, err := models.NewFlowState(providerType, codeChallenge, codeChallengeMethodType, models.OAuth)
 		if err != nil {
 			return err
 		}
@@ -94,12 +86,6 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 			return err
 		}
 		flowStateID = flowState.ID.String()
-	// Implicit Flow
-	case flowType == "":
-		break
-	default:
-		// Should not reach here
-		return badRequestError("invalid request parameters")
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, ExternalProviderClaims{

--- a/internal/api/external_test.go
+++ b/internal/api/external_test.go
@@ -77,7 +77,7 @@ func performAuthorizationRequest(ts *ExternalTestSuite, provider string, inviteT
 }
 
 func performPKCEAuthorizationRequest(ts *ExternalTestSuite, provider, codeChallenge, codeChallengeMethod string) *httptest.ResponseRecorder {
-	authorizeURL := "http://localhost/authorize?flow_type=pkce&provider=" + provider
+	authorizeURL := "http://localhost/authorize?provider=" + provider
 	if codeChallenge != "" {
 		authorizeURL = authorizeURL + "&code_challenge=" + codeChallenge + "&code_challenge_method=" + codeChallengeMethod
 	}

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -20,7 +20,6 @@ var codeChallengePattern = regexp.MustCompile("^[a-zA-Z._~0-9-]+$")
 
 func isValidCodeChallenge(codeChallenge string) (bool, error) {
 	// See RFC 7636 Section 4.2: https://www.rfc-editor.org/rfc/rfc7636#section-4.2
-
 	switch codeChallengeLength := len(codeChallenge); {
 	case codeChallengeLength < MinCodeChallengeLength, codeChallengeLength > MaxCodeChallengeLength:
 		return false, badRequestError("code challenge has to be between %v and %v characters", MinCodeChallengeLength, MaxCodeChallengeLength)

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -70,7 +70,9 @@ func validatePKCEParams(codeChallengeMethod, codeChallenge string) error {
 	case codeChallenge != "" && codeChallengeMethod == "":
 		return badRequestError(InvalidPKCEParamsErrorMessage)
 	case codeChallenge != "" && codeChallengeMethod != "":
-		break
+		if valid, err := isValidCodeChallenge(codeChallenge); !valid {
+			return err
+		}
 	case codeChallenge == "" && codeChallengeMethod == "":
 		break
 	default:

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -380,7 +380,7 @@ func (ts *TokenTestSuite) TestMagicLinkPKCESignIn() {
 	require.NoError(ts.T(), err)
 
 	// Verify OTP
-	requestUrl := fmt.Sprintf("http://localhost/verify?type=%v&token=%v&flow_type=%v", "magiclink", u.RecoveryToken, models.PKCEFlow.String())
+	requestUrl := fmt.Sprintf("http://localhost/verify?type=%v&token=%v", "magiclink", u.RecoveryToken)
 	req = httptest.NewRequest(http.MethodGet, requestUrl, &buffer)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -71,7 +71,7 @@ func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
 		{
 			desc: "PKCE Flow",
 			body: map[string]interface{}{
-				"email":                 testEmail,
+				"email": testEmail,
 				// Code Challenge needs to be at least 43 characters long
 				"code_challenge":        "6b151854-cc15-4e29-8db7-3d3a9f15b3066b151854-cc15-4e29-8db7-3d3a9f15b306",
 				"code_challenge_method": models.SHA256.String(),

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -72,7 +72,7 @@ func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
 			desc: "PKCE Flow",
 			body: map[string]interface{}{
 				"email":                 testEmail,
-				"code_challenge":        "6b151854-cc15-4e29-8db7-3d3a9f15b306",
+				"code_challenge":        "6b151854-cc15-4e29-8db7-3d3a9f15b3066b151854-cc15-4e29-8db7-3d3a9f15b306",
 				"code_challenge_method": models.SHA256.String(),
 			},
 			isPKCE: true,

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -72,6 +72,7 @@ func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
 			desc: "PKCE Flow",
 			body: map[string]interface{}{
 				"email":                 testEmail,
+				// Code Challenge needs to be at least 43 characters long
 				"code_challenge":        "6b151854-cc15-4e29-8db7-3d3a9f15b3066b151854-cc15-4e29-8db7-3d3a9f15b306",
 				"code_challenge_method": models.SHA256.String(),
 			},

--- a/internal/models/flow_state.go
+++ b/internal/models/flow_state.go
@@ -38,8 +38,8 @@ const (
 	Plain
 )
 
-func (authMethod CodeChallengeMethod) String() string {
-	switch authMethod {
+func (codeChallengeMethod CodeChallengeMethod) String() string {
+	switch codeChallengeMethod {
 	case SHA256:
 		return "s256"
 	case Plain:
@@ -48,14 +48,14 @@ func (authMethod CodeChallengeMethod) String() string {
 	return ""
 }
 
-func ParseCodeChallengeMethod(authMethod string) (CodeChallengeMethod, error) {
-	switch strings.ToLower(authMethod) {
+func ParseCodeChallengeMethod(codeChallengeMethod string) (CodeChallengeMethod, error) {
+	switch strings.ToLower(codeChallengeMethod) {
 	case "s256":
 		return SHA256, nil
 	case "plain":
 		return Plain, nil
 	}
-	return 0, fmt.Errorf("unsupported code_challenge method %q", authMethod)
+	return 0, fmt.Errorf("unsupported code_challenge method %q", codeChallengeMethod)
 }
 
 type FlowType int

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -280,14 +280,6 @@ paths:
           schema:
             type: string
             format: uri
-        - name: flow_type
-          in: query
-          description: (Optional) OAuth flow used for authorization. When not specified, `implicit` is used. Given that `pkce` is a more secure option, it is recommended that users of this API use `pkce`.
-          schema:
-            type: string
-            enum:
-              - pkce
-              - implicit
         - name: code_challenge_method
           in: query
           description: (Optional) Method used to encrypt the verifier. Can be `plain` (no transformation) or `s256` (where SHA-256 is used). It is always recommended that `s256` is used.
@@ -330,7 +322,6 @@ paths:
                 value:
                   email: user@example.com
                   password: password1
-                  flow_type: pkce
                   code_challenge_method: s256
                   code_challenge: elU6u5zyqQT2f92GRQUq6PautAeNDf4DQPayyR0ek_c&
             schema:


### PR DESCRIPTION
The flow_type parameter is not needed as we can deduce the flow from the presence of  a code_challenge (pkce if present, implicit if not)