### PR TITLE
feat: add different logout scopes

### DIFF
--- a/internal/api/logout.go
+++ b/internal/api/logout.go
@@ -1,10 +1,19 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
+)
+
+type LogoutBehavior string
+
+const (
+	LogoutGlobal LogoutBehavior = "global"
+	LogoutLocal  LogoutBehavior = "local"
+	LogoutOthers LogoutBehavior = "others"
 )
 
 // Logout is the endpoint for logging out a user and thereby revoking any refresh tokens
@@ -13,7 +22,23 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 	db := a.db.WithContext(ctx)
 	config := a.config
 
-	a.clearCookieTokens(config, w)
+	scope := LogoutGlobal
+
+	if r.URL.Query() != nil {
+		switch r.URL.Query().Get("scope") {
+		case "", "global":
+			scope = LogoutGlobal
+
+		case "local":
+			scope = LogoutLocal
+
+		case "others":
+			scope = LogoutOthers
+
+		default:
+			return badRequestError(fmt.Sprintf("Unsupported logout scope %q", r.URL.Query().Get("scope")))
+		}
+	}
 
 	s := getSession(ctx)
 	u := getUser(ctx)
@@ -22,15 +47,28 @@ func (a *API) Logout(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(r, tx, u, models.LogoutAction, "", nil); terr != nil {
 			return terr
 		}
-		if s != nil {
-			return models.Logout(tx, u.ID)
+
+		if s == nil {
+			return models.LogoutAllRefreshTokens(tx, u.ID)
 		}
-		return models.LogoutAllRefreshTokens(tx, u.ID)
+
+		switch scope {
+		case LogoutLocal:
+			return models.LogoutSession(tx, s.ID)
+
+		case LogoutOthers:
+			return models.LogoutAllExceptMe(tx, s.ID, u.ID)
+		}
+
+		// default mode, log out everywhere
+		return models.Logout(tx, u.ID)
 	})
 	if err != nil {
 		return internalServerError("Error logging out user").WithInternalError(err)
 	}
 
+	a.clearCookieTokens(config, w)
 	w.WriteHeader(http.StatusNoContent)
+
 	return nil
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -158,6 +158,17 @@ paths:
       security:
         - APIKeyAuth: []
           UserAuth: []
+      parameters:
+        - name: scope
+          in: query
+          description: >
+            (Optional.) Determines how the user should be logged out. When `global` is used, the user is logged out from all active sessions. When `local` is used, the user is logged out from the current session. When `others` is used, the user is logged out from all other sessions except the current one. Clients should remove stored access and refresh tokens except when `others` is used.
+          schema:
+            type: string
+            enum:
+              - global
+              - local
+              - others
       responses:
         204:
           description: No content returned on successful logout.


### PR DESCRIPTION
Right now, probably due to a bug, `POST /logout` would log the user out from _all_ sessions they have. This is not always desired behavior.

This change adds a new `scope` query param on `/logout` with these values:
- `global` (default when not provided) Logs a user out from all sessions they have.
- `local` Logs a user out from the current session only.
- `others` Logs a user out from all other sessions except the current one.

See:
- https://github.com/supabase/gotrue-js/pull/713