### PR TITLE
fix: check freq on email change

### DIFF
--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -340,6 +340,9 @@ func (a *API) sendMagicLink(tx *storage.Connection, u *models.User, mailer maile
 // sendEmailChange sends out an email change token to the new email.
 func (a *API) sendEmailChange(tx *storage.Connection, config *conf.GlobalConfiguration, u *models.User, mailer mailer.Mailer, email string, referrerURL string, otpLength int) error {
 	var err error
+	if u.EmailChangeSentAt != nil && !u.EmailChangeSentAt.Add(config.SMTP.MaxFrequency).Before(time.Now()) {
+		return MaxFrequencyLimitError
+	}
 	otpNew, err := crypto.GenerateOtp(otpLength)
 	if err != nil {
 		return err

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/fatih/structs"
@@ -176,6 +177,9 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			mailer := a.Mailer(ctx)
 			referrer := a.getReferrer(r)
 			if terr = a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, config.Mailer.OtpLength); terr != nil {
+				if errors.Is(terr, MaxFrequencyLimitError) {
+					return tooManyRequestsError("For security purposes, you can only request this once every 60 seconds")
+				}
 				return internalServerError("Error sending change email").WithInternalError(terr)
 			}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Email change requests on `PUT /user` should adhere to the max frequency rule.