### PR TITLE
feat: add CORS allowed headers config

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -230,7 +230,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 
 	corsHandler := cors.New(cors.Options{
 		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-Client-IP", "X-Client-Info", audHeaderName, useCookieHeader},
+		AllowedHeaders:   globalConfig.CORS.AllAllowedHeaders([]string{"Accept", "Authorization", "Content-Type", "X-Client-IP", "X-Client-Info", audHeaderName, useCookieHeader}),
 		ExposedHeaders:   []string{"X-Total-Count", "Link"},
 		AllowCredentials: true,
 	})

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -127,6 +127,31 @@ type GlobalConfiguration struct {
 		Duration int    `json:"duration"`
 	} `json:"cookies"`
 	SAML SAMLConfiguration `json:"saml"`
+	CORS CORSConfiguration `json:"cors"`
+}
+
+type CORSConfiguration struct {
+	AllowedHeaders []string `json:"allowed_headers" split_words:"true"`
+}
+
+func (c *CORSConfiguration) AllAllowedHeaders(defaults []string) []string {
+	set := make(map[string]bool)
+	for _, header := range defaults {
+		set[header] = true
+	}
+
+	var result []string
+	result = append(result, defaults...)
+
+	for _, header := range c.AllowedHeaders {
+		if !set[header] {
+			result = append(result, header)
+		}
+
+		set[header] = true
+	}
+
+	return result
 }
 
 // EmailContentConfiguration holds the configuration for emails, both subjects and template URLs.


### PR DESCRIPTION
Adds a new `GOTRUE_CORS_ALLOWED_HEADERS` config option to add additional allowed headers when performing CORS with GoTrue.