### PR TITLE
feat: remove flow state expiry on Magic Links (PKCE)

### DIFF
--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -42,15 +42,10 @@ func addFlowPrefixToToken(token string, flowType models.FlowType) string {
 
 func issueAuthCode(tx *storage.Connection, user *models.User, expiryDuration time.Duration, authenticationMethod models.AuthenticationMethod) (string, error) {
 	flowState, err := models.FindFlowStateByUserID(tx, user.ID.String(), authenticationMethod)
-	if err != nil {
-		if models.IsNotFoundError(err) {
-			return "", badRequestError("No valid flow state found for user.")
-		}
+	if err != nil && models.IsNotFoundError(err) {
+		return "", badRequestError("No valid flow state found for user.")
+	} else if err != nil {
 		return "", err
-	}
-
-	if flowState.IsExpired(expiryDuration) {
-		return "", badRequestError("Flow state is expired")
 	}
 	return flowState.AuthCode, nil
 }

--- a/internal/mailer/template.go
+++ b/internal/mailer/template.go
@@ -126,7 +126,7 @@ func (m *TemplateMailer) ConfirmationMail(user *models.User, otp, referrerURL st
 
 	return m.Mailer.Mail(
 		user.GetEmail(),
-		string(withDefault(m.Config.Mailer.Subjects.Confirmation, "Confirm Your Email")),
+		withDefault(m.Config.Mailer.Subjects.Confirmation, "Confirm Your Email"),
 		m.Config.Mailer.Templates.Confirmation,
 		defaultConfirmationMail,
 		data,
@@ -144,7 +144,7 @@ func (m *TemplateMailer) ReauthenticateMail(user *models.User, otp string) error
 
 	return m.Mailer.Mail(
 		user.GetEmail(),
-		string(withDefault(m.Config.Mailer.Subjects.Reauthentication, "Confirm reauthentication")),
+		withDefault(m.Config.Mailer.Subjects.Reauthentication, "Confirm reauthentication"),
 		m.Config.Mailer.Templates.Reauthentication,
 		defaultReauthenticateMail,
 		data,
@@ -206,7 +206,7 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, 
 			}
 			errors <- m.Mailer.Mail(
 				address,
-				string(withDefault(m.Config.Mailer.Subjects.EmailChange, "Confirm Email Change")),
+				withDefault(m.Config.Mailer.Subjects.EmailChange, "Confirm Email Change"),
 				template,
 				defaultEmailChangeMail,
 				data,
@@ -245,7 +245,7 @@ func (m *TemplateMailer) RecoveryMail(user *models.User, otp, referrerURL string
 
 	return m.Mailer.Mail(
 		user.GetEmail(),
-		string(withDefault(m.Config.Mailer.Subjects.Recovery, "Reset Your Password")),
+		withDefault(m.Config.Mailer.Subjects.Recovery, "Reset Your Password"),
 		m.Config.Mailer.Templates.Recovery,
 		defaultRecoveryMail,
 		data,
@@ -274,7 +274,7 @@ func (m *TemplateMailer) MagicLinkMail(user *models.User, otp, referrerURL strin
 
 	return m.Mailer.Mail(
 		user.GetEmail(),
-		string(withDefault(m.Config.Mailer.Subjects.MagicLink, "Your Magic Link")),
+		withDefault(m.Config.Mailer.Subjects.MagicLink, "Your Magic Link"),
 		m.Config.Mailer.Templates.MagicLink,
 		defaultMagicLinkMail,
 		data,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removes the expiry on flow state which might overshadow the `OTP expiry` since default OTP expiry (1 day) is typically longer than default flow state expiry (5 mins). Flow state expiry is still enforced on token exchange.

## What is the current behavior?

Flow state expiry is checked on verification/issuance of Auth code

## What is the new behavior?

No flow state expiry check on verification of magic link. Flow state expiry continues to be enforced on token exchange.