### PR TITLE
feat: allow `whatsapp` channels with Twilio Verify

### DIFF
--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -51,7 +51,7 @@ func IsValidMessageChannel(channel string, smsProvider string) bool {
 	case SMSProvider:
 		return true
 	case WhatsappProvider:
-		return smsProvider == "twilio"
+		return smsProvider == "twilio" || smsProvider == "twilio_verify"
 	default:
 		return false
 	}


### PR DESCRIPTION
WhatsApp is supported by Twilio Verify but we've missed the validation here.