### PR TITLE
fix: check err before using user

### DIFF
--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -339,12 +339,10 @@ func (a *API) signupNewUser(ctx context.Context, conn *storage.Connection, param
 		// handles external provider case
 		user, err = models.NewUser("", params.Email, params.Password, params.Aud, params.Data)
 	}
-
-	user.IsSSOUser = isSSOUser
-
 	if err != nil {
 		return nil, internalServerError("Database error creating user").WithInternalError(err)
 	}
+	user.IsSSOUser = isSSOUser
 	if user.AppMetaData == nil {
 		user.AppMetaData = make(map[string]interface{})
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Set `IsSSOUser` field on user only after err has been checked, else this might result in a panic the the rare case where  `models.NewUser` returns an error
