### PR TITLE
fix: set the otp if it's not a test otp

### DIFF
--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -75,6 +75,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 	now := time.Now()
 
 	var otp, messageID string
+	var err error
 
 	if testOTP, ok := config.Sms.GetTestOTP(phone, now); ok {
 		otp = testOTP
@@ -82,7 +83,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 	}
 
 	if otp == "" { // not using test OTPs
-		otp, err := crypto.GenerateOtp(config.Sms.OtpLength)
+		otp, err = crypto.GenerateOtp(config.Sms.OtpLength)
 		if err != nil {
 			return "", internalServerError("error generating otp").WithInternalError(err)
 		}

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -353,7 +353,9 @@ func (ts *VerifyTestSuite) TestInvalidOtp() {
 		},
 	}
 
-	for _, c := range cases {
+	for _, caseItem := range cases {
+		c := caseItem
+
 		ts.Run(c.desc, func() {
 			// update token sent time
 			sentTime = time.Now()

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -906,7 +906,8 @@ func (ts *VerifyTestSuite) TestVerifyValidOtp() {
 		},
 	}
 
-	for _, c := range cases {
+	for _, caseItem := range cases {
+		c := caseItem
 		ts.Run(c.desc, func() {
 			// create user
 			u.ConfirmationSentAt = &c.sentTime


### PR DESCRIPTION
## What kind of change does this PR introduce?
* OTP should be test if not using the test OTP