### PR TITLE
feat: require different passwords on update

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -72,11 +72,6 @@ func (p *UserUpdateParams) Validate(tx *storage.Connection, user *models.User, a
 			return invalidPasswordLengthError(config.PasswordMinLength)
 		}
 
-		// if password reauthentication is enabled, user can only update password together with a nonce sent
-		if config.Security.UpdatePasswordRequireReauthentication && p.Nonce == "" {
-			return unauthorizedError("Password update requires reauthentication.")
-		}
-
 		if user.EncryptedPassword != "" && user.Authenticate(password) {
 			return unprocessableEntityError("New password should be different from the old password.")
 		}


### PR DESCRIPTION
When the user updates their password, the new and old passwords must be different. When an admin does it, this is not checked.