### PR TITLE
feat: add pkce to email_change routes

### DIFF
--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -132,7 +132,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			}
 			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, sms_provider.SMSProvider)
 		case emailChangeVerification:
-			return a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, config.Mailer.OtpLength)
+			return a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, config.Mailer.OtpLength, models.ImplicitFlow)
 		case phoneChangeVerification:
 			smsProvider, terr := sms_provider.GetSmsProvider(*config)
 			if terr != nil {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -14,13 +14,15 @@ import (
 
 // UserUpdateParams parameters for updating a user
 type UserUpdateParams struct {
-	Email    string                 `json:"email"`
-	Password *string                `json:"password"`
-	Nonce    string                 `json:"nonce"`
-	Data     map[string]interface{} `json:"data"`
-	AppData  map[string]interface{} `json:"app_metadata,omitempty"`
-	Phone    string                 `json:"phone"`
-	Channel  string                 `json:"channel"`
+	Email               string                 `json:"email"`
+	Password            *string                `json:"password"`
+	Nonce               string                 `json:"nonce"`
+	Data                map[string]interface{} `json:"data"`
+	AppData             map[string]interface{} `json:"app_metadata,omitempty"`
+	Phone               string                 `json:"phone"`
+	Channel             string                 `json:"channel"`
+	CodeChallenge       string                 `json:"code_challenge"`
+	CodeChallengeMethod string                 `json:"code_challenge_method"`
 }
 
 // UserGet returns a user
@@ -175,7 +177,17 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 			mailer := a.Mailer(ctx)
 			referrer := a.getReferrer(r)
-			if terr = a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, config.Mailer.OtpLength); terr != nil {
+			flowType := getFlowFromChallenge(params.CodeChallenge)
+			if isPKCEFlow(flowType) {
+				codeChallengeMethod, terr := models.ParseCodeChallengeMethod(params.CodeChallengeMethod)
+				if terr != nil {
+					return terr
+				}
+				if terr := models.NewFlowStateWithUserID(tx, models.MagicLink.String(), params.CodeChallenge, codeChallengeMethod, models.MagicLink, &user.ID); terr != nil {
+					return terr
+				}
+			}
+			if terr = a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, config.Mailer.OtpLength, flowType); terr != nil {
 				return internalServerError("Error sending change email").WithInternalError(terr)
 			}
 		}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -183,7 +183,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				if terr != nil {
 					return terr
 				}
-				if terr := models.NewFlowStateWithUserID(tx, models.MagicLink.String(), params.CodeChallenge, codeChallengeMethod, models.MagicLink, &user.ID); terr != nil {
+				if terr := models.NewFlowStateWithUserID(tx, models.EmailChange.String(), params.CodeChallenge, codeChallengeMethod, models.EmailChange, &user.ID); terr != nil {
 					return terr
 				}
 			}

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -127,76 +127,116 @@ func (ts *VerifyTestSuite) TestVerifyPasswordRecovery() {
 }
 
 func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
-	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
-	require.NoError(ts.T(), err)
-	u.EmailChangeSentAt = &time.Time{}
-	require.NoError(ts.T(), ts.API.db.Update(u))
+	currentEmail := "test@example.com"
+	newEmail := "new@example.com"
 
-	// Request body
-	var buffer bytes.Buffer
-	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
-		"email": "new@example.com",
-	}))
+	// Change from new email to current email and back to new email
+	cases := []struct {
+		desc         string
+		body         map[string]interface{}
+		isPKCE       bool
+		currentEmail string
+		newEmail     string
+	}{
+		{
+			desc: "Implict Flow Email Change",
+			body: map[string]interface{}{
+				"email": newEmail,
+			},
+			isPKCE:       false,
+			currentEmail: currentEmail,
+			newEmail:     newEmail,
+		},
+		{
+			desc: "PKCE Email Change",
+			body: map[string]interface{}{
+				"email": currentEmail,
+				// Code Challenge needs to be at least 43 characters long
+				"code_challenge":        "6b151854-cc15-4e29-8db7-3d3a9f15b3066b151854-cc15-4e29-8db7-3d3a9f15b306",
+				"code_challenge_method": models.SHA256.String(),
+			},
+			isPKCE:       true,
+			currentEmail: newEmail,
+			newEmail:     currentEmail,
+		},
+	}
 
-	// Setup request
-	req := httptest.NewRequest(http.MethodPut, "http://localhost/user", &buffer)
-	req.Header.Set("Content-Type", "application/json")
+	for _, c := range cases {
+		u, err := models.FindUserByEmailAndAudience(ts.API.db, c.currentEmail, ts.Config.JWT.Aud)
+		require.NoError(ts.T(), err)
+		u.EmailChangeSentAt = &time.Time{}
+		require.NoError(ts.T(), ts.API.db.Update(u))
 
-	// Generate access token for request
-	var token string
-	token, err = generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
-	require.NoError(ts.T(), err)
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+		// Request body
+		var buffer bytes.Buffer
+		require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(c.body))
 
-	// Setup response recorder
-	w := httptest.NewRecorder()
-	ts.API.handler.ServeHTTP(w, req)
-	assert.Equal(ts.T(), http.StatusOK, w.Code)
+		// Setup request
+		req := httptest.NewRequest(http.MethodPut, "http://localhost/user", &buffer)
+		req.Header.Set("Content-Type", "application/json")
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
-	require.NoError(ts.T(), err)
+		// Generate access token for request
+		var token string
+		token, err = generateAccessToken(ts.API.db, u, nil, time.Second*time.Duration(ts.Config.JWT.Exp), ts.Config.JWT.Secret)
+		require.NoError(ts.T(), err)
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	assert.WithinDuration(ts.T(), time.Now(), *u.EmailChangeSentAt, 1*time.Second)
-	assert.False(ts.T(), u.IsConfirmed())
+		// Setup response recorder
+		w := httptest.NewRecorder()
+		ts.API.handler.ServeHTTP(w, req)
+		assert.Equal(ts.T(), http.StatusOK, w.Code)
 
-	// Verify new email
-	reqURL := fmt.Sprintf("http://localhost/verify?type=%s&token=%s", emailChangeVerification, u.EmailChangeTokenNew)
-	req = httptest.NewRequest(http.MethodGet, reqURL, nil)
+		u, err = models.FindUserByEmailAndAudience(ts.API.db, c.currentEmail, ts.Config.JWT.Aud)
+		require.NoError(ts.T(), err)
 
-	w = httptest.NewRecorder()
-	ts.API.handler.ServeHTTP(w, req)
+		assert.WithinDuration(ts.T(), time.Now(), *u.EmailChangeSentAt, 1*time.Second)
+		assert.False(ts.T(), u.IsConfirmed())
 
-	require.Equal(ts.T(), http.StatusSeeOther, w.Code)
-	urlVal, err := url.Parse(w.Result().Header.Get("Location"))
-	ts.Require().NoError(err, "redirect url parse failed")
-	v, err := url.ParseQuery(urlVal.Fragment)
-	ts.Require().NoError(err)
-	ts.Require().NotEmpty(v.Get("message"))
+		// Verify new email
+		reqURL := fmt.Sprintf("http://localhost/verify?type=%s&token=%s", emailChangeVerification, u.EmailChangeTokenNew)
+		req = httptest.NewRequest(http.MethodGet, reqURL, nil)
 
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
-	require.NoError(ts.T(), err)
-	assert.Equal(ts.T(), singleConfirmation, u.EmailChangeConfirmStatus)
+		w = httptest.NewRecorder()
+		ts.API.handler.ServeHTTP(w, req)
 
-	// Verify old email
-	reqURL = fmt.Sprintf("http://localhost/verify?type=%s&token=%s", emailChangeVerification, u.EmailChangeTokenCurrent)
-	req = httptest.NewRequest(http.MethodGet, reqURL, nil)
+		require.Equal(ts.T(), http.StatusSeeOther, w.Code)
+		urlVal, err := url.Parse(w.Result().Header.Get("Location"))
+		ts.Require().NoError(err, "redirect url parse failed")
+		v, err := url.ParseQuery(urlVal.Fragment)
+		ts.Require().NoError(err)
+		ts.Require().NotEmpty(v.Get("message"))
 
-	w = httptest.NewRecorder()
-	ts.API.handler.ServeHTTP(w, req)
-	require.Equal(ts.T(), http.StatusSeeOther, w.Code)
+		u, err = models.FindUserByEmailAndAudience(ts.API.db, c.currentEmail, ts.Config.JWT.Aud)
+		require.NoError(ts.T(), err)
+		assert.Equal(ts.T(), singleConfirmation, u.EmailChangeConfirmStatus)
 
-	urlVal, err = url.Parse(w.Header().Get("Location"))
-	ts.Require().NoError(err, "redirect url parse failed")
-	v, err = url.ParseQuery(urlVal.Fragment)
-	ts.Require().NoError(err)
-	ts.Require().NotEmpty(v.Get("access_token"))
-	ts.Require().NotEmpty(v.Get("expires_in"))
-	ts.Require().NotEmpty(v.Get("refresh_token"))
+		// Verify old email
+		reqURL = fmt.Sprintf("http://localhost/verify?type=%s&token=%s", emailChangeVerification, u.EmailChangeTokenCurrent)
+		req = httptest.NewRequest(http.MethodGet, reqURL, nil)
 
-	// user's email should've been updated to new@example.com
-	u, err = models.FindUserByEmailAndAudience(ts.API.db, "new@example.com", ts.Config.JWT.Aud)
-	require.NoError(ts.T(), err)
-	require.Equal(ts.T(), zeroConfirmation, u.EmailChangeConfirmStatus)
+		w = httptest.NewRecorder()
+		ts.API.handler.ServeHTTP(w, req)
+		require.Equal(ts.T(), http.StatusSeeOther, w.Code)
+
+		urlVal, err = url.Parse(w.Header().Get("Location"))
+		ts.Require().NoError(err, "redirect url parse failed")
+		if !c.isPKCE {
+			v, err = url.ParseQuery(urlVal.Fragment)
+			ts.Require().NoError(err)
+			ts.Require().NotEmpty(v.Get("access_token"))
+			ts.Require().NotEmpty(v.Get("expires_in"))
+			ts.Require().NotEmpty(v.Get("refresh_token"))
+		} else if c.isPKCE {
+			v, err = url.ParseQuery(urlVal.RawQuery)
+			ts.Require().NoError(err)
+			ts.Require().NotEmpty(v.Get("code"))
+		}
+
+		// user's email should've been updated to new@example.com
+		u, err = models.FindUserByEmailAndAudience(ts.API.db, c.newEmail, ts.Config.JWT.Aud)
+		require.NoError(ts.T(), err)
+		require.Equal(ts.T(), zeroConfirmation, u.EmailChangeConfirmStatus)
+	}
 }
 
 func (ts *VerifyTestSuite) TestExpiredConfirmationToken() {

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -164,6 +164,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 	for _, c := range cases {
 		u, err := models.FindUserByEmailAndAudience(ts.API.db, c.currentEmail, ts.Config.JWT.Aud)
 		require.NoError(ts.T(), err)
+
 		u.EmailChangeSentAt = &time.Time{}
 		require.NoError(ts.T(), ts.API.db.Update(u))
 
@@ -236,6 +237,11 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 		u, err = models.FindUserByEmailAndAudience(ts.API.db, c.newEmail, ts.Config.JWT.Aud)
 		require.NoError(ts.T(), err)
 		require.Equal(ts.T(), zeroConfirmation, u.EmailChangeConfirmStatus)
+
+		// Reset confirmation status after each test
+		u.EmailConfirmedAt = nil
+		require.NoError(ts.T(), ts.API.db.Update(u))
+
 	}
 }
 

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -232,7 +232,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 			ts.Require().NotEmpty(v.Get("code"))
 		}
 
-		// user's email should've been updated to new@example.com
+		// user's email should've been updated to newEmail
 		u, err = models.FindUserByEmailAndAudience(ts.API.db, c.newEmail, ts.Config.JWT.Aud)
 		require.NoError(ts.T(), err)
 		require.Equal(ts.T(), zeroConfirmation, u.EmailChangeConfirmStatus)

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -42,6 +42,7 @@ const (
 	Invite
 	MagicLink
 	EmailSignup
+	EmailChange
 )
 
 func (authMethod AuthenticationMethod) String() string {
@@ -64,6 +65,8 @@ func (authMethod AuthenticationMethod) String() string {
 		return "magiclink"
 	case EmailSignup:
 		return "email/signup"
+	case EmailChange:
+		return "email_change"
 	}
 	return ""
 }
@@ -88,6 +91,8 @@ func ParseAuthenticationMethod(authMethod string) (AuthenticationMethod, error) 
 		return MagicLink, nil
 	case "email/signup":
 		return EmailSignup, nil
+	case "email_change":
+		return EmailChange, nil
 	}
 	return 0, fmt.Errorf("unsupported authentication method %q", authMethod)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add PKCE to email Change routes

## What is the current behavior?

No PKCE on email change routes

## What is the new behavior?

PKCE on email change routes 


## Additional context

There's an additional AMR claim known as `email_change` I'm not sure whether we want to have a special claim for this given that `email_change` is not typically classed as a login method. The other option would be to use the Magic Link AMR claim instead. Let me know if anyone has a preference here.

Should be tested  with: https://github.com/supabase/gotrue-js/pull/661/files


TODOs:
- [x] Tests need to be written for the PKCE path