### PR TITLE
fix: correct pkce redirect generation

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -225,7 +225,10 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	if flowState != nil {
 		// This means that the callback is using PKCE
 		// Set the flowState.AuthCode to the query param here
-		rurl = a.prepPKCERedirectURL(rurl, flowState.AuthCode)
+		rurl, err = a.prepPKCERedirectURL(rurl, flowState.AuthCode)
+		if err != nil {
+			return err
+		}
 	} else if token != nil {
 		q := url.Values{}
 		q.Set("provider_token", providerAccessToken)

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -380,6 +380,7 @@ func (a *API) prepPKCERedirectURL(rurl, code string) (string, error) {
 	}
 	q := u.Query()
 	q.Set("code", code)
+	u.RawQuery = q.Encode()
 	return u.String(), nil
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, it seems like PKCE flow implementation incorrectly adds a `?` instead of a `&` to the url when there is a redirect with multiple parameters (e.g. on `/resend` like in the url below:) . This PR aims to fix this.

