### PR TITLE
feat: increase max enrolled factors

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -65,7 +65,7 @@ type MFAConfiguration struct {
 	Enabled                     bool    `default:"false"`
 	ChallengeExpiryDuration     float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	RateLimitChallengeAndVerify float64 `split_words:"true" default:"15"`
-	MaxEnrolledFactors          float64 `split_words:"true" default:"50"`
+	MaxEnrolledFactors          float64 `split_words:"true" default:"30"`
 	MaxVerifiedFactors          int     `split_words:"true" default:"10"`
 }
 

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -65,7 +65,7 @@ type MFAConfiguration struct {
 	Enabled                     bool    `default:"false"`
 	ChallengeExpiryDuration     float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
 	RateLimitChallengeAndVerify float64 `split_words:"true" default:"15"`
-	MaxEnrolledFactors          float64 `split_words:"true" default:"10"`
+	MaxEnrolledFactors          float64 `split_words:"true" default:"50"`
 	MaxVerifiedFactors          int     `split_words:"true" default:"10"`
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Aims to address #979. One reason that the `MFA_ENROLLED_FACTORS` was introduced was to ensure that the database does not get flooded when users attempt to enroll multiple times either by error or due to malicious intent of a user. Unfortunately, this can pose as a hassle to developers when they try to develop their application and make multiple calls to `/enroll`. 

They will have to clear their database when they hit the limit which might cause frustration. With the introduction of #875 , there's probably more room to allow for more enrolled factors.

In this PR, we propose increasing the limit from 10 to a more generous limit of 30