### PR TITLE
feat: fix account linking

### DIFF
--- a/internal/models/linking.go
+++ b/internal/models/linking.go
@@ -78,8 +78,12 @@ func DetermineAccountLinking(tx *storage.Connection, provider, sub string, email
 			return AccountLinkingResult{}, terr
 		}
 
-		if terr := tx.Q().Eager().Where("email in (?) and is_sso_user is false", emails).All(&similarUsers); terr != nil {
-			return AccountLinkingResult{}, terr
+		if !strings.HasPrefix(provider, "sso:") {
+			// there can be multiple user accounts with the same email when is_sso_user is true
+			// so we just do not consider those similar user accounts
+			if terr := tx.Q().Eager().Where("email in (?) and is_sso_user is false", emails).All(&similarUsers); terr != nil {
+				return AccountLinkingResult{}, terr
+			}
 		}
 	}
 


### PR DESCRIPTION
The issue is that the modified account linking algorithm _always_ linked SSO to non-SSO accounts if a similar email account was present.