### PR TITLE
chore: amend email and phone enabled checks on resend 

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -108,7 +108,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		r.With(sharedLimiter).With(api.requireAdminCredentials).Post("/invite", api.Invite)
 		r.With(sharedLimiter).With(api.verifyCaptcha).Post("/signup", api.Signup)
 		r.With(sharedLimiter).With(api.verifyCaptcha).With(api.requireEmailProvider).Post("/recover", api.Recover)
-		r.With(sharedLimiter).With(api.verifyCaptcha).With(api.requireEmailProvider).Post("/resend", api.Resend)
+		r.With(sharedLimiter).With(api.verifyCaptcha).Post("/resend", api.Resend)
 		r.With(sharedLimiter).With(api.verifyCaptcha).Post("/magiclink", api.MagicLink)
 
 		r.With(sharedLimiter).With(api.verifyCaptcha).Post("/otp", api.Otp)

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -19,7 +19,7 @@ type ResendConfirmationParams struct {
 	Phone string `json:"phone"`
 }
 
-func (p *ResendConfirmationParams) Validate() error {
+func (p *ResendConfirmationParams) Validate(emailEnabled bool) error {
 	switch p.Type {
 	case signupVerification, emailChangeVerification, smsVerification, phoneChangeVerification:
 		break
@@ -39,6 +39,9 @@ func (p *ResendConfirmationParams) Validate() error {
 	if p.Email != "" && p.Phone != "" {
 		return badRequestError("Only an email address or phone number should be provided.")
 	} else if p.Email != "" {
+		if !emailEnabled {
+			return badRequestError("Email logins are disabled")
+		}
 		p.Email, err = validateEmail(p.Email)
 		if err != nil {
 			return err
@@ -71,7 +74,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read params: %v", err)
 	}
 
-	if err := params.Validate(); err != nil {
+	if err := params.Validate(config.External.Email.Enabled); err != nil {
 		return err
 	}
 

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/supabase/gotrue/internal/api/sms_provider"
+	"github.com/supabase/gotrue/internal/conf"
 	"github.com/supabase/gotrue/internal/models"
 	"github.com/supabase/gotrue/internal/storage"
 	"github.com/supabase/gotrue/internal/utilities"
@@ -19,7 +20,7 @@ type ResendConfirmationParams struct {
 	Phone string `json:"phone"`
 }
 
-func (p *ResendConfirmationParams) Validate(emailEnabled bool) error {
+func (p *ResendConfirmationParams) Validate(config *conf.GlobalConfiguration) error {
 	switch p.Type {
 	case signupVerification, emailChangeVerification, smsVerification, phoneChangeVerification:
 		break
@@ -39,7 +40,7 @@ func (p *ResendConfirmationParams) Validate(emailEnabled bool) error {
 	if p.Email != "" && p.Phone != "" {
 		return badRequestError("Only an email address or phone number should be provided.")
 	} else if p.Email != "" {
-		if !emailEnabled {
+		if !config.External.Email.Enabled {
 			return badRequestError("Email logins are disabled")
 		}
 		p.Email, err = validateEmail(p.Email)
@@ -47,6 +48,9 @@ func (p *ResendConfirmationParams) Validate(emailEnabled bool) error {
 			return err
 		}
 	} else if p.Phone != "" {
+		if !config.External.Phone.Enabled {
+			return badRequestError("Phone logins are disabled")
+		}
 		p.Phone, err = validatePhone(p.Phone)
 		if err != nil {
 			return err
@@ -74,7 +78,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read params: %v", err)
 	}
 
-	if err := params.Validate(config.External.Email.Enabled); err != nil {
+	if err := params.Validate(config); err != nil {
 		return err
 	}
 

--- a/internal/api/resend_test.go
+++ b/internal/api/resend_test.go
@@ -116,6 +116,8 @@ func (ts *ResendTestSuite) TestResendSuccess() {
 	// Avoid max freq limit error
 	now := time.Now().Add(-1 * time.Minute)
 
+	// Enable Phone Logoin for phone related tests
+	ts.Config.External.Phone.Enabled = true
 	// disable secure email change
 	ts.Config.Mailer.SecureEmailChangeEnabled = false
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Move the check for whether email logins are enabled into the resend function. Also checks if Phone Logins are enabled before proceeding to resend

## What is the current behavior?

Currently, the check  is done in middleware. This would mean that resend requests with phone based logins will not go through if email logins are disabled.

