### PR TITLE
chore: normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,41 @@
+# Set the default behavior
+* text=auto
+
+# Go files
+*.mod text eol=lf
+*.sum text eol=lf
+*.go text eol=lf
+
+# Serialization
+*.yml eol=lf
+*.yaml eol=lf
+*.toml eol=lf
+*.json eol=lf
+
+# Scripts
+*.sh eol=lf
+
+# DB files
+*.sql eol=lf
+
+# Html
+*.html eol=lf
+
+# Text and markdown files
+*.txt text eol=lf
+*.md text eol=lf
+
+# Environment files/examples
+*.env text eol=lf
+
+# Docker files
+.dockerignore text eol=lf
+Dockerfile* text eol=lf
+
+# Makefile
+Makefile text eol=lf
+
+# Git files
+.gitignore text eol=lf
+.gitattributes text eol=lf
+.gitkeep text eol=lf


### PR DESCRIPTION
This addresses differences in eol handling between OSes by normalizing the line endings using a `.gitattributes` file.

On Windows, cloning the repo and building the containers causes the Postgres container to fail to initialize and shutdown early due to `init_postgres.sh` being copied into the container with Windows line endings. 

Fixes #1155

New clones of the repo shouldn't have issues with this after this PR is merged. Existing clones which don't already contain `LF` line endings may have to reset using
```
git rm --cached -r .
git reset --hard
```
to update their files' line endings.
