### PR TITLE
fix: patch secure email change (double confirm) response format.

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -453,9 +453,9 @@ func (a *API) emailChangeVerify(r *http.Request, ctx context.Context, conn *stor
 	if config.Mailer.SecureEmailChangeEnabled && user.EmailChangeConfirmStatus == zeroConfirmation && user.GetEmail() != "" {
 		err := conn.Transaction(func(tx *storage.Connection) error {
 			user.EmailChangeConfirmStatus = singleConfirmation
-			if params.Token == user.EmailChangeTokenCurrent {
+			if params.Token == user.EmailChangeTokenCurrent || params.TokenHash == user.EmailChangeTokenCurrent {
 				user.EmailChangeTokenCurrent = ""
-			} else if params.Token == user.EmailChangeTokenNew {
+			} else if params.Token == user.EmailChangeTokenNew || params.TokenHash == user.EmailChangeTokenNew {
 				user.EmailChangeTokenNew = ""
 			}
 			if terr := tx.UpdateOnly(user, "email_change_confirm_status", "email_change_token_current", "email_change_token_new"); terr != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

There are two issues the PR aims to resolve:

1. Currently, a Token Hash can be re-used twice in place of using the token hash send to the new email and a token has in the current mail. A solve attempt was originally made in #1240 but a test was added in this branch.

2. Currently, the single confirmation response is slightly misformed and has an additional null param

<img width="1062" alt="CleanShot 2023-09-04 at 15 47 04@2x" src="https://github.com/supabase/gotrue/assets/8011761/69da91e5-e646-4970-8e80-1659e2e3fd41">

This stems from the return in the transaction. sendJSON doesn't return an error. Consequently, he error returned by the transaction will be nil. This leads to 

<img width="755" alt="CleanShot 2023-09-04 at 15 47 41@2x" src="https://github.com/supabase/gotrue/assets/8011761/af583492-1aac-4cbd-aaad-856282cce808">

 `sendJSON(w, http.StatusOK, token)`  being run after `sendJSON` is callled which will write the `token` (`nil` in this case) to the existing singleConfirmationResponse. This in turn affects returned response for the  first confirmation as the client library is unable to unpack the returned JSON with extra null leading to an error.


## What is the new behavior?

Returns response
<img width="617" alt="CleanShot 2023-09-04 at 15 50 07@2x" src="https://github.com/supabase/gotrue/assets/8011761/e27db0ab-0489-4cda-a25f-8a650db5cab1">

## Additional context

TODO
- [x] Need to complete a test for the SecureEmailChange TokenHash to prevent a regression