### PR TITLE
feat: allow `POST /verify` to accept a token hash

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -48,42 +48,83 @@ const singleConfirmationAccepted = "Confirmation link accepted. Please proceed t
 type VerifyParams struct {
 	Type       string `json:"type"`
 	Token      string `json:"token"`
+	TokenHash  string `json:"token_hash"`
 	Email      string `json:"email"`
 	Phone      string `json:"phone"`
 	RedirectTo string `json:"redirect_to"`
 }
 
-func (p *VerifyParams) Validate() error {
-	if p.Token == "" {
-		return badRequestError("Verify requires a token")
-	}
-
+func (p *VerifyParams) Validate(r *http.Request) error {
+	var err error
 	if p.Type == "" {
 		return badRequestError("Verify requires a verification type")
+	}
+	switch r.Method {
+	case http.MethodGet:
+		if p.Token == "" {
+			return badRequestError("Verify requires a token or a token hash")
+		}
+		p.TokenHash = p.Token
+	case http.MethodPost:
+		if (p.Token == "" && p.TokenHash == "") || (p.Token != "" && p.TokenHash != "") {
+			return badRequestError("Verify requires either a token or a token hash")
+		}
+		if p.Token != "" {
+			if isPhoneOtpVerification(p) {
+				p.Phone, err = validatePhone(p.Phone)
+				if err != nil {
+					return err
+				}
+				p.TokenHash = fmt.Sprintf("%x", sha256.Sum224([]byte(string(p.Phone)+p.Token)))
+			} else if isEmailOtpVerification(p) {
+				p.Email, err = validateEmail(p.Email)
+				if err != nil {
+					return unprocessableEntityError("Invalid email format").WithInternalError(err)
+				}
+				p.TokenHash = fmt.Sprintf("%x", sha256.Sum224([]byte(string(p.Email)+p.Token)))
+			} else {
+				return badRequestError("Only an email address or phone number should be provided on verify")
+			}
+		}
+	default:
+		return nil
 	}
 	return nil
 }
 
 // Verify exchanges a confirmation or recovery token to a refresh token
 func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
+	params := &VerifyParams{}
 	switch r.Method {
 	case http.MethodGet:
-		return a.verifyGet(w, r)
+		params.Token = r.FormValue("token")
+		params.Type = r.FormValue("type")
+		params.RedirectTo = a.getRedirectURLOrReferrer(r, r.FormValue("redirect_to"))
+		if err := params.Validate(r); err != nil {
+			return err
+		}
+		return a.verifyGet(w, r, params)
 	case http.MethodPost:
-		return a.verifyPost(w, r)
+		body, err := getBodyBytes(r)
+		if err != nil {
+			return badRequestError("Could not read body").WithInternalError(err)
+		}
+		if err := json.Unmarshal(body, params); err != nil {
+			return badRequestError("Could not read verification params: %v", err)
+		}
+		if err := params.Validate(r); err != nil {
+			return err
+		}
+		return a.verifyPost(w, r, params)
 	default:
 		return unprocessableEntityError("Only GET and POST methods are supported.")
 	}
 }
 
-func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
+func (a *API) verifyGet(w http.ResponseWriter, r *http.Request, params *VerifyParams) error {
 	ctx := r.Context()
 	db := a.db.WithContext(ctx)
 	config := a.config
-	params := &VerifyParams{}
-	params.Token = r.FormValue("token")
-	params.Type = r.FormValue("type")
-	params.RedirectTo = a.getRedirectURLOrReferrer(r, r.FormValue("redirect_to"))
 
 	var (
 		user        *models.User
@@ -92,7 +133,7 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 		token       *AccessTokenResponse
 		authCode    string
 	)
-	var flowType models.FlowType
+	flowType := models.ImplicitFlow
 	var authenticationMethod models.AuthenticationMethod
 	if strings.HasPrefix(params.Token, PKCEPrefix) {
 		flowType = models.PKCEFlow
@@ -100,19 +141,11 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
-	} else {
-		flowType = models.ImplicitFlow
 	}
-	if err := params.Validate(); err != nil {
-		return err
-	}
-
 	err = db.Transaction(func(tx *storage.Connection) error {
 		var terr error
-
-		params.Token = strings.ReplaceAll(params.Token, "-", "")
 		aud := a.requestAud(ctx, r)
-		user, terr = a.verifyEmailLink(ctx, tx, params, aud, flowType)
+		user, terr = a.verifyTokenHash(ctx, tx, params, aud)
 		if terr != nil {
 			return terr
 		}
@@ -177,26 +210,10 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
+func (a *API) verifyPost(w http.ResponseWriter, r *http.Request, params *VerifyParams) error {
 	ctx := r.Context()
 	db := a.db.WithContext(ctx)
 	config := a.config
-	params := &VerifyParams{}
-
-	body, err := getBodyBytes(r)
-	if err != nil {
-		return badRequestError("Could not read body").WithInternalError(err)
-	}
-
-	if err := json.Unmarshal(body, params); err != nil {
-		return badRequestError("Could not read verification params: %v", err)
-	}
-
-	if err := params.Validate(); err != nil {
-		return err
-	}
-
-	params.Token = strings.ReplaceAll(params.Token, "-", "")
 
 	var (
 		user        *models.User
@@ -204,10 +221,15 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request) error {
 		token       *AccessTokenResponse
 	)
 
-	err = db.Transaction(func(tx *storage.Connection) error {
+	err := db.Transaction(func(tx *storage.Connection) error {
 		var terr error
 		aud := a.requestAud(ctx, r)
-		user, terr = a.verifyUserAndToken(ctx, tx, params, aud)
+
+		if isUsingTokenHash(params) {
+			user, terr = a.verifyTokenHash(ctx, tx, params, aud)
+		} else {
+			user, terr = a.verifyUserAndToken(ctx, tx, params, aud)
+		}
 		if terr != nil {
 			return terr
 		}
@@ -432,18 +454,18 @@ func (a *API) emailChangeVerify(r *http.Request, ctx context.Context, conn *stor
 	return user, nil
 }
 
-func (a *API) verifyEmailLink(ctx context.Context, conn *storage.Connection, params *VerifyParams, aud string, flowType models.FlowType) (*models.User, error) {
+func (a *API) verifyTokenHash(ctx context.Context, conn *storage.Connection, params *VerifyParams, aud string) (*models.User, error) {
 	config := a.config
 
 	var user *models.User
 	var err error
 	switch params.Type {
 	case signupVerification, inviteVerification:
-		user, err = models.FindUserByConfirmationToken(conn, params.Token)
+		user, err = models.FindUserByConfirmationToken(conn, params.TokenHash)
 	case recoveryVerification, magicLinkVerification:
-		user, err = models.FindUserByRecoveryToken(conn, params.Token)
+		user, err = models.FindUserByRecoveryToken(conn, params.TokenHash)
 	case emailChangeVerification:
-		user, err = models.FindUserByEmailChangeToken(conn, params.Token)
+		user, err = models.FindUserByEmailChangeToken(conn, params.TokenHash)
 	default:
 		return nil, badRequestError("Invalid email verification type")
 	}
@@ -482,36 +504,17 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 
 	var user *models.User
 	var err error
-	var tokenHash string
+	tokenHash := params.TokenHash
 
-	if isPhoneOtpVerification(params) {
-		params.Phone, err = validatePhone(params.Phone)
-		if err != nil {
-			return nil, err
-		}
-		tokenHash = fmt.Sprintf("%x", sha256.Sum224([]byte(string(params.Phone)+params.Token)))
-		switch params.Type {
-		case phoneChangeVerification:
-			user, err = models.FindUserByPhoneChangeAndAudience(conn, params.Phone, aud)
-		case smsVerification:
-			user, err = models.FindUserByPhoneAndAudience(conn, params.Phone, aud)
-		default:
-			return nil, badRequestError("Invalid sms verification type")
-		}
-	} else if isEmailOtpVerification(params) {
-		params.Email, err = validateEmail(params.Email)
-		if err != nil {
-			return nil, unprocessableEntityError("Invalid email format").WithInternalError(err)
-		}
-		tokenHash = fmt.Sprintf("%x", sha256.Sum224([]byte(string(params.Email)+params.Token)))
-		switch params.Type {
-		case emailChangeVerification:
-			user, err = models.FindUserForEmailChange(conn, params.Email, tokenHash, aud, config.Mailer.SecureEmailChangeEnabled)
-		default:
-			user, err = models.FindUserByEmailAndAudience(conn, params.Email, aud)
-		}
-	} else {
-		return nil, badRequestError("Only an email address or phone number should be provided on verify")
+	switch params.Type {
+	case phoneChangeVerification:
+		user, err = models.FindUserByPhoneChangeAndAudience(conn, params.Phone, aud)
+	case smsVerification:
+		user, err = models.FindUserByPhoneAndAudience(conn, params.Phone, aud)
+	case emailChangeVerification:
+		user, err = models.FindUserForEmailChange(conn, params.Email, tokenHash, aud, config.Mailer.SecureEmailChangeEnabled)
+	default:
+		user, err = models.FindUserByEmailAndAudience(conn, params.Email, aud)
 	}
 
 	if err != nil {
@@ -590,4 +593,8 @@ func isPhoneOtpVerification(params *VerifyParams) bool {
 // isEmailOtpVerification checks if the verification came from an email otp
 func isEmailOtpVerification(params *VerifyParams) bool {
 	return params.Phone == "" && params.Email != ""
+}
+
+func isUsingTokenHash(params *VerifyParams) bool {
+	return params.TokenHash != "" && params.Token == "" && params.Phone == "" && params.Email == ""
 }

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -110,7 +110,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 			return badRequestError("Could not read body").WithInternalError(err)
 		}
 		if err := json.Unmarshal(body, params); err != nil {
-			return badRequestError("Could not read verification params: %v", err)
+			return badRequestError("Could not parse verification params: %v", err)
 		}
 		if err := params.Validate(r); err != nil {
 			return err

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -761,11 +761,8 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 	require.NoError(ts.T(), ts.API.db.Update(u))
 
 	type expected struct {
-		code int
-	}
-
-	expectedResponse := expected{
-		code: http.StatusOK,
+		code      int
+		tokenHash string
 	}
 
 	cases := []struct {
@@ -783,7 +780,10 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 				"token":     "123456",
 				"phone":     u.GetPhone(),
 			},
-			expected: expectedResponse,
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetPhone()+"123456"))),
+			},
 		},
 		{
 			desc:     "Valid Confirmation OTP",
@@ -794,7 +794,10 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 				"token":     "123456",
 				"email":     u.GetEmail(),
 			},
-			expected: expectedResponse,
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+			},
 		},
 		{
 			desc:     "Valid Recovery OTP",
@@ -805,7 +808,10 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 				"token":     "123456",
 				"email":     u.GetEmail(),
 			},
-			expected: expectedResponse,
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+			},
 		},
 		{
 			desc:     "Valid Email OTP",
@@ -816,7 +822,10 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 				"token":     "123456",
 				"email":     u.GetEmail(),
 			},
-			expected: expectedResponse,
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+			},
 		},
 		{
 			desc:     "Valid Email Change OTP",
@@ -827,7 +836,10 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 				"token":     "123456",
 				"email":     u.EmailChange,
 			},
-			expected: expectedResponse,
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.EmailChange+"123456"))),
+			},
 		},
 		{
 			desc:     "Valid Phone Change OTP",
@@ -838,7 +850,34 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 				"token":     "123456",
 				"phone":     u.PhoneChange,
 			},
-			expected: expectedResponse,
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.PhoneChange+"123456"))),
+			},
+		},
+		{
+			desc:     "Valid Signup Token Hash",
+			sentTime: time.Now(),
+			body: map[string]interface{}{
+				"type":       signupVerification,
+				"token_hash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.Email+"123456"))),
+			},
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.Email+"123456"))),
+			},
+		},
+		{
+			desc:     "Valid Email Change Token Hash",
+			sentTime: time.Now(),
+			body: map[string]interface{}{
+				"type":       emailChangeVerification,
+				"token_hash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.EmailChange+"123456"))),
+			},
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.EmailChange+"123456"))),
+			},
 		},
 	}
 
@@ -849,10 +888,10 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			u.RecoverySentAt = &c.sentTime
 			u.EmailChangeSentAt = &c.sentTime
 			u.PhoneChangeSentAt = &c.sentTime
-			u.ConfirmationToken = c.body["tokenHash"].(string)
-			u.RecoveryToken = c.body["tokenHash"].(string)
-			u.EmailChangeTokenNew = c.body["tokenHash"].(string)
-			u.PhoneChangeToken = c.body["tokenHash"].(string)
+			u.ConfirmationToken = c.expected.tokenHash
+			u.RecoveryToken = c.expected.tokenHash
+			u.EmailChangeTokenNew = c.expected.tokenHash
+			u.PhoneChangeToken = c.expected.tokenHash
 			require.NoError(ts.T(), ts.API.db.Update(u))
 
 			var buffer bytes.Buffer
@@ -866,6 +905,81 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			w := httptest.NewRecorder()
 			ts.API.handler.ServeHTTP(w, req)
 			assert.Equal(ts.T(), c.expected.code, w.Code)
+		})
+	}
+}
+
+func (ts *VerifyTestSuite) TestVerifyValidateParams() {
+	cases := []struct {
+		desc     string
+		params   *VerifyParams
+		method   string
+		expected error
+	}{
+		{
+			desc: "Successful GET Verify",
+			params: &VerifyParams{
+				Type:  "signup",
+				Token: "some-token-hash",
+			},
+			method:   http.MethodGet,
+			expected: nil,
+		},
+		{
+			desc: "Successful POST Verify (TokenHash)",
+			params: &VerifyParams{
+				Type:      "signup",
+				TokenHash: "some-token-hash",
+			},
+			method:   http.MethodPost,
+			expected: nil,
+		},
+		{
+			desc: "Successful POST Verify (Token)",
+			params: &VerifyParams{
+				Type:  "signup",
+				Token: "some-token",
+				Email: "email@example.com",
+			},
+			method:   http.MethodPost,
+			expected: nil,
+		},
+		// unsuccessful validations
+		{
+			desc: "Need to send email or phone number with token",
+			params: &VerifyParams{
+				Type:  "signup",
+				Token: "some-token",
+			},
+			method:   http.MethodPost,
+			expected: badRequestError("Only an email address or phone number should be provided on verify"),
+		},
+		{
+			desc: "Cannot send both TokenHash and Token",
+			params: &VerifyParams{
+				Type:      "signup",
+				Token:     "some-token",
+				TokenHash: "some-token-hash",
+			},
+			method:   http.MethodPost,
+			expected: badRequestError("Verify requires either a token or a token hash"),
+		},
+		{
+			desc: "No verification type specified",
+			params: &VerifyParams{
+				Token: "some-token",
+				Email: "email@example.com",
+			},
+			method:   http.MethodPost,
+			expected: badRequestError("Verify requires a verification type"),
+		},
+	}
+
+	for _, c := range cases {
+		ts.Run(c.desc, func() {
+			req := httptest.NewRequest(c.method, "http://localhost", nil)
+			err := c.params.Validate(req)
+			require.Equal(ts.T(), c.expected, err)
 		})
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* To enable server-side redirection via an email link, we need some way to return the session in the response body rather than in the query fragments (`GET /verify`) because the fragments can't be parsed on the server-side.

* By allowing `POST /verify` to accept just a token hash, a developer would be able to set the verification URL in their email template to point to their own endpoint (`https://myapp.com/confirm-signup?token_hash=XXX&type=signup`) and  parse the `token_hash` param before calling `POST /verify` with the following:

```bash
curl -X POST 'http://localhost:9999/verify' -H 'Content-Type: application/json' \ 
-d '{"token_hash": "my_token_hash", "type": "signup" }'
```

If the token hash is valid and the request is successful, this would return the verified user's session in the response and the developer can subsequently handle any redirection on their own.