### PR TITLE
Ignore built .exe file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 vendor/
 gotrue
 gotrue-arm64
+gotrue.exe
 
 coverage.out
 


### PR DESCRIPTION
Ignores the built gotrue.exe file generated on Windows.

This improves development experience and repo contribution if the user clones the repo to a Windows environment. 

## What is the current behavior?

Git marks the built gotrue.exe file as untracked.

## What is the new behavior?

Git ignores the gotrue.exe file as it already does with similar built files.
