### PR TITLE
fix: POST /verify should check pkce case

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -549,7 +549,7 @@ func isOtpValid(actual, expected string, sentAt *time.Time, otpExp uint) bool {
 	if expected == "" || sentAt == nil {
 		return false
 	}
-	return !isOtpExpired(sentAt, otpExp) && (actual == expected)
+	return !isOtpExpired(sentAt, otpExp) && ((actual == expected) || ("pkce_"+actual == expected))
 }
 
 func isOtpExpired(sentAt *time.Time, otpExp uint) bool {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Since `POST /verify` doesn't implement PKCE, it should check for cases where the initial request could have been a PKCE request 
* Fixes https://github.com/supabase/gotrue-js/issues/662