### PR TITLE
refactor: centralize metric counter to observability package

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -23,7 +23,7 @@ import (
 
 // ExternalProviderClaims are the JWT claims sent as the state in the external oauth provider signup flow
 type ExternalProviderClaims struct {
-	NetlifyMicroserviceClaims
+	AuthMicroserviceClaims
 	Provider    string `json:"provider"`
 	InviteToken string `json:"invite_token,omitempty"`
 	Referrer    string `json:"referrer,omitempty"`
@@ -83,7 +83,7 @@ func (a *API) ExternalProviderRedirect(w http.ResponseWriter, r *http.Request) e
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, ExternalProviderClaims{
-		NetlifyMicroserviceClaims: NetlifyMicroserviceClaims{
+		AuthMicroserviceClaims: AuthMicroserviceClaims{
 			StandardClaims: jwt.StandardClaims{
 				ExpiresAt: time.Now().Add(5 * time.Minute).Unix(),
 			},

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -20,7 +20,7 @@ import (
 
 type FunctionHooks map[string][]string
 
-type NetlifyMicroserviceClaims struct {
+type AuthMicroserviceClaims struct {
 	jwt.StandardClaims
 	SiteURL       string        `json:"site_url"`
 	InstanceID    string        `json:"id"`

--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/supabase/gotrue/internal/observability"
 	"go.opentelemetry.io/otel/attribute"
-	metricinstrument "go.opentelemetry.io/otel/metric/instrument"
+
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -28,27 +28,14 @@ const (
 // GenerateHashFromPassword.
 var PasswordHashCost = DefaultHashCost
 
-type metricCounter interface {
-	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
-}
-
-func obtainMetricCounter(name, desc string) metricCounter {
-	counter, err := observability.Meter("gotrue").SyncInt64().Counter(name, metricinstrument.WithDescription(desc))
-	if err != nil {
-		panic(err)
-	}
-
-	return counter
-}
-
 var (
-	generateFromPasswordSubmittedCounter = obtainMetricCounter("gotrue_generate_from_password_submitted", "Number of submitted GenerateFromPassword hashing attempts")
-	generateFromPasswordCompletedCounter = obtainMetricCounter("gotrue_generate_from_password_completed", "Number of completed GenerateFromPassword hashing attempts")
+	generateFromPasswordSubmittedCounter = observability.ObtainMetricCounter("gotrue_generate_from_password_submitted", "Number of submitted GenerateFromPassword hashing attempts")
+	generateFromPasswordCompletedCounter = observability.ObtainMetricCounter("gotrue_generate_from_password_completed", "Number of completed GenerateFromPassword hashing attempts")
 )
 
 var (
-	compareHashAndPasswordSubmittedCounter = obtainMetricCounter("gotrue_compare_hash_and_password_submitted", "Number of submitted CompareHashAndPassword hashing attempts")
-	compareHashAndPasswordCompletedCounter = obtainMetricCounter("gotrue_compare_hash_and_password_completed", "Number of completed CompareHashAndPassword hashing attempts")
+	compareHashAndPasswordSubmittedCounter = observability.ObtainMetricCounter("gotrue_compare_hash_and_password_submitted", "Number of submitted CompareHashAndPassword hashing attempts")
+	compareHashAndPasswordCompletedCounter = observability.ObtainMetricCounter("gotrue_compare_hash_and_password_completed", "Number of completed CompareHashAndPassword hashing attempts")
 )
 
 // CompareHashAndPassword compares the hash and

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/supabase/gotrue/internal/conf"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -31,10 +31,6 @@ func Meter(instrumentationName string, opts ...metric.MeterOption) metric.Meter 
 	return metricglobal.Meter(instrumentationName, opts...)
 }
 
-type metricCounter interface {
-	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
-}
-
 func ObtainMetricCounter(name, desc string) metricCounter {
 	counter, err := Meter("gotrue").SyncInt64().Counter(name, metricinstrument.WithDescription(desc))
 	if err != nil {


### PR DESCRIPTION
- Move metric counter to observability package so that we can reuse it to track other metrics
- Rename `NetlifyMicroserviceClaims` to `AuthMicroserviceClaims`


Supports the email rate limit task