### PR TITLE
fix: unescape  escaped special characters in subject header

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -361,6 +361,8 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 	if config.Mailer.URLPaths.EmailChange == "" {
 		config.Mailer.URLPaths.EmailChange = "/"
 	}
+	// TODO: Remove this line once GoTrue has moved to a config file which doesn't escape ''
+	config.Mailer.UnescapeMailSubjects()
 
 	if config.Mailer.OtpExp == 0 {
 		config.Mailer.OtpExp = 86400 // 1 day
@@ -533,4 +535,13 @@ func (t *VonageProviderConfiguration) Validate() error {
 
 func (t *SmsProviderConfiguration) IsTwilioVerifyProvider() bool {
 	return t.Provider == "twilio_verify"
+}
+
+func (m *MailerConfiguration) UnescapeMailSubjects() {
+	m.Subjects.Confirmation = strings.ReplaceAll(m.Subjects.Confirmation, "\\'", "'")
+	m.Subjects.EmailChange = strings.ReplaceAll(m.Subjects.EmailChange, "\\'", "'")
+	m.Subjects.Invite = strings.ReplaceAll(m.Subjects.Invite, "\\'", "'")
+	m.Subjects.MagicLink = strings.ReplaceAll(m.Subjects.MagicLink, "\\'", "'")
+	m.Subjects.Reauthentication = strings.ReplaceAll(m.Subjects.Reauthentication, "\\'", "'")
+	m.Subjects.Recovery = strings.ReplaceAll(m.Subjects.Recovery, "\\'", "'")
 }

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -538,10 +538,11 @@ func (t *SmsProviderConfiguration) IsTwilioVerifyProvider() bool {
 }
 
 func (m *MailerConfiguration) UnescapeMailSubjects() {
-	m.Subjects.Confirmation = strings.ReplaceAll(m.Subjects.Confirmation, "\\'", "'")
-	m.Subjects.EmailChange = strings.ReplaceAll(m.Subjects.EmailChange, "\\'", "'")
-	m.Subjects.Invite = strings.ReplaceAll(m.Subjects.Invite, "\\'", "'")
-	m.Subjects.MagicLink = strings.ReplaceAll(m.Subjects.MagicLink, "\\'", "'")
-	m.Subjects.Reauthentication = strings.ReplaceAll(m.Subjects.Reauthentication, "\\'", "'")
-	m.Subjects.Recovery = strings.ReplaceAll(m.Subjects.Recovery, "\\'", "'")
+	escapeSequence := "\\\\'"
+	m.Subjects.Confirmation = strings.ReplaceAll(m.Subjects.Confirmation, escapeSequence, "'")
+	m.Subjects.EmailChange = strings.ReplaceAll(m.Subjects.EmailChange, escapeSequence, "'")
+	m.Subjects.Invite = strings.ReplaceAll(m.Subjects.Invite, escapeSequence, "'")
+	m.Subjects.MagicLink = strings.ReplaceAll(m.Subjects.MagicLink, escapeSequence, "'")
+	m.Subjects.Reauthentication = strings.ReplaceAll(m.Subjects.Reauthentication, escapeSequence, "'")
+	m.Subjects.Recovery = strings.ReplaceAll(m.Subjects.Recovery, escapeSequence, "'")
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the Supabase config file escapes special characters wherever present. This PR aims to unescape given special characters. Since the primary character of contention seems to be the apostrophe `'` we escape this character. While this fix seems to work, it seems rather hacky as the issue it resolves is somewaht specific to the Supabase hosted setup

## What is the current behavior?

Emails are sent with \' wherever there is a '. For example, John's email becomes John\'s Email

## What is the new behavior?

John's email remains as John's email.  Tested on a hosted Supabase instance with `'` inserted

