### PR TITLE
fix: log correct referer value

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -59,7 +59,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 	api.deprecationNotices(ctx)
 
 	xffmw, _ := xff.Default()
-	logger := observability.NewStructuredLogger(logrus.StandardLogger())
+	logger := observability.NewStructuredLogger(logrus.StandardLogger(), globalConfig)
 
 	r := newRouter()
 	r.Use(addRequestID(globalConfig))

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -64,7 +64,7 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 		}
 	}
 
-	redirectURL := a.getRedirectURLOrReferrer(r, query.Get("redirect_to"))
+	redirectURL := utilities.GetReferrer(r, config)
 	log := observability.GetLogEntry(r)
 	log.WithField("provider", providerType).Info("Redirecting to external provider")
 	if err := validatePKCEParams(codeChallengeMethod, codeChallenge); err != nil {
@@ -380,7 +380,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 	if !user.IsConfirmed() {
 		if !emailData.Verified && !config.Mailer.Autoconfirm {
 			mailer := a.Mailer(ctx)
-			referrer := a.getReferrer(r)
+			referrer := utilities.GetReferrer(r, config)
 			externalURL := getExternalHost(ctx)
 			if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow); terr != nil {
 				if errors.Is(terr, MaxFrequencyLimitError) {

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -8,6 +8,7 @@ import (
 	"github.com/supabase/gotrue/internal/api/provider"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 // InviteParams are the parameters the Signup endpoint accepts
@@ -78,7 +79,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		mailer := a.Mailer(ctx)
-		referrer := a.getReferrer(r)
+		referrer := utilities.GetReferrer(r, config)
 		externalURL := getExternalHost(ctx)
 		if err := sendInvite(tx, user, mailer, referrer, externalURL, config.Mailer.OtpLength); err != nil {
 			return internalServerError("Error inviting user").WithInternalError(err)

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 // MagicLinkParams holds the parameters for a magic link request
@@ -141,7 +142,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		mailer := a.Mailer(ctx)
-		referrer := a.getReferrer(r)
+		referrer := utilities.GetReferrer(r, config)
 		externalURL := getExternalHost(ctx)
 		return a.sendMagicLink(tx, user, mailer, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType)
 	})

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -50,8 +50,6 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 	config := a.config
 	mailer := a.Mailer(ctx)
 	adminUser := getAdminUser(ctx)
-	referrer := utilities.GetReferrer(r, config)
-
 	params := &GenerateLinkParams{}
 
 	body, err := getBodyBytes(r)
@@ -66,6 +64,10 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 	params.Email, err = validateEmail(params.Email)
 	if err != nil {
 		return err
+	}
+	referrer := utilities.GetReferrer(r, config)
+	if utilities.IsRedirectURLValid(config, params.RedirectTo) {
+		referrer = params.RedirectTo
 	}
 
 	aud := a.requestAud(ctx, r)

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -19,6 +19,7 @@ import (
 	"github.com/supabase/gotrue/internal/mailer"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 var (
@@ -49,6 +50,7 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 	config := a.config
 	mailer := a.Mailer(ctx)
 	adminUser := getAdminUser(ctx)
+	referrer := utilities.GetReferrer(r, config)
 
 	params := &GenerateLinkParams{}
 
@@ -85,7 +87,6 @@ func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var url string
-	referrer := a.getRedirectURLOrReferrer(r, params.RedirectTo)
 	now := time.Now()
 	otp, err := crypto.GenerateOtp(config.Mailer.OtpLength)
 	if err != nil {

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/gobwas/glob"
 	"github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -55,11 +56,13 @@ func (ts *MailTestSuite) TestGenerateLink() {
 	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(ts.Config.JWT.Secret))
 	require.NoError(ts.T(), err, "Error generating admin jwt")
 
+	ts.setURIAllowListMap("http://localhost:8000/**")
 	// create test cases
 	cases := []struct {
-		Desc         string
-		Body         GenerateLinkParams
-		ExpectedCode int
+		Desc             string
+		Body             GenerateLinkParams
+		ExpectedCode     int
+		ExpectedResponse map[string]interface{}
 	}{
 		{
 			Desc: "Generate signup link",
@@ -69,6 +72,22 @@ func (ts *MailTestSuite) TestGenerateLink() {
 				Type:     "signup",
 			},
 			ExpectedCode: http.StatusOK,
+			ExpectedResponse: map[string]interface{}{
+				"redirect_to": ts.Config.SiteURL,
+			},
+		},
+		{
+			Desc: "Generate signup link with custom redirect url",
+			Body: GenerateLinkParams{
+				Email:      "test@example.com",
+				Password:   "secret123",
+				Type:       "signup",
+				RedirectTo: "http://localhost:8000/welcome",
+			},
+			ExpectedCode: http.StatusOK,
+			ExpectedResponse: map[string]interface{}{
+				"redirect_to": "http://localhost:8000/welcome",
+			},
 		},
 		{
 			Desc: "Generate magic link",
@@ -77,6 +96,9 @@ func (ts *MailTestSuite) TestGenerateLink() {
 				Type:  "magiclink",
 			},
 			ExpectedCode: http.StatusOK,
+			ExpectedResponse: map[string]interface{}{
+				"redirect_to": ts.Config.SiteURL,
+			},
 		},
 		{
 			Desc: "Generate invite link",
@@ -85,6 +107,9 @@ func (ts *MailTestSuite) TestGenerateLink() {
 				Type:  "invite",
 			},
 			ExpectedCode: http.StatusOK,
+			ExpectedResponse: map[string]interface{}{
+				"redirect_to": ts.Config.SiteURL,
+			},
 		},
 		{
 			Desc: "Generate recovery link",
@@ -93,6 +118,9 @@ func (ts *MailTestSuite) TestGenerateLink() {
 				Type:  "recovery",
 			},
 			ExpectedCode: http.StatusOK,
+			ExpectedResponse: map[string]interface{}{
+				"redirect_to": ts.Config.SiteURL,
+			},
 		},
 		{
 			Desc: "Generate email change link",
@@ -102,6 +130,9 @@ func (ts *MailTestSuite) TestGenerateLink() {
 				Type:     "email_change_current",
 			},
 			ExpectedCode: http.StatusOK,
+			ExpectedResponse: map[string]interface{}{
+				"redirect_to": ts.Config.SiteURL,
+			},
 		},
 		{
 			Desc: "Generate email change link",
@@ -111,6 +142,9 @@ func (ts *MailTestSuite) TestGenerateLink() {
 				Type:     "email_change_new",
 			},
 			ExpectedCode: http.StatusOK,
+			ExpectedResponse: map[string]interface{}{
+				"redirect_to": ts.Config.SiteURL,
+			},
 		},
 	}
 
@@ -138,13 +172,23 @@ func (ts *MailTestSuite) TestGenerateLink() {
 			require.Contains(ts.T(), data, "redirect_to")
 			require.Equal(ts.T(), c.Body.Type, data["verification_type"])
 
+			// check if redirect_to is correct
+			require.Equal(ts.T(), c.ExpectedResponse["redirect_to"], data["redirect_to"])
+
 			// check if hashed_token matches hash function of email and the raw otp
-			require.Equal(ts.T(), data["hashed_token"], fmt.Sprintf("%x", sha256.Sum224([]byte(c.Body.Email+data["email_otp"].(string)))))
+			require.Equal(ts.T(), fmt.Sprintf("%x", sha256.Sum224([]byte(c.Body.Email+data["email_otp"].(string)))), data["hashed_token"])
 
 			// check if the host used in the email link matches the initial request host
 			u, err := url.ParseRequestURI(data["action_link"].(string))
 			require.NoError(ts.T(), err)
 			require.Equal(ts.T(), req.Host, u.Host)
 		})
+	}
+}
+
+func (ts *MailTestSuite) setURIAllowListMap(uris ...string) {
+	for _, uri := range uris {
+		g := glob.MustCompile(uri, '.', '/')
+		ts.Config.URIAllowListMap[uri] = g
 	}
 }

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 // RecoverParams holds the parameters for a password recovery request
@@ -67,7 +68,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 		mailer := a.Mailer(ctx)
-		referrer := a.getReferrer(r)
+		referrer := utilities.GetReferrer(r, config)
 		if isPKCEFlow(flowType) {
 			codeChallengeMethod, terr := models.ParseCodeChallengeMethod(params.CodeChallengeMethod)
 			if terr != nil {

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -9,6 +9,7 @@ import (
 	"github.com/supabase/gotrue/internal/api/sms_provider"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 // ResendConfirmationParams holds the parameters for a resend request
@@ -113,10 +114,10 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	messageID := ""
+	mailer := a.Mailer(ctx)
+	referrer := utilities.GetReferrer(r, config)
+	externalURL := getExternalHost(ctx)
 	err = db.Transaction(func(tx *storage.Connection) error {
-		mailer := a.Mailer(ctx)
-		referrer := a.getReferrer(r)
-		externalURL := getExternalHost(ctx)
 		switch params.Type {
 		case signupVerification:
 			if terr := models.NewAuditLogEntry(r, tx, user, models.UserConfirmationRequestedAction, "", nil); terr != nil {

--- a/internal/api/samlacs.go
+++ b/internal/api/samlacs.go
@@ -292,7 +292,7 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 		return internalServerError("Failed to set JWT cookie").WithInternalError(err)
 	}
 
-	if !isRedirectURLValid(config, redirectTo) {
+	if !utilities.IsRedirectURLValid(config, redirectTo) {
 		redirectTo = config.SiteURL
 	}
 

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/supabase/gotrue/internal/metering"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 // SignupParams are the parameters the Signup endpoint accepts
@@ -178,7 +179,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				}
 			} else {
 				mailer := a.Mailer(ctx)
-				referrer := a.getReferrer(r)
+				referrer := utilities.GetReferrer(r, config)
 				if terr = models.NewAuditLogEntry(r, tx, user, models.UserConfirmationRequestedAction, "", map[string]interface{}{
 					"provider": params.Provider,
 				}); terr != nil {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -14,6 +14,7 @@ import (
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/storage"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 // UserUpdateParams parameters for updating a user
@@ -193,7 +194,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 			identities = append(identities, *identity)
 			mailer := a.Mailer(ctx)
-			referrer := a.getReferrer(r)
+			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlowFromChallenge(params.CodeChallenge)
 			if isPKCEFlow(flowType) {
 				codeChallengeMethod, terr := models.ParseCodeChallengeMethod(params.CodeChallengeMethod)

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -17,6 +17,7 @@ import (
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/storage"
+	"github.com/supabase/gotrue/internal/utilities"
 )
 
 var (
@@ -104,7 +105,7 @@ func (a *API) Verify(w http.ResponseWriter, r *http.Request) error {
 	case http.MethodGet:
 		params.Token = r.FormValue("token")
 		params.Type = r.FormValue("type")
-		params.RedirectTo = a.getRedirectURLOrReferrer(r, r.FormValue("redirect_to"))
+		params.RedirectTo = utilities.GetReferrer(r, a.config)
 		if err := params.Validate(r); err != nil {
 			return err
 		}

--- a/internal/observability/request-logger.go
+++ b/internal/observability/request-logger.go
@@ -7,25 +7,28 @@ import (
 
 	chimiddleware "github.com/go-chi/chi/middleware"
 	"github.com/sirupsen/logrus"
+	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/utilities"
 )
 
-func NewStructuredLogger(logger *logrus.Logger) func(next http.Handler) http.Handler {
-	return chimiddleware.RequestLogger(&structuredLogger{logger})
+func NewStructuredLogger(logger *logrus.Logger, config *conf.GlobalConfiguration) func(next http.Handler) http.Handler {
+	return chimiddleware.RequestLogger(&structuredLogger{logger, config})
 }
 
 type structuredLogger struct {
 	Logger *logrus.Logger
+	Config *conf.GlobalConfiguration
 }
 
 func (l *structuredLogger) NewLogEntry(r *http.Request) chimiddleware.LogEntry {
+	referrer := utilities.GetReferrer(r, l.Config)
 	entry := &structuredLoggerEntry{Logger: logrus.NewEntry(l.Logger)}
 	logFields := logrus.Fields{
 		"component":   "api",
 		"method":      r.Method,
 		"path":        r.URL.Path,
 		"remote_addr": utilities.GetIPAddress(r),
-		"referer":     r.Referer(),
+		"referer":     referrer,
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
 	}
 

--- a/internal/utilities/request.go
+++ b/internal/utilities/request.go
@@ -5,7 +5,10 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
+
+	"github.com/supabase/gotrue/internal/conf"
 )
 
 // GetIPAddress returns the real IP address of the HTTP request. It parses the
@@ -53,4 +56,57 @@ func GetBodyBytes(req *http.Request) ([]byte, error) {
 	req.Body = io.NopCloser(bytes.NewReader(buf))
 
 	return buf, nil
+}
+
+func GetReferrer(r *http.Request, config *conf.GlobalConfiguration) string {
+	// try get redirect url from query or post data first
+	reqref := getRedirectTo(r)
+	if IsRedirectURLValid(config, reqref) {
+		return reqref
+	}
+
+	// instead try referrer header value
+	reqref = r.Referer()
+	if IsRedirectURLValid(config, reqref) {
+		return reqref
+	}
+
+	return config.SiteURL
+}
+
+func IsRedirectURLValid(config *conf.GlobalConfiguration, redirectURL string) bool {
+	if redirectURL == "" {
+		return false
+	}
+
+	base, berr := url.Parse(config.SiteURL)
+	refurl, rerr := url.Parse(redirectURL)
+
+	// As long as the referrer came from the site, we will redirect back there
+	if berr == nil && rerr == nil && base.Hostname() == refurl.Hostname() {
+		return true
+	}
+
+	// For case when user came from mobile app or other permitted resource - redirect back
+	for _, pattern := range config.URIAllowListMap {
+		if pattern.Match(redirectURL) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getRedirectTo tries extract redirect url from header or from query params
+func getRedirectTo(r *http.Request) (reqref string) {
+	reqref = r.Header.Get("redirect_to")
+	if reqref != "" {
+		return
+	}
+
+	if err := r.ParseForm(); err == nil {
+		reqref = r.Form.Get("redirect_to")
+	}
+
+	return
 }

--- a/internal/utilities/request_test.go
+++ b/internal/utilities/request_test.go
@@ -2,9 +2,11 @@ package utilities
 
 import (
 	"net/http"
+	"net/http/httptest"
 	tst "testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/internal/conf"
 )
 
 func TestGetIPAddress(t *tst.T) {
@@ -83,5 +85,47 @@ func TestGetIPAddress(t *tst.T) {
 		expected := example(req)
 
 		require.Equal(t, GetIPAddress(req), expected)
+	}
+}
+
+func TestGetReferrer(t *tst.T) {
+	config := conf.GlobalConfiguration{
+		SiteURL:      "https://example.com",
+		URIAllowList: []string{"http://localhost:8000/*"},
+	}
+	config.ApplyDefaults()
+	cases := []struct {
+		desc        string
+		redirectURL string
+		expected    string
+	}{
+		{
+			desc:        "valid redirect url",
+			redirectURL: "http://localhost:8000/path",
+			expected:    "http://localhost:8000/path",
+		},
+		{
+			desc:        "invalid redirect url",
+			redirectURL: "http://localhost:3000",
+			expected:    config.SiteURL,
+		},
+		{
+			desc:        "no / separator",
+			redirectURL: "http://localhost:8000",
+			expected:    config.SiteURL,
+		},
+		{
+			desc:        "* respects separator",
+			redirectURL: "http://localhost:8000/path/to/page",
+			expected:    config.SiteURL,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *tst.T) {
+			r := httptest.NewRequest("GET", "http://localhost?redirect_to="+c.redirectURL, nil)
+			referrer := GetReferrer(r, &config)
+			require.Equal(t, c.expected, referrer)
+		})
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Currently, we always log [`r.Referer()`](https://cs.opensource.google/go/go/+/refs/tags/go1.20.5:src/net/http/request.go;l=454) in the gotrue logs. However, this assumes that the referrer is always sent in the header which is false.
* Move the functions to get the referrer and validate the referrer to  the `utilities` package so it can be used across the `api` and `observability` packages
* Removed `getRedirectURLOrReferrer` because it's basically a repeat of `getReferrer`. You would still need to parse the `redirect_to` before calling `getRedirectURLOrReferrer` and `getReferrer` handles the parsing + validation for us already.
