### PR TITLE
feat: expose email address being sent to for email change flow

### DIFF
--- a/internal/mailer/template.go
+++ b/internal/mailer/template.go
@@ -195,7 +195,6 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, 
 			return err
 		}
 		go func(address, token, tokenHash, template string) {
-			sendingTo := address
 			data := map[string]interface{}{
 				"SiteURL":         m.Config.SiteURL,
 				"ConfirmationURL": externalURL.ResolveReference(path).String(),
@@ -203,7 +202,7 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, 
 				"NewEmail":        user.EmailChange,
 				"Token":           token,
 				"TokenHash":       tokenHash,
-				"SendingTo":       sendingTo,
+				"SendingTo":       address,
 				"Data":            user.UserMetaData,
 			}
 			errors <- m.Mailer.Mail(

--- a/internal/mailer/template.go
+++ b/internal/mailer/template.go
@@ -195,6 +195,7 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, 
 			return err
 		}
 		go func(address, token, tokenHash, template string) {
+			sendingTo := address
 			data := map[string]interface{}{
 				"SiteURL":         m.Config.SiteURL,
 				"ConfirmationURL": externalURL.ResolveReference(path).String(),
@@ -202,6 +203,7 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, 
 				"NewEmail":        user.EmailChange,
 				"Token":           token,
 				"TokenHash":       tokenHash,
+				"SendingTo":       sendingTo,
 				"Data":            user.UserMetaData,
 			}
 			errors <- m.Mailer.Mail(


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Exposes the email address that we're sending to so that devs can customize the email conditionally

### Follow Up Tasks
- [x] [Update Docs around Email Templates and Update Dashboard to reflect that the SendingTo parameter exists](https://github.com/supabase/supabase/blob/master/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx#L128) See [the dashboard PR](https://github.com/supabase/supabase/pull/16970)

### How this was tested

Build and update a staging project to use the GoTrue binary from this branch.

On staging, add `{{.SendingTo}}` as a parameter and execute email change. Confirm that the parameter is parsed on both emails when using secure email change.