### PR TITLE
feat: set `updated_at` on `refresh_tokens` when revoking family

### DIFF
--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -73,7 +73,7 @@ func RevokeTokenFamily(tx *storage.Connection, token *RefreshToken) error {
 	var err error
 	tablename := (&pop.Model{Value: RefreshToken{}}).TableName()
 	if token.SessionId != nil {
-		err = tx.RawQuery(`update `+tablename+` set revoked = true where session_id = ? and revoked = false;`, token.SessionId).Exec()
+		err = tx.RawQuery(`update `+tablename+` set revoked = true, updated_at = now() where session_id = ? and revoked = false;`, token.SessionId).Exec()
 	} else {
 		err = tx.RawQuery(`
 		with recursive token_family as (


### PR DESCRIPTION
`updated_at` was not being updated when the token family was being revoked, which makes it impossible to figure out when the revocation actually happened.