### PR TITLE
refactor: replace fmt.Sprintf with generateTokenHash

### DIFF
--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/models"
 )
 
@@ -152,7 +152,7 @@ func (ts *InviteTestSuite) TestVerifyInvite() {
 			user.InvitedAt = &now
 			user.ConfirmationSentAt = &now
 			user.EncryptedPassword = ""
-			user.ConfirmationToken = fmt.Sprintf("%x", sha256.Sum224([]byte(c.email+c.requestBody["token"].(string))))
+			user.ConfirmationToken = crypto.GenerateTokenHash(c.email, c.requestBody["token"].(string))
 			require.NoError(ts.T(), err)
 			require.NoError(ts.T(), ts.API.db.Create(user))
 

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/models"
 )
 
@@ -176,7 +176,7 @@ func (ts *MailTestSuite) TestGenerateLink() {
 			require.Equal(ts.T(), c.ExpectedResponse["redirect_to"], data["redirect_to"])
 
 			// check if hashed_token matches hash function of email and the raw otp
-			require.Equal(ts.T(), fmt.Sprintf("%x", sha256.Sum224([]byte(c.Body.Email+data["email_otp"].(string)))), data["hashed_token"])
+			require.Equal(ts.T(), crypto.GenerateTokenHash(c.Body.Email, data["email_otp"].(string)), data["hashed_token"])
 
 			// check if the host used in the email link matches the initial request host
 			u, err := url.ParseRequestURI(data["action_link"].(string))

--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"regexp"
 	"strings"
@@ -76,7 +75,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 	if err != nil {
 		return "", internalServerError("error generating otp").WithInternalError(err)
 	}
-	*token = fmt.Sprintf("%x", sha256.Sum224([]byte(phone+otp)))
+	*token = crypto.GenerateTokenHash(phone, otp)
 
 	var message string
 	if config.Sms.Template == "" {

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/models"
 )
 
@@ -340,7 +340,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	require.NotEmpty(ts.T(), u.ReauthenticationSentAt)
 
 	// update reauthentication token to a known token
-	u.ReauthenticationToken = fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456")))
+	u.ReauthenticationToken = crypto.GenerateTokenHash(u.GetEmail(), "123456")
 	require.NoError(ts.T(), ts.API.db.Update(u))
 
 	// update password with reauthentication token

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -2,10 +2,8 @@ package api
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -14,6 +12,7 @@ import (
 
 	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/gotrue/internal/api/sms_provider"
+	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/storage"
@@ -77,13 +76,13 @@ func (p *VerifyParams) Validate(r *http.Request) error {
 				if err != nil {
 					return err
 				}
-				p.TokenHash = fmt.Sprintf("%x", sha256.Sum224([]byte(p.Phone+p.Token)))
+				p.TokenHash = crypto.GenerateTokenHash(p.Phone, p.Token)
 			} else if isEmailOtpVerification(p) {
 				p.Email, err = validateEmail(p.Email)
 				if err != nil {
 					return unprocessableEntityError("Invalid email format").WithInternalError(err)
 				}
-				p.TokenHash = fmt.Sprintf("%x", sha256.Sum224([]byte(p.Email+p.Token)))
+				p.TokenHash = crypto.GenerateTokenHash(p.Email, p.Token)
 			} else {
 				return badRequestError("Only an email address or phone number should be provided on verify")
 			}

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/supabase/gotrue/internal/conf"
+	"github.com/supabase/gotrue/internal/crypto"
 	"github.com/supabase/gotrue/internal/models"
 )
 
@@ -787,13 +787,13 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":      smsVerification,
-				"tokenHash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetPhone()+"123456"))),
+				"tokenHash": crypto.GenerateTokenHash(u.GetPhone(), "123456"),
 				"token":     "123456",
 				"phone":     u.GetPhone(),
 			},
 			expected: expected{
 				code:      http.StatusOK,
-				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetPhone()+"123456"))),
+				tokenHash: crypto.GenerateTokenHash(u.GetPhone(), "123456"),
 			},
 		},
 		{
@@ -801,13 +801,13 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":      signupVerification,
-				"tokenHash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+				"tokenHash": crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 				"token":     "123456",
 				"email":     u.GetEmail(),
 			},
 			expected: expected{
 				code:      http.StatusOK,
-				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+				tokenHash: crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 			},
 		},
 		{
@@ -815,13 +815,13 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":      recoveryVerification,
-				"tokenHash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+				"tokenHash": crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 				"token":     "123456",
 				"email":     u.GetEmail(),
 			},
 			expected: expected{
 				code:      http.StatusOK,
-				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+				tokenHash: crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 			},
 		},
 		{
@@ -829,13 +829,13 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":      emailOTPVerification,
-				"tokenHash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+				"tokenHash": crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 				"token":     "123456",
 				"email":     u.GetEmail(),
 			},
 			expected: expected{
 				code:      http.StatusOK,
-				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.GetEmail()+"123456"))),
+				tokenHash: crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 			},
 		},
 		{
@@ -843,13 +843,13 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":      emailChangeVerification,
-				"tokenHash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.EmailChange+"123456"))),
+				"tokenHash": crypto.GenerateTokenHash(u.EmailChange, "123456"),
 				"token":     "123456",
 				"email":     u.EmailChange,
 			},
 			expected: expected{
 				code:      http.StatusOK,
-				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.EmailChange+"123456"))),
+				tokenHash: crypto.GenerateTokenHash(u.EmailChange, "123456"),
 			},
 		},
 		{
@@ -857,13 +857,13 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":      phoneChangeVerification,
-				"tokenHash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.PhoneChange+"123456"))),
+				"tokenHash": crypto.GenerateTokenHash(u.PhoneChange, "123456"),
 				"token":     "123456",
 				"phone":     u.PhoneChange,
 			},
 			expected: expected{
 				code:      http.StatusOK,
-				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.PhoneChange+"123456"))),
+				tokenHash: crypto.GenerateTokenHash(u.PhoneChange, "123456"),
 			},
 		},
 		{
@@ -871,11 +871,11 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":       signupVerification,
-				"token_hash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.Email+"123456"))),
+				"token_hash": crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 			},
 			expected: expected{
 				code:      http.StatusOK,
-				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.Email+"123456"))),
+				tokenHash: crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 			},
 		},
 		{
@@ -883,11 +883,11 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":       emailChangeVerification,
-				"token_hash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.EmailChange+"123456"))),
+				"token_hash": crypto.GenerateTokenHash(u.EmailChange, "123456"),
 			},
 			expected: expected{
 				code:      http.StatusOK,
-				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.EmailChange+"123456"))),
+				tokenHash: crypto.GenerateTokenHash(u.EmailChange, "123456"),
 			},
 		},
 		{
@@ -895,11 +895,11 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 			sentTime: time.Now(),
 			body: map[string]interface{}{
 				"type":       emailOTPVerification,
-				"token_hash": fmt.Sprintf("%x", sha256.Sum224([]byte(u.Email+"123456"))),
+				"token_hash": crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 			},
 			expected: expected{
 				code:      http.StatusOK,
-				tokenHash: fmt.Sprintf("%x", sha256.Sum224([]byte(u.Email+"123456"))),
+				tokenHash: crypto.GenerateTokenHash(u.GetEmail(), "123456"),
 			},
 		},
 	}

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -36,4 +37,7 @@ func GenerateOtp(digits int) (string, error) {
 	expr := "%0" + strconv.Itoa(digits) + "v"
 	otp := fmt.Sprintf(expr, val.String())
 	return otp, nil
+}
+func GenerateTokenHash(emailOrPhone, otp string) string {
+	return fmt.Sprintf("%x", sha256.Sum224([]byte(emailOrPhone+otp)))
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

see title -  relevant command:
```
#!/bin/bash

# Function to apply sed command to files in a directory
replace_in_files() {
  # The sed command with the pattern for replacement
  sed -E -i '' 's/fmt\.Sprintf\("%x", sha256\.Sum224\(\[\]byte\(([^+]+)\+([^)]+)\)\)\)/crypto.GenerateTokenHash(\1, \2)/g' "$1"
}

# Check if a directory is provided as an argument
if [ -z "$1" ]; then
  echo "Please provide the directory path as an argument."
  exit 1
fi

# Check if the directory exists
if [ ! -d "$1" ]; then
  echo "Directory not found: $1"
  exit 1
fi

# Loop through all files in the directory and apply the sed command
for file in "$1"/*; do
  if [ -f "$file" ]; then
    replace_in_files "$file"
  fi
done
```

