### PR TITLE
fix: return the latest flow state

### DIFF
--- a/internal/models/flow_state.go
+++ b/internal/models/flow_state.go
@@ -136,7 +136,7 @@ func FindFlowStateByID(tx *storage.Connection, id string) (*FlowState, error) {
 
 func FindFlowStateByUserID(tx *storage.Connection, id string) (*FlowState, error) {
 	obj := &FlowState{}
-	if err := tx.Eager().Q().Where("user_id = ?", id).Order("created_at asc").First(obj); err != nil {
+	if err := tx.Eager().Q().Where("user_id = ?", id).Last(obj); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, FlowStateNotFoundError{}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Return the latest flow state instead of first one created 

## TODO
- [ ] Also search based on the `authentication_method` and not just on the `created_at` field