### PR TITLE
feat: add mfa cleanup

### DIFF
--- a/internal/models/cleanup.go
+++ b/internal/models/cleanup.go
@@ -31,6 +31,7 @@ func init() {
 	tableSessions := Session{}.TableName()
 	tableRelayStates := SAMLRelayState{}.TableName()
 	tableFlowStates := FlowState{}.TableName()
+	tableMFAChallenges := Challenge{}.TableName()
 
 	// These statements intentionally use SELECT ... FOR UPDATE SKIP LOCKED
 	// as this makes sure that only rows that are not being used in another
@@ -45,6 +46,7 @@ func init() {
 		fmt.Sprintf("delete from %q where id in (select id from %q where not_after < now() - interval '72 hours' limit 10 for update skip locked);", tableSessions, tableSessions),
 		fmt.Sprintf("delete from %q where id in (select id from %q where created_at < now() - interval '24 hours' limit 100 for update skip locked);", tableRelayStates, tableRelayStates),
 		fmt.Sprintf("delete from %q where id in (select id from %q where created_at < now() - interval '24 hours' limit 100 for update skip locked);", tableFlowStates, tableFlowStates),
+		fmt.Sprintf("delete from %q where id in (select id from %q where created_at < now() - interval '12 hours' limit 100 for update skip locked);", tableMFAChallenges, tableMFAChallenges),
 	)
 
 	var err error

--- a/migrations/20230508135423_add_cleanup_indexes.up.sql
+++ b/migrations/20230508135423_add_cleanup_indexes.up.sql
@@ -15,7 +15,3 @@ create index if not exists
 create index if not exists
   sessions_not_after_idx
   on {{ index .Options "Namespace" }}.sessions (not_after desc);
-
-create index if not exists
-  mfa_challenge_created_at_idx
-  on {{ index .Options "Namespace" }}.mfa_challenges (created_at desc);

--- a/migrations/20230508135423_add_cleanup_indexes.up.sql
+++ b/migrations/20230508135423_add_cleanup_indexes.up.sql
@@ -15,3 +15,7 @@ create index if not exists
 create index if not exists
   sessions_not_after_idx
   on {{ index .Options "Namespace" }}.sessions (not_after desc);
+
+create index if not exists
+  mfa_challenge_created_at_idx
+  on {{ index .Options "Namespace" }}.mfa_challenges (created_at desc);

--- a/migrations/20230523124323_add_mfa_challenge_cleanup_index.up.sql
+++ b/migrations/20230523124323_add_mfa_challenge_cleanup_index.up.sql
@@ -1,0 +1,5 @@
+-- Index used to clean up mfa challenges
+
+create index if not exists
+  mfa_challenge_created_at_idx
+  on {{ index .Options "Namespace" }}.mfa_challenges (created_at desc);


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR extends #875 to clean up MFA challenges as well so that they don't clog the database.


## How this was tested

set `GOTRUE_DB_CLEANUP_ENABLED = true`

1. Sign up locally
2. Enroll a factor
3. `ab -p testfileforab -T application/json -H 'Authorization: Bearer <token>' -c 10 -n 100 http://localhost:9999/factors/0bca5d9c-157a-4a15-890c-2ad33415b4f3/challenge` 
4. `update auth.mfa_challenges set created_at = created_at - interval  '48 hours';`
5. Make about 7 requests to ensure there's a cleanup performed
