### PR TITLE
fix: support email verification type on token hash verification

### DIFF
--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -890,6 +890,18 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.EmailChange+"123456"))),
 			},
 		},
+		{
+			desc:     "Valid Email Verification Type",
+			sentTime: time.Now(),
+			body: map[string]interface{}{
+				"type":       emailOTPVerification,
+				"token_hash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.Email+"123456"))),
+			},
+			expected: expected{
+				code:      http.StatusOK,
+				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.Email+"123456"))),
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -47,6 +47,13 @@ func (e IdentityNotFoundError) Error() string {
 	return "Identity not found"
 }
 
+// ConfirmationOrRecoveryTokenNotFoundError represents when a confirmation or recovery token is not found.
+type ConfirmationOrRecoveryTokenNotFoundError struct{}
+
+func (e ConfirmationOrRecoveryTokenNotFoundError) Error() string {
+	return "Confirmation or Recovery Token not found"
+}
+
 // ConfirmationTokenNotFoundError represents when a confirmation token is not found.
 type ConfirmationTokenNotFoundError struct{}
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -392,6 +392,15 @@ func findUser(tx *storage.Connection, query string, args ...interface{}) (*User,
 }
 
 // FindUserByConfirmationToken finds users with the matching confirmation token.
+func FindUserByConfirmationOrRecoveryToken(tx *storage.Connection, token string) (*User, error) {
+	user, err := findUser(tx, "(confirmation_token = ? or recovery_token = ?) and is_sso_user = false", token, token)
+	if err != nil {
+		return nil, ConfirmationOrRecoveryTokenNotFoundError{}
+	}
+	return user, nil
+}
+
+// FindUserByConfirmationToken finds users with the matching confirmation token.
 func FindUserByConfirmationToken(tx *storage.Connection, token string) (*User, error) {
 	user, err := findUser(tx, "confirmation_token = ? and is_sso_user = false", token)
 	if err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Allow `POST /verify` to accept the email verification type when used together with the `token_hash`
* For example:
```
curl -X POST "http://localhost:9999/verify" -H "Content-Type: application/json" -d '{"token_hash": "d00bae897e954fd46a72d72ee9e00eb3e061541413395f08f7f754c1", "type": "email"}'
```