### PR TITLE
feat: add turnstile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ Or Messagebird credentials, which can be obtained in the [Dashboard](https://das
 
 ### CAPTCHA
 
-- If enabled, CAPTCHA will check the request body for the `hcaptcha_token` field and make a verification request to the CAPTCHA provider.
+- If enabled, CAPTCHA will check the request body for the `captcha_token` field and make a verification request to the CAPTCHA provider.
 
 `SECURITY_CAPTCHA_ENABLED` - `string`
 
@@ -715,12 +715,12 @@ Whether captcha middleware is enabled
 
 `SECURITY_CAPTCHA_PROVIDER` - `string`
 
-for now the only option supported is: `hcaptcha`
+for now the only options supported are: `hcaptcha` and `turnstile`
 
 - `SECURITY_CAPTCHA_SECRET` - `string`
 - `SECURITY_CAPTCHA_TIMEOUT` - `string`
 
-Retrieve from hcaptcha account
+Retrieve from hcaptcha or turnstile account
 
 ### Reauthentication
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -160,11 +160,11 @@ func (a *API) verifyCaptcha(w http.ResponseWriter, req *http.Request) (context.C
 
 	verificationResult, err := security.VerifyRequest(req, strings.TrimSpace(config.Security.Captcha.Secret), config.Security.Captcha.Provider)
 	if err != nil {
-		return nil, internalServerError("hCaptcha verification process failed").WithInternalError(err)
+		return nil, internalServerError("captcha verification process failed").WithInternalError(err)
 	}
 
 	if !verificationResult.Success {
-		return nil, badRequestError("hCaptcha protection: request disallowed (%s)", strings.Join(verificationResult.ErrorCodes, ", "))
+		return nil, badRequestError("captcha protection: request disallowed (%s)", strings.Join(verificationResult.ErrorCodes, ", "))
 
 	}
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -158,7 +158,7 @@ func (a *API) verifyCaptcha(w http.ResponseWriter, req *http.Request) (context.C
 		return ctx, nil
 	}
 
-	verificationResult, err := security.VerifyRequest(req, strings.TrimSpace(config.Security.Captcha.Secret))
+	verificationResult, err := security.VerifyRequest(req, strings.TrimSpace(config.Security.Captcha.Secret), config.Security.Captcha.Provider)
 	if err != nil {
 		return nil, internalServerError("hCaptcha verification process failed").WithInternalError(err)
 	}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -122,7 +122,17 @@ func (ts *MiddlewareTestSuite) TestVerifyCaptchaInvalid() {
 				Secret:   "test",
 			},
 			http.StatusBadRequest,
-			"hCaptcha protection: request disallowed (not-using-dummy-secret)",
+			"captcha protection: request disallowed (not-using-dummy-secret)",
+		},
+		{
+			"Captcha validation failed",
+			&conf.CaptchaConfiguration{
+				Enabled:  true,
+				Provider: "turnstile",
+				Secret:   "anothertest",
+			},
+			http.StatusBadRequest,
+			"captcha protection: request disallowed (invalid-input-secret)",
 		},
 	}
 	for _, c := range cases {

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -235,14 +235,14 @@ func (c *CaptchaConfiguration) Validate() error {
 		return nil
 	}
 
-	if c.Provider != "hcaptcha" {
+	if c.Provider != "hcaptcha" && c.Provider != "turnstile" {
 		return fmt.Errorf("unsupported captcha provider: %s", c.Provider)
 	}
 
 	c.Secret = strings.TrimSpace(c.Secret)
 
 	if c.Secret == "" {
-		return errors.New("hcaptcha provider secret is empty")
+		return errors.New("captcha provider secret is empty")
 	}
 
 	return nil

--- a/internal/security/captcha.go
+++ b/internal/security/captcha.go
@@ -60,7 +60,7 @@ func VerifyRequest(r *http.Request, secretKey, captchaProvider string) (Verifica
 	captchaResponse := strings.TrimSpace(requestBody.Security.Token)
 
 	if captchaResponse == "" {
-		return VerificationResponse{}, errors.New("no hCaptcha response (captcha_token) found in request")
+		return VerificationResponse{}, errors.New("no captcha response (captcha_token) found in request")
 	}
 
 	clientIP := utilities.GetIPAddress(r)
@@ -81,20 +81,20 @@ func verifyCaptchaCode(token, secretKey, clientIP, captchaURL string) (Verificat
 
 	r, err := http.NewRequest("POST", captchaURL, strings.NewReader(data.Encode()))
 	if err != nil {
-		return VerificationResponse{}, errors.Wrap(err, "couldn't initialize request object for hcaptcha check")
+		return VerificationResponse{}, errors.Wrap(err, "couldn't initialize request object for captcha check")
 	}
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	r.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
 	res, err := Client.Do(r)
 	if err != nil {
-		return VerificationResponse{}, errors.Wrap(err, "failed to verify hcaptcha response")
+		return VerificationResponse{}, errors.Wrap(err, "failed to verify captcha response")
 	}
 	defer utilities.SafeClose(res.Body)
 
 	var verificationResponse VerificationResponse
 
 	if err := json.NewDecoder(res.Body).Decode(&verificationResponse); err != nil {
-		return VerificationResponse{}, errors.Wrap(err, "failed to decode hcaptcha response: not JSON")
+		return VerificationResponse{}, errors.Wrap(err, "failed to decode captcha response: not JSON")
 	}
 
 	return verificationResponse, nil

--- a/internal/security/captcha.go
+++ b/internal/security/captcha.go
@@ -107,6 +107,6 @@ func GetCaptchaURL(captchaProvider string) (string, error) {
 	case "turnstile":
 		return "https://challenges.cloudflare.com/turnstile/v0/siteverify", nil
 	default:
-		return "", fmt.Errorf("Captcha Provider %q could not be found", captchaProvider)
+		return "", fmt.Errorf("captcha Provider %q could not be found", captchaProvider)
 	}
 }


### PR DESCRIPTION
## Overview

Captcha providers are treated as generic in this PR. Users can swap out the provider which in turn swaps out only the `siteverify` URL.  This approach generally works fine when considering `turnstile` and `hcaptcha` since both have similar feature sets.

However, for  other providers like `recaptcha` users might want to use specialized features such as Android recaptcha and  recaptcha V3 score. Since the [responses slightly differ between an android response and a generic response](https://developers.google.com/recaptcha/docs/verify), we may need to introduce separate structs.

Another alternative considered was to initialize a new provider type for each methods (similar to `SMSProvider`) and have corresponding `verifyCaptcha` methods for each provider. This way there is clear separation of decoding logic for response types for each provider but there will be slightly more code to maintain.




### TODOs:
- [x] Manual testing with FE components

After PR:
- Update dashboard to reflect additional provider
- Update [hcaptcha docs](https://supabase.com/docs/guides/auth/auth-captcha) 

 