### PR TITLE
feat: drop restriction that PKCE cannot be used with autoconfirm

### DIFF
--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -103,10 +103,6 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		if codeChallengeMethod, err = models.ParseCodeChallengeMethod(params.CodeChallengeMethod); err != nil {
 			return err
 		}
-		// PKCE not needed as autoconfirm returns access token in body
-		if config.Mailer.Autoconfirm {
-			return badRequestError("PKCE flow is not supported on signups with autoconfirm enabled")
-		}
 	}
 
 	var user *models.User


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow autoconfirm signup to be used with PKCE. When used with PKCE,  autoconfirm signups retain their behaviour of returning an access token directly

## What is the current behavior?

Calling signup with autoconfirm enabled will throw an error

## What is the new behavior?

Calling signup with autoconfirm enabled will return a session similar to implicit flow

## Additional context

Linked to: https://github.com/supabase/gotrue/pulls?q=is%3Apr+is%3Aclosed++accept+