### PR TITLE
fix: only apply rate limit if autoconfirm is false

### DIFF
--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -186,6 +186,7 @@ func (ts *MiddlewareTestSuite) TestLimitEmailOrPhoneSentHandler() {
 	// Set up rate limit config for this test
 	ts.Config.RateLimitEmailSent = 5
 	ts.Config.RateLimitSmsSent = 5
+	ts.Config.External.Phone.Enabled = true
 
 	cases := []struct {
 		desc             string


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Rate limit for total emails / sms-es sent should only be applied when autoconfirm is disabled