### PR TITLE
feat: fix SAML metadata XML update on fetched metadata

### DIFF
--- a/internal/api/samlacs.go
+++ b/internal/api/samlacs.go
@@ -263,7 +263,7 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 
 	var token *AccessTokenResponse
 	if samlMetadataModified {
-		if err := a.db.Update(ssoProvider.SAMLProvider); err != nil {
+		if err := db.UpdateColumns(&ssoProvider.SAMLProvider, "metadata_xml", "updated_at"); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When GoTrue needs to update the SAML metadata XML by fetching from the URL, there were a few issues:

- `Update` was being called with a non-pointer argument which generally fails with a panic in Pop 😞 
- Only the `metadata_xml` and `updated_at` columns should be updated

This PR fixes it.