### PR TITLE
Issue #1194 - Gotrue is returning http 500 if API_EXTERNAL_URL is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,19 +553,19 @@ Controls the duration an email link or otp is valid for.
 
 `MAILER_URLPATHS_INVITE` - `string`
 
-URL path to use in the user invite email. Defaults to `/`.
+URL path to use in the user invite email. Defaults to `/verify`.
 
 `MAILER_URLPATHS_CONFIRMATION` - `string`
 
-URL path to use in the signup confirmation email. Defaults to `/`.
+URL path to use in the signup confirmation email. Defaults to `/verify`.
 
 `MAILER_URLPATHS_RECOVERY` - `string`
 
-URL path to use in the password reset email. Defaults to `/`.
+URL path to use in the password reset email. Defaults to `/verify`.
 
 `MAILER_URLPATHS_EMAIL_CHANGE` - `string`
 
-URL path to use in the email change confirmation email. Defaults to `/`.
+URL path to use in the email change confirmation email. Defaults to `/verify`.
 
 `MAILER_SUBJECTS_INVITE` - `string`
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Only the previous revoked token can be reused. Using an old refresh token way be
 ```properties
 GOTRUE_API_HOST=localhost
 PORT=9999
+API_EXTERNAL_URL=http://localhost:9999
 ```
 
 `API_HOST` - `string`
@@ -245,6 +246,10 @@ Port number to listen on. Defaults to `8081`.
 `API_ENDPOINT` - `string` _Multi-instance mode only_
 
 Controls what endpoint Netlify can access this API on.
+
+`API_EXTERNAL_URL` - `string` **required**
+
+The URL on which Gotrue might be accessed at.
 
 `REQUEST_ID_HEADER` - `string`
 

--- a/example.docker.env
+++ b/example.docker.env
@@ -4,4 +4,5 @@ GOTRUE_DB_MIGRATIONS_PATH=/go/src/github.com/supabase/gotrue/migrations
 GOTRUE_DB_DRIVER=postgres
 DATABASE_URL=postgres://supabase_auth_admin:root@postgres:5432/postgres
 GOTRUE_API_HOST=0.0.0.0
+API_EXTERNAL_URL="http://localhost:9999"
 PORT=9999

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -77,14 +77,14 @@ type APIConfiguration struct {
 	Port            string `envconfig:"PORT" default:"8081"`
 	Endpoint        string
 	RequestIDHeader string `envconfig:"REQUEST_ID_HEADER"`
-  ExternalURL     string `json:"external_url" envconfig:"API_EXTERNAL_URL" required:"true"`
+	ExternalURL     string `json:"external_url" envconfig:"API_EXTERNAL_URL" required:"true"`
 }
 
 func (a *APIConfiguration) Validate() error {
-		_, err := url.ParseRequestURI(a.ExternalURL)
-		if err != nil {
-			return err
-		}
+	_, err := url.ParseRequestURI(a.ExternalURL)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -393,19 +393,19 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 	}
 
 	if config.Mailer.URLPaths.Invite == "" {
-		config.Mailer.URLPaths.Invite = "/"
+		config.Mailer.URLPaths.Invite = "/verify"
 	}
 
 	if config.Mailer.URLPaths.Confirmation == "" {
-		config.Mailer.URLPaths.Confirmation = "/"
+		config.Mailer.URLPaths.Confirmation = "/verify"
 	}
 
 	if config.Mailer.URLPaths.Recovery == "" {
-		config.Mailer.URLPaths.Recovery = "/"
+		config.Mailer.URLPaths.Recovery = "/verify"
 	}
 
 	if config.Mailer.URLPaths.EmailChange == "" {
-		config.Mailer.URLPaths.EmailChange = "/"
+		config.Mailer.URLPaths.EmailChange = "/verify"
 	}
 
 	if config.Mailer.OtpExp == 0 {

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -77,18 +77,14 @@ type APIConfiguration struct {
 	Port            string `envconfig:"PORT" default:"8081"`
 	Endpoint        string
 	RequestIDHeader string `envconfig:"REQUEST_ID_HEADER"`
-	ExternalURL     string `json:"external_url" envconfig:"API_EXTERNAL_URL"`
+  ExternalURL     string `json:"external_url" envconfig:"API_EXTERNAL_URL" required:"true"`
 }
 
 func (a *APIConfiguration) Validate() error {
-	if a.ExternalURL != "" {
-		// sometimes, in tests, ExternalURL is empty and we regard that
-		// as a valid value
 		_, err := url.ParseRequestURI(a.ExternalURL)
 		if err != nil {
 			return err
 		}
-	}
 
 	return nil
 }

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -20,7 +20,7 @@ func TestGlobal(t *testing.T) {
 	os.Setenv("GOTRUE_OPERATOR_TOKEN", "token")
 	os.Setenv("GOTRUE_API_REQUEST_ID_HEADER", "X-Request-ID")
 	os.Setenv("GOTRUE_JWT_SECRET", "secret")
-  os.Setenv("API_EXTERNAL_URL", "http://localhost:9999")
+	os.Setenv("API_EXTERNAL_URL", "http://localhost:9999")
 	gc, err := LoadGlobal("")
 	require.NoError(t, err)
 	require.NotNil(t, gc)

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -20,6 +20,7 @@ func TestGlobal(t *testing.T) {
 	os.Setenv("GOTRUE_OPERATOR_TOKEN", "token")
 	os.Setenv("GOTRUE_API_REQUEST_ID_HEADER", "X-Request-ID")
 	os.Setenv("GOTRUE_JWT_SECRET", "secret")
+  os.Setenv("API_EXTERNAL_URL", "http://localhost:9999")
 	gc, err := LoadGlobal("")
 	require.NoError(t, err)
 	require.NotNil(t, gc)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, setting sane defaults

## What is the current behavior?
https://github.com/supabase/gotrue/issues/1194

- If the configuration API_EXTERNAL_URL is not set requests to gotrue return 500 errors. This configuration was undocumented and only part of some examplary configurations.

- If the URLPaths for the Mailer are not set they defaulted to / which by default is not the correct endpoint to handle verification requests. 

## What is the new behavior?

- API_EXTERNAL_URL needs to be set for gotrue to start.
- URLPaths for Invite,Confirmation,Recovery and EmailChange are set to "/verify" by default instead of "/"