### PR TITLE
feat: allow updating saml providers `metadata_xml`

### DIFF
--- a/internal/api/ssoadmin.go
+++ b/internal/api/ssoadmin.go
@@ -279,6 +279,7 @@ func (a *API) adminSSOProvidersUpdate(w http.ResponseWriter, r *http.Request) er
 	}
 
 	modified := false
+	updateSAMLProvider := false
 
 	provider := getSSOProvider(ctx)
 
@@ -298,6 +299,7 @@ func (a *API) adminSSOProvidersUpdate(w http.ResponseWriter, r *http.Request) er
 		}
 
 		provider.SAMLProvider.MetadataXML = string(rawMetadata)
+		updateSAMLProvider = true
 		modified = true
 	}
 
@@ -360,7 +362,7 @@ func (a *API) adminSSOProvidersUpdate(w http.ResponseWriter, r *http.Request) er
 				}
 			}
 
-			if updateAttributeMapping {
+			if updateAttributeMapping || updateSAMLProvider {
 				if terr := tx.Eager().Update(&provider.SAMLProvider); terr != nil {
 					return terr
 				}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix the `PUT` `/admin/providers/<id>` endpoint not committing the SAMLProvider changes to the database when updating the metadata XML (resulting in a no-op).

## What is the current behavior?

Updates to the metadata XML via the `/admin/providers/<id>` should be reflected on the `saml_provider` database object.

## What is the new behavior?

The provider metadata XML can now be correctly updated.
