### PR TITLE
chore: update example .env file to use DB_NAMESPACE instead of NAMESPACE

### DIFF
--- a/example.env
+++ b/example.env
@@ -9,7 +9,7 @@ GOTRUE_JWT_ADMIN_ROLES="supabase_admin,service_role"
 
 # Database & API connection details
 GOTRUE_DB_DRIVER="postgres"
-NAMESPACE="auth"
+DB_NAMESPACE="auth"
 DATABASE_URL="postgres://supabase_auth_admin:root@localhost:5432/postgres"
 API_EXTERNAL_URL="http://localhost:9999"
 GOTRUE_API_HOST="localhost"


### PR DESCRIPTION
The `DB_` prefix was added and it's needed for the migrations to run to completion