### PR TITLE
fix: return error if user not found but identity exists

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -573,10 +573,9 @@ func IsDuplicatedEmail(tx *storage.Connection, email, aud string, currentUser *U
 
 	for _, userID := range userIDs {
 		user, err := FindUserByID(tx, userID)
-		if err != nil && !IsNotFoundError(err) {
+		if err != nil {
 			return nil, errors.Wrap(err, "unable to find user from email identity for duplicates")
 		}
-
 		if user.Aud == aud {
 			return user, nil
 		}
@@ -586,7 +585,7 @@ func IsDuplicatedEmail(tx *storage.Connection, email, aud string, currentUser *U
 	// identities table we also do a final check on the users table
 	user, err := FindUserByEmailAndAudience(tx, email, aud)
 	if err != nil && !IsNotFoundError(err) {
-		return nil, errors.Wrap(err, "unable to find user email addres for duplicates")
+		return nil, errors.Wrap(err, "unable to find user email address for duplicates")
 	}
 
 	return user, nil


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Currently, if an identity exists without a user (e.g. the dev accidentally inserts a user identity without creating a user), `IsDuplicatedEmail` function will panic because we omit the check for `IsNotFound(err)`. This leads to a `nil` user being accessed when you check for `user.Aud` which leads to a panic.