### PR TITLE
refactor: drop sendWhatsappMessage method

### DIFF
--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -56,25 +56,26 @@ func NewTwilioProvider(config conf.TwilioProviderConfiguration) (SmsProvider, er
 
 func (t *TwilioProvider) SendMessage(phone string, message string, channel string) error {
 	switch channel {
-	case SMSProvider:
-		return t.SendSms(phone, message)
-	case WhatsappProvider:
-		return t.SendWhatsappMessage(phone, message)
+	case SMSProvider, WhatsappProvider:
+		return t.SendSms(phone, message, channel)
 	default:
 		return fmt.Errorf("channel type %q is not supported for Twilio", channel)
 	}
 }
 
-// Send a Whatsapp message containing the OTP with Twilio's API
-// TODO (J0) Merge with SendSms once stable
-func (t *TwilioProvider) SendWhatsappMessage(phone string, message string) error {
+// Send an SMS containing the OTP with Twilio's API
+func (t *TwilioProvider) SendSms(phone, message, channel string) error {
+	if channel == WhatsappProvider {
+		phone = "whatsapp:" + "+" + phone
+	} else if channel == SMSProvider {
+		phone = "+" + phone
+	}
 	body := url.Values{
-		"To":      {"whatsapp:" + "+" + phone}, // twilio api requires "+" extension to be included
-		"Channel": {"whatsapp"},
-		"From":    {"whatsapp:" + t.Config.MessageServiceSid},
+		"To":      {phone}, // twilio api requires "+" extension to be included
+		"Channel": {channel},
+		"From":    {t.Config.MessageServiceSid},
 		"Body":    {message},
 	}
-
 	client := &http.Client{Timeout: defaultTimeout}
 	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
 	if err != nil {
@@ -94,49 +95,6 @@ func (t *TwilioProvider) SendWhatsappMessage(phone string, message string) error
 		}
 		return resp
 	}
-
-	// validate sms status
-	resp := &SmsStatus{}
-	derr := json.NewDecoder(res.Body).Decode(resp)
-	if derr != nil {
-		return derr
-	}
-
-	if resp.Status == "failed" || resp.Status == "undelivered" {
-		return fmt.Errorf("twilio error: %v %v", resp.ErrorMessage, resp.ErrorCode)
-	}
-
-	return nil
-}
-
-// Send an SMS containing the OTP with Twilio's API
-func (t *TwilioProvider) SendSms(phone string, message string) error {
-	body := url.Values{
-		"To":      {"+" + phone}, // twilio api requires "+" extension to be included
-		"Channel": {"sms"},
-		"From":    {t.Config.MessageServiceSid},
-		"Body":    {message},
-	}
-	client := &http.Client{Timeout: defaultTimeout}
-	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
-	if err != nil {
-		return err
-	}
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	r.SetBasicAuth(t.Config.AccountSid, t.Config.AuthToken)
-	res, err := client.Do(r)
-	if err != nil {
-		return err
-	}
-	if res.StatusCode/100 != 2 {
-		resp := &twilioErrResponse{}
-		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
-			return err
-		}
-		return resp
-	}
-	defer utilities.SafeClose(res.Body)
-
 	// validate sms status
 	resp := &SmsStatus{}
 	derr := json.NewDecoder(res.Body).Decode(resp)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Now that the WhatsApp provider, we can condense the SendSMS and SendWhatsApp methods into a single method