### PR TITLE
feat: infer `Mail` in SAML assertion and allow deleting SSO user

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -459,10 +459,6 @@ func (a *API) adminUserDelete(w http.ResponseWriter, r *http.Request) error {
 	user := getUser(ctx)
 	adminUser := getAdminUser(ctx)
 
-	if user.IsSSOUser {
-		return badRequestError("user should be removed via identity provider instead")
-	}
-
 	var err error
 	params := &adminUserDeleteParams{}
 	body, err := getBodyBytes(r)

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -545,7 +545,7 @@ func (ts *AdminTestSuite) TestAdminUserDelete() {
 			desc:         "Test admin delete user (soft deletion & sso user)",
 			isSoftDelete: "?is_soft_delete=true",
 			isSSOUser:    true,
-			expected:     expected{code: http.StatusBadRequest, err: nil},
+			expected:     expected{code: http.StatusOK, err: nil},
 			body: map[string]interface{}{
 				"should_soft_delete": true,
 			},

--- a/internal/api/samlassertion.go
+++ b/internal/api/samlassertion.go
@@ -96,6 +96,7 @@ func (a *SAMLAssertion) Email() string {
 		"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
 		"http://schemas.xmlsoap.org/claims/EmailAddress",
 		"mail",
+		"Mail",
 		"email",
 	}
 


### PR DESCRIPTION
PingIdentity usually sends the email address in `Mail` with capital M. We also are allowing deleting the user record when the user is SSO with the admin API.