### PR TITLE
fix: pass through redirect query parameters

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -137,7 +137,7 @@ func (a *API) ExternalProviderCallback(w http.ResponseWriter, r *http.Request) e
 	if err != nil {
 		return err
 	}
-	a.redirectErrors(a.internalExternalProviderCallback, w, r, rurl, u.Query())
+	a.redirectErrors(a.internalExternalProviderCallback, w, r, u)
 	return nil
 }
 
@@ -559,14 +559,15 @@ func (a *API) Provider(ctx context.Context, name string, scopes string) (provide
 	}
 }
 
-func (a *API) redirectErrors(handler apiHandler, w http.ResponseWriter, r *http.Request, rurl string, rq url.Values) {
+func (a *API) redirectErrors(handler apiHandler, w http.ResponseWriter, r *http.Request, u *url.URL) {
 	ctx := r.Context()
 	log := observability.GetLogEntry(r)
 	errorID := getRequestID(ctx)
 	err := handler(w, r)
 	if err != nil {
-		q := getErrorQueryString(err, errorID, log, rq)
-		http.Redirect(w, r, rurl+"?"+q.Encode(), http.StatusFound)
+		q := getErrorQueryString(err, errorID, log, u.Query())
+		u.RawQuery = q.Encode()
+		http.Redirect(w, r, u.String(), http.StatusFound)
 	}
 }
 

--- a/internal/api/external_test.go
+++ b/internal/api/external_test.go
@@ -199,25 +199,26 @@ func (ts *ExternalTestSuite) TestSignupExternalUnsupported() {
 }
 
 func (ts *ExternalTestSuite) TestRedirectErrorsShouldPreserveParams() {
+	// Request with invalid external provider
 	req := httptest.NewRequest(http.MethodGet, "http://localhost/authorize?provider=external", nil)
 	w := httptest.NewRecorder()
 	cases := []struct {
-		Desc        string
-		RedirectURL string
-		QueryParams []string
-		ErrorString string
+		Desc         string
+		RedirectURL  string
+		QueryParams  []string
+		ErrorMessage string
 	}{
 		{
-			Desc:        "HTTP error with redirect errors",
-			RedirectURL: "http://example.com/path?param2=value2",
-			QueryParams: []string{"param2"},
-			ErrorString: "invalid_request",
+			Desc:         "Should preserve redirect query params on error",
+			RedirectURL:  "http://example.com/path?paramforpreservation=value2",
+			QueryParams:  []string{"paramforpreservation"},
+			ErrorMessage: "invalid_request",
 		},
 		{
-			Desc:        "HTTP error with error param gets overwritten",
-			RedirectURL: "http://example.com/path?error=abc",
-			QueryParams: []string{"error"},
-			ErrorString: "invalid_request",
+			Desc:         "Error param should be overwritten",
+			RedirectURL:  "http://example.com/path?error=abc",
+			QueryParams:  []string{"error"},
+			ErrorMessage: "invalid_request",
 		},
 	}
 	for _, c := range cases {
@@ -229,13 +230,14 @@ func (ts *ExternalTestSuite) TestRedirectErrorsShouldPreserveParams() {
 		parsedParams, err := url.ParseQuery(parsedURL.RawQuery)
 		require.Equal(ts.T(), err, nil)
 
+		// An error and description should be returned
 		expectedQueryParams := append(c.QueryParams, "error", "error_description")
 
 		for _, expectedQueryParam := range expectedQueryParams {
 			val, exists := parsedParams[expectedQueryParam]
 			require.True(ts.T(), exists)
 			if expectedQueryParam == "error" {
-				require.Equal(ts.T(), val[0], c.ErrorString)
+				require.Equal(ts.T(), val[0], c.ErrorMessage)
 			}
 		}
 	}

--- a/internal/api/external_test.go
+++ b/internal/api/external_test.go
@@ -197,3 +197,22 @@ func (ts *ExternalTestSuite) TestSignupExternalUnsupported() {
 	ts.API.handler.ServeHTTP(w, req)
 	ts.Equal(w.Code, http.StatusBadRequest)
 }
+
+func (ts *ExternalTestSuite) TestRedirectErrors() {
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/authorize?provider=external&code=1234", nil)
+	w := httptest.NewRecorder()
+	mockRedirectURL := &url.URL{
+		Scheme:   "http",
+		Host:     "example.com",
+		Path:     "/",
+		RawQuery: "code=1234&param2=value2",
+	}
+	ts.API.redirectErrors(ts.API.internalExternalProviderCallback, w, req, mockRedirectURL)
+	// Check if the response status code is what you expect
+	require.Equal(ts.T(), http.StatusFound, w.Code)
+
+	// Check if the response header contains the correct Location header for the redirection
+	expectedLocation := mockRedirectURL.String() // Modify this according to your expected URL
+	location := w.Header().Get("Location")
+	require.Equal(ts.T(), location, expectedLocation)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Aims to address #1150  so that we can pass redirect query parameters alongside errors. Note that if any of the existing query parameters are named `error` or `error_description` they will be overwritten. In such cases, the error added by Supabase Auth will take precedence


## What is the current behavior?

When an error occurs the redirect query params only return error and error_description without other query parameters.


## How this was tested
- Case with Error was induced by artifically returning an error in `internalExternalProviderCallback`
- Happy path was tested as per normal
