### PR TITLE
Fix LinkedIn OAuth Scope and Profile Collection in GoTrue Library

### DIFF
--- a/internal/api/provider/linkedin.go
+++ b/internal/api/provider/linkedin.go
@@ -1,130 +1,130 @@
 package provider
 
 import (
-	"context"
-	"strings"
+  "context"
+  "strings"
 
-	"log"
-	"github.com/supabase/gotrue/internal/conf"
-	"golang.org/x/oauth2"
+  "log"
+  "github.com/supabase/gotrue/internal/conf"
+  "golang.org/x/oauth2"
 )
 
 const (
-	defaultLinkedinAPIBase = "api.linkedin.com"
+  defaultLinkedinAPIBase = "api.linkedin.com"
 )
 
 type linkedinProvider struct {
-	*oauth2.Config
-	APIPath      string
-	UserInfoURL  string
-	UserEmailUrl string
+  *oauth2.Config
+  APIPath      string
+  UserInfoURL  string
+  UserEmailUrl string
 }
 
 // See https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context
 // for retrieving a member's profile. This requires the r_liteprofile scope.
 type linkedinUser struct {
-	Sub        		string       `json:"sub"`
-	Email					string			 `json:"email"`
-	Name					string			 `json:"name"`
-	Picture				string			 `json:"picture"`
-	GivenName			string			 `json:"given_name"`
-	FamilyName		string			 `json:"family_name"`
-	EmailVerified	bool			 	 `json:"email_verified"`
+  Sub           string        `json:"sub"`
+  Email         string        `json:"email"`
+  Name          string        `json:"name"`
+  Picture       string        `json:"picture"`
+  GivenName     string        `json:"given_name"`
+  FamilyName    string        `json:"family_name"`
+  EmailVerified bool          `json:"email_verified"`
 }
 
 func (u *linkedinUser) getAvatarUrl() string {
-	avatarURL := u.Picture
-	return avatarURL
+  avatarURL := u.Picture
+  return avatarURL
 }
 
 type linkedinName struct {
-	Localized       interface{}    `json:"localized"`
-	PreferredLocale linkedinLocale `json:"preferredLocale"`
+  Localized       interface{}    `json:"localized"`
+  PreferredLocale linkedinLocale `json:"preferredLocale"`
 }
 
 type linkedinLocale struct {
-	Country  string `json:"country"`
-	Language string `json:"language"`
+  Country  string `json:"country"`
+  Language string `json:"language"`
 }
 
 // See https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context#retrieving-member-email-address
 // for retrieving a member email address. This requires the r_email_address scope.
 type linkedinElements struct {
-	Elements []struct {
-		Handle      string `json:"handle"`
-		HandleTilde struct {
-			EmailAddress string `json:"emailAddress"`
-		} `json:"handle~"`
-	} `json:"elements"`
+  Elements []struct {
+    Handle      string `json:"handle"`
+    HandleTilde struct {
+      EmailAddress string `json:"emailAddress"`
+    } `json:"handle~"`
+  } `json:"elements"`
 }
 
 // NewLinkedinProvider creates a Linkedin account provider.
 func NewLinkedinProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
-	if err := ext.ValidateOAuth(); err != nil {
-		return nil, err
-	}
+  if err := ext.ValidateOAuth(); err != nil {
+    return nil, err
+  }
 
-	apiPath := chooseHost(ext.URL, defaultLinkedinAPIBase)
+  apiPath := chooseHost(ext.URL, defaultLinkedinAPIBase)
 
-	oauthScopes := []string{
-		"openid",
-		"email",
-		"profile",
-	}
+  oauthScopes := []string{
+    "openid",
+    "email",
+    "profile",
+  }
 
-	if scopes != "" {
-		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
-	}
+  if scopes != "" {
+    oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
+  }
 
-	return &linkedinProvider{
-		Config: &oauth2.Config{
-			ClientID:     ext.ClientID[0],
-			ClientSecret: ext.Secret,
-			Endpoint: oauth2.Endpoint{
-				AuthURL:  apiPath + "/oauth/v2/authorization",
-				TokenURL: apiPath + "/oauth/v2/accessToken",
-			},
-			Scopes:      oauthScopes,
-			RedirectURL: ext.RedirectURI,
-		},
-		APIPath: apiPath,
-	}, nil
+  return &linkedinProvider{
+    Config: &oauth2.Config{
+      ClientID:     ext.ClientID[0],
+      ClientSecret: ext.Secret,
+      Endpoint: oauth2.Endpoint{
+        AuthURL:  apiPath + "/oauth/v2/authorization",
+        TokenURL: apiPath + "/oauth/v2/accessToken",
+      },
+      Scopes:      oauthScopes,
+      RedirectURL: ext.RedirectURI,
+    },
+    APIPath: apiPath,
+  }, nil
 }
 
 func (g linkedinProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
-	return g.Exchange(context.Background(), code)
+  return g.Exchange(context.Background(), code)
 }
 
 func GetName(name linkedinName) string {
-	key := name.PreferredLocale.Language + "_" + name.PreferredLocale.Country
-	myMap := name.Localized.(map[string]interface{})
-	return myMap[key].(string)
+  key := name.PreferredLocale.Language + "_" + name.PreferredLocale.Country
+  myMap := name.Localized.(map[string]interface{})
+  return myMap[key].(string)
 }
 
 func (g linkedinProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
-	var u linkedinUser
-	if err := makeRequest(ctx, tok, g.Config, g.APIPath+"/v2/userinfo", &u); err != nil {
-		return nil, err
-	}
+  var u linkedinUser
+  if err := makeRequest(ctx, tok, g.Config, g.APIPath+"/v2/userinfo", &u); err != nil {
+    return nil, err
+  }
 
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        g.APIPath,
-			Subject:       u.Sub,
-			Name:          strings.TrimSpace(u.GivenName + " " + u.FamilyName),
-			Picture:       u.Picture,
-			Email:         u.Email,
-			EmailVerified: u.EmailVerified,
+  return &UserProvidedData{
+    Metadata: &Claims{
+      Issuer:        g.APIPath,
+      Subject:       u.Sub,
+      Name:          strings.TrimSpace(u.GivenName + " " + u.FamilyName),
+      Picture:       u.Picture,
+      Email:         u.Email,
+      EmailVerified: u.EmailVerified,
 
-			// To be deprecated
-			AvatarURL:  u.Picture,
-			FullName:   strings.TrimSpace(u.GivenName + " " + u.FamilyName),
-			ProviderId: u.Sub,
-		},
-		Emails: []Email{{
-			Email: u.Email,
-			Verified: u.EmailVerified,
-			Primary: true,
-		}},
-	}, nil
+      // To be deprecated
+      AvatarURL:  u.Picture,
+      FullName:   strings.TrimSpace(u.GivenName + " " + u.FamilyName),
+      ProviderId: u.Sub,
+    },
+    Emails: []Email{{
+      Email: u.Email,
+      Verified: u.EmailVerified,
+      Primary: true,
+    }},
+  }, nil
 }

--- a/internal/api/provider/linkedin.go
+++ b/internal/api/provider/linkedin.go
@@ -4,7 +4,6 @@ import (
   "context"
   "strings"
 
-  "log"
   "github.com/supabase/gotrue/internal/conf"
   "golang.org/x/oauth2"
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces a bug fix to address issues related to LinkedIn OAuth within the GoTrue library.

## What is the current behavior?

LinkedIn applications created after 1st of August experience difficulties while attempting to log in with GoTrue due to incorrect scope requests.

Relevant issue: [Link to relevant issue](https://github.com/supabase/gotrue/issues/1216#issuecomment-1688943690)

## What is the new behavior?

This PR aims to rectify the issue by making necessary adjustments to the OAuth scopes. Specifically, the scopes `openid`, `email`, and `profile` will be utilized. Additionally, the method of collecting profile information is updated, employing the `/v2/userinfo` API endpoint.

Visual changes: No visual changes.

## Additional context

While I may not be a Go developer or intimately familiar with the library, I have conducted local testing within a Docker environment. By utilizing the GoTrue.js library, I was able to successfully log in and retrieve the access token through the callback URL. However, I have not progressed to subsequent testing stages due to a lack of understanding about the next steps required.
