### PR TITLE
fix: lowercase oauth emails for account linking

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -271,7 +271,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 
 	for _, email := range userData.Emails {
 		if email.Verified || config.Mailer.Autoconfirm {
-			emails = append(emails, email.Email)
+			emails = append(emails, strings.ToLower(email.Email))
 		}
 	}
 

--- a/internal/models/linking.go
+++ b/internal/models/linking.go
@@ -74,14 +74,14 @@ func DetermineAccountLinking(tx *storage.Connection, provider, sub string, email
 	var similarUsers []*User
 
 	if len(emails) > 0 {
-		if terr := tx.Q().Eager().Where("email in (?)", emails).All(&similarIdentities); terr != nil {
+		if terr := tx.Q().Eager().Where("email ilike any (?)", emails).All(&similarIdentities); terr != nil {
 			return AccountLinkingResult{}, terr
 		}
 
 		if !strings.HasPrefix(provider, "sso:") {
 			// there can be multiple user accounts with the same email when is_sso_user is true
 			// so we just do not consider those similar user accounts
-			if terr := tx.Q().Eager().Where("email in (?) and is_sso_user is false", emails).All(&similarUsers); terr != nil {
+			if terr := tx.Q().Eager().Where("email ilike any (?) and is_sso_user is false", emails).All(&similarUsers); terr != nil {
 				return AccountLinkingResult{}, terr
 			}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* The account linking algorithm in [`DetermineAccountLinking()`](https://github.com/supabase/gotrue/blob/577a97e7aad241fcb8562ded195f8c2e55250272/internal/models/linking.go#L52) checks if the slice of emails returned by the oauth provider matches an existing email in the database. However, the emails returned by the oauth provider might not be lowercase. This may result in cases where the account linking algorithm thinks that a new user should be created instead. For example:

```
Existing user's email: "foo@example.com"
New oauth identity emails: [ "FOO@example.com", "bar@example.com" ] 
```

This would result in [this line](https://github.com/supabase/gotrue/blob/577a97e7aad241fcb8562ded195f8c2e55250272/internal/models/linking.go#L77) failing to return the existing user's email because `foo@example.com` won't match `FOO@example.com`
