### PR TITLE
feat: return SMS ID when possible

### DIFF
--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -43,7 +43,7 @@ func formatPhoneNumber(phone string) string {
 }
 
 // sendPhoneConfirmation sends an otp to the user's phone number
-func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection, user *models.User, phone, otpType string, smsProvider sms_provider.SmsProvider, channel string) error {
+func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection, user *models.User, phone, otpType string, smsProvider sms_provider.SmsProvider, channel string) (string, error) {
 	config := a.config
 
 	var token *string
@@ -65,17 +65,17 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 		sentAt = user.ReauthenticationSentAt
 		includeFields = append(includeFields, "reauthentication_token", "reauthentication_sent_at")
 	default:
-		return internalServerError("invalid otp type")
+		return "", internalServerError("invalid otp type")
 	}
 
 	if sentAt != nil && !sentAt.Add(config.Sms.MaxFrequency).Before(time.Now()) {
-		return MaxFrequencyLimitError
+		return "", MaxFrequencyLimitError
 	}
 
 	oldToken := *token
 	otp, err := crypto.GenerateOtp(config.Sms.OtpLength)
 	if err != nil {
-		return internalServerError("error generating otp").WithInternalError(err)
+		return "", internalServerError("error generating otp").WithInternalError(err)
 	}
 	*token = fmt.Sprintf("%x", sha256.Sum224([]byte(phone+otp)))
 
@@ -86,9 +86,10 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 		message = strings.Replace(config.Sms.Template, "{{ .Code }}", otp, -1)
 	}
 
-	if serr := smsProvider.SendMessage(phone, message, channel); serr != nil {
+	messageID, serr := smsProvider.SendMessage(phone, message, channel)
+	if serr != nil {
 		*token = oldToken
-		return serr
+		return messageID, serr
 	}
 
 	now := time.Now()
@@ -102,5 +103,5 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 		user.ReauthenticationSentAt = &now
 	}
 
-	return errors.Wrap(tx.UpdateOnly(user, includeFields...), "Database error updating user for confirmation")
+	return messageID, errors.Wrap(tx.UpdateOnly(user, includeFields...), "Database error updating user for confirmation")
 }

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -30,8 +30,8 @@ type TestSmsProvider struct {
 	mock.Mock
 }
 
-func (t *TestSmsProvider) SendMessage(phone string, message string, channel string) error {
-	return nil
+func (t *TestSmsProvider) SendMessage(phone string, message string, channel string) (string, error) {
+	return "", nil
 }
 
 func TestPhone(t *testing.T) {
@@ -99,7 +99,7 @@ func (ts *PhoneTestSuite) TestSendPhoneConfirmation() {
 
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
-			err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, &TestSmsProvider{}, sms_provider.SMSProvider)
+			_, err = ts.API.sendPhoneConfirmation(ctx, ts.API.db, u, "123456789", c.otpType, &TestSmsProvider{}, sms_provider.SMSProvider)
 			require.Equal(ts.T(), c.expected, err)
 			u, err = models.FindUserByPhoneAndAudience(ts.API.db, "123456789", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -37,6 +37,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	messageID := ""
 	err := db.Transaction(func(tx *storage.Connection) error {
 		if terr := models.NewAuditLogEntry(r, tx, user, models.UserReauthenticateAction, "", nil); terr != nil {
 			return terr
@@ -49,7 +50,12 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return badRequestError("Error sending sms: %v", terr)
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, phone, phoneReauthenticationOtp, smsProvider, sms_provider.SMSProvider)
+			mID, err := a.sendPhoneConfirmation(ctx, tx, user, phone, phoneReauthenticationOtp, smsProvider, sms_provider.SMSProvider)
+			if err != nil {
+				return err
+			}
+
+			messageID = mID
 		}
 		return nil
 	})
@@ -60,7 +66,13 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	return sendJSON(w, http.StatusOK, make(map[string]string))
+	ret := map[string]any{}
+	if messageID != "" {
+		ret["message_id"] = messageID
+
+	}
+
+	return sendJSON(w, http.StatusOK, ret)
 }
 
 // verifyReauthentication checks if the nonce provided is valid

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -112,6 +112,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	messageID := ""
 	err = db.Transaction(func(tx *storage.Connection) error {
 		mailer := a.Mailer(ctx)
 		referrer := a.getReferrer(r)
@@ -131,7 +132,11 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return terr
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, sms_provider.SMSProvider)
+			mID, terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, sms_provider.SMSProvider)
+			if terr != nil {
+				return terr
+			}
+			messageID = mID
 		case emailChangeVerification:
 			return a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow)
 		case phoneChangeVerification:
@@ -139,7 +144,11 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			if terr != nil {
 				return terr
 			}
-			return a.sendPhoneConfirmation(ctx, tx, user, user.PhoneChange, phoneChangeVerification, smsProvider, sms_provider.SMSProvider)
+			mID, terr := a.sendPhoneConfirmation(ctx, tx, user, user.PhoneChange, phoneChangeVerification, smsProvider, sms_provider.SMSProvider)
+			if terr != nil {
+				return terr
+			}
+			messageID = mID
 		}
 		return nil
 	})
@@ -151,5 +160,10 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 		return internalServerError("Unable to process request").WithInternalError(err)
 	}
 
-	return sendJSON(w, http.StatusOK, map[string]string{})
+	ret := map[string]any{}
+	if messageID != "" {
+		ret["message_id"] = messageID
+	}
+
+	return sendJSON(w, http.StatusOK, ret)
 }

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -223,7 +223,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				if terr != nil {
 					return badRequestError("Error sending confirmation sms: %v", terr)
 				}
-				if terr = a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, params.Channel); terr != nil {
+				if _, terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneConfirmationOtp, smsProvider, params.Channel); terr != nil {
 					return badRequestError("Error sending confirmation sms: %v", terr)
 				}
 			}

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 type SmsProvider interface {
-	SendMessage(phone, message, channel string) error
+	SendMessage(phone, message, channel string) (string, error)
 }
 
 func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {

--- a/internal/api/sms_provider/sms_provider_test.go
+++ b/internal/api/sms_provider/sms_provider_test.go
@@ -86,10 +86,11 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 				MatchHeader("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(twilioProvider.Config.AccountSid+":"+twilioProvider.Config.AuthToken))).
 				MatchType("url").BodyString(body.Encode()).
 				Reply(200).JSON(SmsStatus{
-				To:     "+" + phone,
-				From:   twilioProvider.Config.MessageServiceSid,
-				Status: "sent",
-				Body:   message,
+				To:         "+" + phone,
+				From:       twilioProvider.Config.MessageServiceSid,
+				Status:     "sent",
+				Body:       message,
+				MessageSID: "abcdef",
 			}),
 			ExpectedError: nil,
 		},
@@ -102,8 +103,9 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 				ErrorMessage: "failed to send sms",
 				ErrorCode:    "401",
 				Status:       "failed",
+				MessageSID:   "abcdef",
 			}),
-			ExpectedError: fmt.Errorf("twilio error: %v %v", "failed to send sms", "401"),
+			ExpectedError: fmt.Errorf("twilio error: %v %v for message %v", "failed to send sms", "401", "abcdef"),
 		},
 		{
 			Desc: "Non-2xx status code returned",
@@ -127,7 +129,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 
 	for _, c := range cases {
 		ts.Run(c.Desc, func() {
-			err = twilioProvider.SendSms(phone, message, SMSProvider)
+			_, err = twilioProvider.SendSms(phone, message, SMSProvider)
 			require.Equal(ts.T(), c.ExpectedError, err)
 		})
 	}
@@ -156,7 +158,7 @@ func (ts *SmsProviderTestSuite) TestMessagebirdSendSms() {
 		},
 	})
 
-	err = messagebirdProvider.SendSms(phone, message)
+	_, err = messagebirdProvider.SendSms(phone, message)
 	require.NoError(ts.T(), err)
 }
 
@@ -185,7 +187,7 @@ func (ts *SmsProviderTestSuite) TestVonageSendSms() {
 		},
 	})
 
-	err = vonageProvider.SendSms(phone, message)
+	_, err = vonageProvider.SendSms(phone, message)
 	require.NoError(ts.T(), err)
 }
 
@@ -211,6 +213,6 @@ func (ts *SmsProviderTestSuite) TestTextLocalSendSms() {
 		Errors: []TextlocalError{},
 	})
 
-	err = textlocalProvider.SendSms(phone, message)
+	_, err = textlocalProvider.SendSms(phone, message)
 	require.NoError(ts.T(), err)
 }

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -27,8 +27,13 @@ type TextlocalError struct {
 }
 
 type TextlocalResponse struct {
-	Status string           `json:"status"`
-	Errors []TextlocalError `json:"errors"`
+	Status   string             `json:"status"`
+	Errors   []TextlocalError   `json:"errors"`
+	Messages []TextlocalMessage `json:"messages"`
+}
+
+type TextlocalMessage struct {
+	MessageID string `json:"id"`
 }
 
 // Creates a SmsProvider with the Textlocal Config
@@ -44,17 +49,17 @@ func NewTextlocalProvider(config conf.TextlocalProviderConfiguration) (SmsProvid
 	}, nil
 }
 
-func (t *TextlocalProvider) SendMessage(phone string, message string, channel string) error {
+func (t *TextlocalProvider) SendMessage(phone string, message string, channel string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
-		return fmt.Errorf("channel type %q is not supported for TextLocal", channel)
+		return "", fmt.Errorf("channel type %q is not supported for TextLocal", channel)
 	}
 }
 
 // Send an SMS containing the OTP with Textlocal's API
-func (t *TextlocalProvider) SendSms(phone string, message string) error {
+func (t *TextlocalProvider) SendSms(phone string, message string) (string, error) {
 	body := url.Values{
 		"sender":  {t.Config.Sender},
 		"apikey":  {t.Config.ApiKey},
@@ -65,29 +70,35 @@ func (t *TextlocalProvider) SendSms(phone string, message string) error {
 	client := &http.Client{Timeout: defaultTimeout}
 	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	res, err := client.Do(r)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer utilities.SafeClose(res.Body)
 
 	resp := &TextlocalResponse{}
 	derr := json.NewDecoder(res.Body).Decode(resp)
 	if derr != nil {
-		return derr
+		return "", derr
 	}
 
 	if len(resp.Errors) > 0 {
-		return errors.New("textlocal error: Internal Error")
+		return "", errors.New("textlocal error: Internal Error")
 	}
+
+	messageID := ""
 
 	if resp.Status != "success" {
-		return fmt.Errorf("textlocal error: %v (code: %v)", resp.Errors[0].Message, resp.Errors[0].Code)
+		if len(resp.Messages) > 0 {
+			messageID = resp.Messages[0].MessageID
+		}
+
+		return messageID, fmt.Errorf("textlocal error: %v (code: %v) message %s", resp.Errors[0].Message, resp.Errors[0].Code, messageID)
 	}
 
-	return nil
+	return messageID, nil
 }

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -24,6 +24,7 @@ type TwilioProvider struct {
 type SmsStatus struct {
 	To           string `json:"to"`
 	From         string `json:"from"`
+	MessageSID   string `json:"sid"`
 	Status       string `json:"status"`
 	ErrorCode    string `json:"error_code"`
 	ErrorMessage string `json:"error_message"`
@@ -54,17 +55,17 @@ func NewTwilioProvider(config conf.TwilioProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
-func (t *TwilioProvider) SendMessage(phone string, message string, channel string) error {
+func (t *TwilioProvider) SendMessage(phone string, message string, channel string) (string, error) {
 	switch channel {
 	case SMSProvider, WhatsappProvider:
 		return t.SendSms(phone, message, channel)
 	default:
-		return fmt.Errorf("channel type %q is not supported for Twilio", channel)
+		return "", fmt.Errorf("channel type %q is not supported for Twilio", channel)
 	}
 }
 
 // Send an SMS containing the OTP with Twilio's API
-func (t *TwilioProvider) SendSms(phone, message, channel string) error {
+func (t *TwilioProvider) SendSms(phone, message, channel string) (string, error) {
 	sender := t.Config.MessageServiceSid
 	receiver := "+" + phone
 	if channel == WhatsappProvider {
@@ -80,32 +81,32 @@ func (t *TwilioProvider) SendSms(phone, message, channel string) error {
 	client := &http.Client{Timeout: defaultTimeout}
 	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
 	if err != nil {
-		return err
+		return "", err
 	}
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	r.SetBasicAuth(t.Config.AccountSid, t.Config.AuthToken)
 	res, err := client.Do(r)
 	defer utilities.SafeClose(res.Body)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		resp := &twilioErrResponse{}
 		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
-			return err
+			return "", err
 		}
-		return resp
+		return "", resp
 	}
 	// validate sms status
 	resp := &SmsStatus{}
 	derr := json.NewDecoder(res.Body).Decode(resp)
 	if derr != nil {
-		return derr
+		return "", derr
 	}
 
 	if resp.Status == "failed" || resp.Status == "undelivered" {
-		return fmt.Errorf("twilio error: %v %v", resp.ErrorMessage, resp.ErrorCode)
+		return resp.MessageSID, fmt.Errorf("twilio error: %v %v for message %s", resp.ErrorMessage, resp.ErrorCode, resp.MessageSID)
 	}
 
-	return nil
+	return resp.MessageSID, nil
 }

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -23,6 +23,7 @@ type VonageProvider struct {
 }
 
 type VonageResponseMessage struct {
+	MessageID string `json:"message-id"`
 	Status    string `json:"status"`
 	ErrorText string `json:"error-text"`
 }
@@ -44,17 +45,17 @@ func NewVonageProvider(config conf.VonageProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
-func (t *VonageProvider) SendMessage(phone string, message string, channel string) error {
+func (t *VonageProvider) SendMessage(phone string, message string, channel string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)
 	default:
-		return fmt.Errorf("channel type %q is not supported for Vonage", channel)
+		return "", fmt.Errorf("channel type %q is not supported for Vonage", channel)
 	}
 }
 
 // Send an SMS containing the OTP with Vonage's API
-func (t *VonageProvider) SendSms(phone string, message string) error {
+func (t *VonageProvider) SendSms(phone string, message string) (string, error) {
 	body := url.Values{
 		"from":       {t.Config.From},
 		"to":         {phone},
@@ -71,30 +72,30 @@ func (t *VonageProvider) SendSms(phone string, message string) error {
 	client := &http.Client{Timeout: defaultTimeout}
 	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	res, err := client.Do(r)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer utilities.SafeClose(res.Body)
 
 	resp := &VonageResponse{}
 	derr := json.NewDecoder(res.Body).Decode(resp)
 	if derr != nil {
-		return derr
+		return "", derr
 	}
 
 	if len(resp.Messages) <= 0 {
-		return errors.New("vonage error: Internal Error")
+		return "", errors.New("vonage error: Internal Error")
 	}
 
 	// A status of zero indicates success; a non-zero value means something went wrong.
 	if resp.Messages[0].Status != "0" {
-		return fmt.Errorf("vonage error: %v (status: %v)", resp.Messages[0].ErrorText, resp.Messages[0].Status)
+		return resp.Messages[0].MessageID, fmt.Errorf("vonage error: %v (status: %v) for message %s", resp.Messages[0].ErrorText, resp.Messages[0].Status, resp.Messages[0].MessageID)
 	}
 
-	return nil
+	return resp.Messages[0].MessageID, nil
 }

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -217,7 +217,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				if terr != nil {
 					return badRequestError("Error sending sms: %v", terr)
 				}
-				if terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider, params.Channel); terr != nil {
+				if _, terr := a.sendPhoneConfirmation(ctx, tx, user, params.Phone, phoneChangeVerification, smsProvider, params.Channel); terr != nil {
 					return internalServerError("Error sending phone change otp").WithInternalError(terr)
 				}
 			}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -457,6 +457,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  message_id:
+                    type: string
+                    description: Unique ID of the message as reported by the SMS sending provider. Useful for tracking deliverability problems.
         400:
           $ref: "#/components/responses/BadRequestResponse"
         422:
@@ -554,6 +558,10 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  message_id:
+                    type: string
+                    description: Unique ID of the message as reported by the SMS sending provider. Useful for tracking deliverability problems.
         400:
           $ref: "#/components/responses/BadRequestResponse"
         422:


### PR DESCRIPTION
Returns the SMS message ID as received from the SMS sending provider in `/otp` and `/resend` to aid in debugging deliverability issues. Logs also include the message ID when available.