### PR TITLE
fix: use started transaction, not a new one

### DIFF
--- a/internal/api/token_refresh.go
+++ b/internal/api/token_refresh.go
@@ -67,7 +67,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 	var newTokenResponse *AccessTokenResponse
 
 	err = db.Transaction(func(tx *storage.Connection) error {
-		user, token, _, terr := models.FindUserWithRefreshToken(db, params.RefreshToken, true /* forUpdate */)
+		user, token, _, terr := models.FindUserWithRefreshToken(tx, params.RefreshToken, true /* forUpdate */)
 		if terr != nil {
 			if models.IsNotFoundError(terr) {
 				return oauthError("invalid_grant", "Invalid Refresh Token: Refresh Token Not Found")


### PR DESCRIPTION
Should be using `tx` in refresh token grant instead of `db`. Thanks @bnjmnt4n for [spotting this](https://github.com/supabase/gotrue/pull/1190#discussion_r1270861390).