### PR TITLE
fix: make flow_state migrations idempotent, add index

### DIFF
--- a/migrations/20230322519590_add_flow_state_table.up.sql
+++ b/migrations/20230322519590_add_flow_state_table.up.sql
@@ -17,4 +17,4 @@ create table if not exists {{ index .Options "Namespace" }}.flow_state(
        updated_at timestamptz null
 );
 create index if not exists idx_auth_code on {{ index .Options "Namespace" }}.flow_state(auth_code);
-comment on table {{ index .Options "Namespace" }}.flow_state is 'stores metadata for oauth provider logins';
+comment on table {{ index .Options "Namespace" }}.flow_state is 'stores metadata for pkce logins';

--- a/migrations/20230322519590_add_flow_state_table.up.sql
+++ b/migrations/20230322519590_add_flow_state_table.up.sql
@@ -16,5 +16,5 @@ create table if not exists {{ index .Options "Namespace" }}.flow_state(
        created_at timestamptz null,
        updated_at timestamptz null
 );
-create index idx_auth_code on {{ index .Options "Namespace" }}.flow_state(auth_code);
+create index if not exists idx_auth_code on {{ index .Options "Namespace" }}.flow_state(auth_code);
 comment on table {{ index .Options "Namespace" }}.flow_state is 'stores metadata for oauth provider logins';

--- a/migrations/20230402418590_add_authentication_method_to_flow_state_table.up.sql
+++ b/migrations/20230402418590_add_authentication_method_to_flow_state_table.up.sql
@@ -1,3 +1,6 @@
 alter table {{index .Options "Namespace" }}.flow_state
 add column if not exists authentication_method text not null;
 create index if not exists idx_user_id_auth_method on {{index .Options "Namespace" }}.flow_state (user_id, authentication_method);
+
+-- Update comment as we have generalized the table
+comment on table {{ index .Options "Namespace" }}.flow_state is 'stores metadata for pkce logins';

--- a/migrations/20230402418590_add_authentication_method_to_flow_state_table.up.sql
+++ b/migrations/20230402418590_add_authentication_method_to_flow_state_table.up.sql
@@ -1,2 +1,3 @@
 alter table {{index .Options "Namespace" }}.flow_state
-add column authentication_method text not null;
+add column if not exists authentication_method text not null;
+create index if not exists idx_user_id_auth_method on {{index .Options "Namespace" }}.flow_state (user_id, authentication_method);


### PR DESCRIPTION
## What kind of change does this PR introduce?

With the introduction of an Authentication Method check on `FindFlowStateByUserID` we may wish to add an index. Also introduces an idempotency condition on flow state related migrations.  Finally, updates the old Postgres comment by [issuing a new comment to overrwrite previous comment](https://www.postgresql.org/docs/current/sql-comment.html)


Left as draft till this is tested together with other remaining PKCE changes.