### PR TITLE
fix: make migration idempotent

### DIFF
--- a/migrations/20230411005111_remove_duplicate_idx.up.sql
+++ b/migrations/20230411005111_remove_duplicate_idx.up.sql
@@ -1,1 +1,1 @@
-drop index {{index .Options "Namespace" }}.refresh_tokens_token_idx;
+drop index if exists {{index .Options "Namespace" }}.refresh_tokens_token_idx;


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Migration to remove duplicate index wasn't idempotent