### PR TITLE
fix: duplicate identity error on update user

### DIFF
--- a/internal/models/identity.go
+++ b/internal/models/identity.go
@@ -115,5 +115,11 @@ func (i *Identity) UpdateIdentityData(tx *storage.Connection, updates map[string
 			}
 		}
 	}
-	return tx.UpdateOnly(i, "identity_data")
+	// pop doesn't support updates on tables with composite primary keys so we use a raw query here.
+	return tx.RawQuery(
+		"update "+(&pop.Model{Value: Identity{}}).TableName()+" set identity_data = ? where provider = ? and id = ?",
+		i.IdentityData,
+		i.Provider,
+		i.ID,
+	).Exec()
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* When updating a user's email or phone number, if the user previously did not have an email or phone number associated to their account, gotrue will create an new identity for it. However, subsequent attempts to update the user's email or phone number will result in gotrue attempting to create the same identity again. This results in postgres returning a unique constraint violation. 

For example, assuming that the user signed up with email + password initially:

```bash
# this request will create a phone identity and send an OTP to the user
curl -X PUT "http://localhost:9999/user" -H "Authorization: Bearer <access_token>" -H "Content-Type: application/json" -d '{"phone": "123456789"}'

# this request will return a "duplicate key value violates unique constraint" error because gotrue attempts to create the same phone identity
curl -X PUT "http://localhost:9999/user" -H "Authorization: Bearer <access_token>" -H "Content-Type: application/json" -d '{"phone": "123456789"}'
```

* ~This PR attempts to fix this issue by only creating the identity if the user's `phone` or `phone_change` columns are empty.~
