### PR TITLE
fix: clear email change token when token hash is used

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -448,9 +448,9 @@ func (a *API) emailChangeVerify(r *http.Request, ctx context.Context, conn *stor
 	if config.Mailer.SecureEmailChangeEnabled && user.EmailChangeConfirmStatus == zeroConfirmation && user.GetEmail() != "" {
 		err := conn.Transaction(func(tx *storage.Connection) error {
 			user.EmailChangeConfirmStatus = singleConfirmation
-			if params.Token == user.EmailChangeTokenCurrent {
+			if params.Token == user.EmailChangeTokenCurrent || params.TokenHash == user.EmailChangeTokenCurrent {
 				user.EmailChangeTokenCurrent = ""
-			} else if params.Token == user.EmailChangeTokenNew {
+			} else if params.Token == user.EmailChangeTokenNew || params.TokenHash == user.EmailChangeTokenNew {
 				user.EmailChangeTokenNew = ""
 			}
 			if terr := tx.UpdateOnly(user, "email_change_confirm_status", "email_change_token_current", "email_change_token_new"); terr != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently,  it is possible to use the same `TokenHash` twice during Secure Email Change. This could potentially lead to malicious users requesting an email to a given email and then completing the flow with the token they receive in their email. 

This is not too major as it's not possible to do an email change to an existing account which blocks potential account takeover attempts. The main downside we aim to guard against would be devs blocked from signing up because someone is squatting on their name similar to what happens when a signup is made but confirmation is not completed.
