### PR TITLE
fix: add discord `global_name` to custom_claims

### DIFF
--- a/internal/api/provider/discord.go
+++ b/internal/api/provider/discord.go
@@ -26,6 +26,7 @@ type discordUser struct {
 	Email         string `json:"email"`
 	ID            string `json:"id"`
 	Name          string `json:"username"`
+	GlobalName    string `json:"global_name"`
 	Verified      bool   `json:"verified"`
 }
 
@@ -104,6 +105,9 @@ func (g discordProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*U
 			Picture:       avatarURL,
 			Email:         u.Email,
 			EmailVerified: u.Verified,
+			CustomClaims: map[string]interface{}{
+				"global_name": u.GlobalName,
+			},
 
 			// To be deprecated
 			AvatarURL:  avatarURL,


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes https://github.com/supabase/gotrue/issues/1133
* Note: The `global_name` attribute will just default to an empty string if it's not returned by discord / not present