### PR TITLE
feat: use refresh token id in family revocation

### DIFF
--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -73,7 +73,7 @@ func RevokeTokenFamily(tx *storage.Connection, token *RefreshToken) error {
 	var err error
 	tablename := (&pop.Model{Value: RefreshToken{}}).TableName()
 	if token.SessionId != nil {
-		err = tx.RawQuery(`update `+tablename+` set revoked = true where session_id = ? and revoked = false;`, token.SessionId).Exec()
+		err = tx.RawQuery(`update `+tablename+` set revoked = true where session_id = ? and revoked = false and id <= ?;`, token.SessionId, token.ID).Exec()
 	} else {
 		err = tx.RawQuery(`
 		with recursive token_family as (


### PR DESCRIPTION
Currently `RevokeTokenFamily` assumes that the `/token` endpoint is not called multiple times locally in time with the same refresh token. This false assumption can cause _all_ refresh tokens (including a valid token issued in the other request) to be revoked.

This was less likely to happen with the recursive algorithm as it revoked the chain of tokens issued _prior_ to the token being refreshed. This change attempts to get the same effect by revoking only refresh tokens with an `id` (of type `bigserial` -- a [monotonically increasing sequence](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL)) less than the token being refreshed.

Because this does not fully solve the raciness, further work is necessary to refactor refresh tokens all together.