### PR TITLE
fix: unflag whatsapp otp on twilio verify

### DIFF
--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -51,7 +51,7 @@ func IsValidMessageChannel(channel string, smsProvider string) bool {
 	case SMSProvider:
 		return true
 	case WhatsappProvider:
-		return smsProvider == "twilio"
+		return smsProvider == "twilio" || smsProvider == "twilio_verify"
 	default:
 		return false
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

We currently only allow WhatsApp OTPs on Twilio. This PR aims to unflag Whatsapp as a channel on Twilio Verify