### PR TITLE
feat: return `expires_at` in addition to `expires_in`

### DIFF
--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -48,7 +48,7 @@ func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
 	u.Role = "supabase_admin"
 
 	var token string
-	token, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}

--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -59,7 +59,7 @@ func (ts *InviteTestSuite) makeSuperAdmin(email string) string {
 	u.Role = "supabase_admin"
 
 	var token string
-	token, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 
 	require.NoError(ts.T(), err, "Error generating access token")
 

--- a/internal/api/logout_test.go
+++ b/internal/api/logout_test.go
@@ -42,7 +42,7 @@ func (ts *LogoutTestSuite) SetupTest() {
 
 	// generate access token to use for logout
 	var t string
-	t, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	t, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 	require.NoError(ts.T(), err)
 	ts.token = t
 }

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -124,7 +124,7 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 			user, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 			ts.Require().NoError(err)
 
-			token, err := generateAccessToken(ts.API.db, user, nil, &ts.Config.JWT)
+			token, _, err := generateAccessToken(ts.API.db, user, nil, &ts.Config.JWT)
 			require.NoError(ts.T(), err)
 
 			w := httptest.NewRecorder()
@@ -161,7 +161,7 @@ func (ts *MFATestSuite) TestChallengeFactor() {
 	require.NoError(ts.T(), err)
 	f := factors[0]
 
-	token, err := generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token, _, err := generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	var buffer bytes.Buffer
@@ -222,7 +222,7 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			secondarySession.FactorID = &f.ID
 			require.NoError(ts.T(), ts.API.db.Create(secondarySession), "Error saving test session")
 
-			token, err := generateAccessToken(ts.API.db, user, r.SessionId, &ts.Config.JWT)
+			token, _, err := generateAccessToken(ts.API.db, user, r.SessionId, &ts.Config.JWT)
 
 			require.NoError(ts.T(), err)
 
@@ -318,7 +318,7 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 
 			var buffer bytes.Buffer
 
-			token, err := generateAccessToken(ts.API.db, u, &s.ID, &ts.Config.JWT)
+			token, _, err := generateAccessToken(ts.API.db, u, &s.ID, &ts.Config.JWT)
 			require.NoError(ts.T(), err)
 
 			w := httptest.NewRecorder()
@@ -360,7 +360,7 @@ func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 
 	var buffer bytes.Buffer
 
-	token, err := generateAccessToken(ts.API.db, u, &s.ID, &ts.Config.JWT)
+	token, _, err := generateAccessToken(ts.API.db, u, &s.ID, &ts.Config.JWT)
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
 		"factor_id": f.ID,

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -128,7 +128,7 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
 	var token string
-	token, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 	require.NoError(ts.T(), err)
 
 	cases := []struct {

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -49,7 +49,7 @@ func (ts *UserTestSuite) TestUserGet() {
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err, "Error finding user")
 	var token string
-	token, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 
 	require.NoError(ts.T(), err, "Error generating access token")
 
@@ -115,7 +115,7 @@ func (ts *UserTestSuite) TestUserUpdateEmail() {
 			require.NoError(ts.T(), ts.API.db.Create(u), "Error saving test user")
 
 			var token string
-			token, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+			token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 
 			require.NoError(ts.T(), err, "Error generating access token")
 
@@ -179,7 +179,7 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
 			var token string
-			token, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+			token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 			require.NoError(ts.T(), err, "Error generating access token")
 
 			var buffer bytes.Buffer
@@ -293,7 +293,7 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 
 			var token string
 
-			token, err = generateAccessToken(ts.API.db, u, c.sessionId, &ts.Config.JWT)
+			token, _, err = generateAccessToken(ts.API.db, u, c.sessionId, &ts.Config.JWT)
 			require.NoError(ts.T(), err)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
@@ -323,7 +323,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
 	var token string
-	token, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 	require.NoError(ts.T(), err)
 
 	// request for reauthentication nonce

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -178,7 +178,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 
 		// Generate access token for request
 		var token string
-		token, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+		token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
 		require.NoError(ts.T(), err)
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1893,6 +1893,9 @@ components:
         expires_in:
           type: integer
           description: Number of seconds after which the `access_token` should be renewed by using the refresh token with the `refresh_token` grant type.
+        expires_at:
+          type: integer
+          description: UNIX timestamp after which the `access_token` should be renewed by using the refresh token with the `refresh_token` grant type.
         user:
           $ref: "#/components/schemas/UserSchema"
 


### PR DESCRIPTION
There are cases where the response for an access and refresh token takes more than 1 second. In such cases, `gotrue-js` will record the *expiry time* as the time it received the response + `expires_in`. However, this is not correct because the access token is likely to have already expired by the recorded time.

With this change, `gotrue-js` can just use an `expires_at` value instead. `expires_in` is still sent for backward compatibility.