### PR TITLE
feat: add email rate limit breach metric

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -23,7 +23,7 @@ import (
 
 // ExternalProviderClaims are the JWT claims sent as the state in the external oauth provider signup flow
 type ExternalProviderClaims struct {
-	NetlifyMicroserviceClaims
+	AuthMicroserviceClaims
 	Provider    string `json:"provider"`
 	InviteToken string `json:"invite_token,omitempty"`
 	Referrer    string `json:"referrer,omitempty"`
@@ -83,7 +83,7 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, ExternalProviderClaims{
-		NetlifyMicroserviceClaims: NetlifyMicroserviceClaims{
+		AuthMicroserviceClaims: AuthMicroserviceClaims{
 			StandardClaims: jwt.StandardClaims{
 				ExpiresAt: time.Now().Add(5 * time.Minute).Unix(),
 			},

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -12,6 +12,7 @@ import (
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/observability"
 	"github.com/supabase/gotrue/internal/security"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/didip/tollbooth/v5"
 	"github.com/didip/tollbooth/v5/limiter"
@@ -114,6 +115,7 @@ func (a *API) limitEmailOrPhoneSentHandler() middlewareHandler {
 							emailRateLimitCounter.Add(
 								req.Context(),
 								1,
+								attribute.String("path", req.URL.Path),
 							)
 							return c, httpError(http.StatusTooManyRequests, "Email rate limit exceeded")
 						}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -87,7 +87,6 @@ func (a *API) limitEmailOrPhoneSentHandler() middlewareHandler {
 	}).SetBurst(int(a.config.RateLimitSmsSent)).SetMethods([]string{"PUT", "POST"})
 
 	return func(w http.ResponseWriter, req *http.Request) (context.Context, error) {
-
 		c := req.Context()
 		config := a.config
 		shouldRateLimitEmail := config.External.Email.Enabled && !config.Mailer.Autoconfirm
@@ -112,7 +111,6 @@ func (a *API) limitEmailOrPhoneSentHandler() middlewareHandler {
 				if shouldRateLimitEmail {
 					if requestBody.Email != "" {
 						if err := tollbooth.LimitByKeys(emailLimiter, []string{"email_functions"}); err != nil {
-							// TODO - check if this needs to be guarded in order to be done safely
 							emailRateLimitCounter.Add(
 								req.Context(),
 								1,

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -20,7 +20,7 @@ import (
 
 type FunctionHooks map[string][]string
 
-type NetlifyMicroserviceClaims struct {
+type AuthMicroserviceClaims struct {
 	jwt.StandardClaims
 	SiteURL       string        `json:"site_url"`
 	InstanceID    string        `json:"id"`

--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/supabase/gotrue/internal/observability"
 	"go.opentelemetry.io/otel/attribute"
-	metricinstrument "go.opentelemetry.io/otel/metric/instrument"
+
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -28,27 +28,14 @@ const (
 // GenerateHashFromPassword.
 var PasswordHashCost = DefaultHashCost
 
-type metricCounter interface {
-	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
-}
-
-func obtainMetricCounter(name, desc string) metricCounter {
-	counter, err := observability.Meter("gotrue").SyncInt64().Counter(name, metricinstrument.WithDescription(desc))
-	if err != nil {
-		panic(err)
-	}
-
-	return counter
-}
-
 var (
-	generateFromPasswordSubmittedCounter = obtainMetricCounter("gotrue_generate_from_password_submitted", "Number of submitted GenerateFromPassword hashing attempts")
-	generateFromPasswordCompletedCounter = obtainMetricCounter("gotrue_generate_from_password_completed", "Number of completed GenerateFromPassword hashing attempts")
+	generateFromPasswordSubmittedCounter = observability.ObtainMetricCounter("gotrue_generate_from_password_submitted", "Number of submitted GenerateFromPassword hashing attempts")
+	generateFromPasswordCompletedCounter = observability.ObtainMetricCounter("gotrue_generate_from_password_completed", "Number of completed GenerateFromPassword hashing attempts")
 )
 
 var (
-	compareHashAndPasswordSubmittedCounter = obtainMetricCounter("gotrue_compare_hash_and_password_submitted", "Number of submitted CompareHashAndPassword hashing attempts")
-	compareHashAndPasswordCompletedCounter = obtainMetricCounter("gotrue_compare_hash_and_password_completed", "Number of completed CompareHashAndPassword hashing attempts")
+	compareHashAndPasswordSubmittedCounter = observability.ObtainMetricCounter("gotrue_compare_hash_and_password_submitted", "Number of submitted CompareHashAndPassword hashing attempts")
+	compareHashAndPasswordCompletedCounter = observability.ObtainMetricCounter("gotrue_compare_hash_and_password_completed", "Number of completed CompareHashAndPassword hashing attempts")
 )
 
 // CompareHashAndPassword compares the hash and

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -215,6 +215,7 @@ func ConfigureMetrics(ctx context.Context, mc *conf.MetricsConfig) error {
 			},
 			func(ctx context.Context) {
 				running.Observe(ctx, 1)
+				emailRateLimit.Observe(ctx, emailRateLimit)
 			},
 		); err != nil {
 			logrus.WithError(err).Error("unable to register gotrue.running gague metric")

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/gotrue/internal/conf"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -215,7 +215,6 @@ func ConfigureMetrics(ctx context.Context, mc *conf.MetricsConfig) error {
 			},
 			func(ctx context.Context) {
 				running.Observe(ctx, 1)
-				emailRateLimit.Observe(ctx, emailRateLimit)
 			},
 		); err != nil {
 			logrus.WithError(err).Error("unable to register gotrue.running gague metric")

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -199,10 +199,6 @@ func ConfigureMetrics(ctx context.Context, mc *conf.MetricsConfig) error {
 			logrus.WithError(err).Error("unable to get gotrue.gotrue_running gague metric")
 			return
 		}
-		emailRateLimit, err := meter.AsyncInt64().Gauge(
-			"email_rate_limit",
-			metricinstrument.WithDescription("Number of times email rate limit has been triggered in a 5 minute interval"),
-		)
 		if err != nil {
 			logrus.WithError(err).Error("unable to get gotrue.email_rate_limit gague metric")
 			return
@@ -211,7 +207,6 @@ func ConfigureMetrics(ctx context.Context, mc *conf.MetricsConfig) error {
 		if err := meter.RegisterCallback(
 			[]metricinstrument.Asynchronous{
 				running,
-				emailRateLimit,
 			},
 			func(ctx context.Context) {
 				running.Observe(ctx, 1)

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -199,10 +199,6 @@ func ConfigureMetrics(ctx context.Context, mc *conf.MetricsConfig) error {
 			logrus.WithError(err).Error("unable to get gotrue.gotrue_running gague metric")
 			return
 		}
-		if err != nil {
-			logrus.WithError(err).Error("unable to get gotrue.email_rate_limit gague metric")
-			return
-		}
 
 		if err := meter.RegisterCallback(
 			[]metricinstrument.Asynchronous{

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -31,10 +31,6 @@ func Meter(instrumentationName string, opts ...metric.MeterOption) metric.Meter 
 	return metricglobal.Meter(instrumentationName, opts...)
 }
 
-type metricCounter interface {
-	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
-}
-
 func ObtainMetricCounter(name, desc string) metricCounter {
 	counter, err := Meter("gotrue").SyncInt64().Counter(name, metricinstrument.WithDescription(desc))
 	if err != nil {

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -199,10 +199,19 @@ func ConfigureMetrics(ctx context.Context, mc *conf.MetricsConfig) error {
 			logrus.WithError(err).Error("unable to get gotrue.gotrue_running gague metric")
 			return
 		}
+		emailRateLimit, err := meter.AsyncInt64().Gauge(
+			"email_rate_limit",
+			metricinstrument.WithDescription("Number of times email rate limit has been triggered in a 5 minute interval"),
+		)
+		if err != nil {
+			logrus.WithError(err).Error("unable to get gotrue.email_rate_limit gague metric")
+			return
+		}
 
 		if err := meter.RegisterCallback(
 			[]metricinstrument.Asynchronous{
 				running,
+				emailRateLimit,
 			},
 			func(ctx context.Context) {
 				running.Observe(ctx, 1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR aims to expose a set of email rate limit metrics as a Prometheus metric that can then be consumed by an alerting system like Prometheus. When a rate limit is triggered we increment a counter. This can then be passed to a monitoring system such as Prometheus alert manager which can fire off a notification (or similar) when a threshold (say 5 occurrences in an hour) has been breached.

Extends: #1213 


The presence of the metric was tested via using the default `prometheus.yml` file that comes on download.  To test that the rate limit is firing, we decreased `GOTRUE_RATE_LIMIT_EMAIL_SENT="5"` to 5 and ran `ab` against the endpoint like

`ab -p mass_signup.txt -T application/json  -c 10 -n 50 http://localhost:9999/otp`
