### PR TITLE
fix: add new Linkedin OIDC due to deprecated scopes for new linkedin applications

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -540,6 +540,8 @@ func (a *API) Provider(ctx context.Context, name string, scopes string) (provide
 		return provider.NewKeycloakProvider(config.External.Keycloak, scopes)
 	case "linkedin":
 		return provider.NewLinkedinProvider(config.External.Linkedin, scopes)
+	case "linkedinOIDC":
+		return provider.NewLinkedinOIDCProvider(config.External.LinkedinOIDC, scopes)
 	case "notion":
 		return provider.NewNotionProvider(config.External.Notion)
 	case "spotify":

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -540,7 +540,7 @@ func (a *API) Provider(ctx context.Context, name string, scopes string) (provide
 		return provider.NewKeycloakProvider(config.External.Keycloak, scopes)
 	case "linkedin":
 		return provider.NewLinkedinProvider(config.External.Linkedin, scopes)
-	case "linkedin-oidc":
+	case "linkedin_oidc":
 		return provider.NewLinkedinOIDCProvider(config.External.LinkedinOIDC, scopes)
 	case "notion":
 		return provider.NewNotionProvider(config.External.Notion)

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -540,7 +540,7 @@ func (a *API) Provider(ctx context.Context, name string, scopes string) (provide
 		return provider.NewKeycloakProvider(config.External.Keycloak, scopes)
 	case "linkedin":
 		return provider.NewLinkedinProvider(config.External.Linkedin, scopes)
-	case "linkedinOIDC":
+	case "linkedin-oidc":
 		return provider.NewLinkedinOIDCProvider(config.External.LinkedinOIDC, scopes)
 	case "notion":
 		return provider.NewNotionProvider(config.External.Notion)

--- a/internal/api/provider/linkedin_oidc.go
+++ b/internal/api/provider/linkedin_oidc.go
@@ -35,16 +35,6 @@ func (u *linkedinOIDCUser) getAvatarUrl() string {
 	return u.Picture
 }
 
-type linkedinOIDCName struct {
-	Localized       interface{}        `json:"localized"`
-	PreferredLocale linkedinOIDCLocale `json:"preferredLocale"`
-}
-
-type linkedinOIDCLocale struct {
-	Country  string `json:"country"`
-	Language string `json:"language"`
-}
-
 // NewLinkedinOIDCProvider creates a Linkedin account provider via OIDC.
 func NewLinkedinOIDCProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
 	if err := ext.ValidateOAuth(); err != nil {
@@ -82,11 +72,6 @@ func (g linkedinOIDCProvider) GetOAuthToken(code string) (*oauth2.Token, error) 
 	return g.Exchange(context.Background(), code)
 }
 
-func GetOIDCName(name linkedinOIDCName) string {
-	key := name.PreferredLocale.Language + "_" + name.PreferredLocale.Country
-	myMap := name.Localized.(map[string]interface{})
-	return myMap[key].(string)
-}
 func (g linkedinOIDCProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
 	var u linkedinOIDCUser
 	if err := makeRequest(ctx, tok, g.Config, g.APIPath+"/v2/userinfo", &u); err != nil {

--- a/internal/api/provider/linkedin_oidc.go
+++ b/internal/api/provider/linkedin_oidc.go
@@ -31,10 +31,6 @@ type linkedinOIDCUser struct {
 	EmailVerified bool   `json:"email_verified"`
 }
 
-func (u *linkedinOIDCUser) getAvatarUrl() string {
-	return u.Picture
-}
-
 // NewLinkedinOIDCProvider creates a Linkedin account provider via OIDC.
 func NewLinkedinOIDCProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
 	if err := ext.ValidateOAuth(); err != nil {

--- a/internal/api/provider/linkedin_oidc.go
+++ b/internal/api/provider/linkedin_oidc.go
@@ -1,0 +1,156 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/supabase/gotrue/internal/conf"
+	"golang.org/x/oauth2"
+)
+
+const (
+	defaultLinkedinAPIBase = "api.linkedin.com"
+)
+
+type linkedinProvider struct {
+	*oauth2.Config
+	APIPath      string
+	UserInfoURL  string
+	UserEmailUrl string
+}
+
+// See https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context
+// for retrieving a member's profile. This requires the r_liteprofile scope.
+type linkedinUser struct {
+	ID        string       `json:"id"`
+	FirstName linkedinName `json:"firstName"`
+	LastName  linkedinName `json:"lastName"`
+	AvatarURL struct {
+		DisplayImage struct {
+			Elements []struct {
+				Identifiers []struct {
+					Identifier string `json:"identifier"`
+				} `json:"identifiers"`
+			} `json:"elements"`
+		} `json:"displayImage~"`
+	} `json:"profilePicture"`
+}
+
+func (u *linkedinUser) getAvatarUrl() string {
+	avatarURL := ""
+	if len(u.AvatarURL.DisplayImage.Elements) > 0 {
+		avatarURL = u.AvatarURL.DisplayImage.Elements[0].Identifiers[0].Identifier
+	}
+	return avatarURL
+}
+
+type linkedinName struct {
+	Localized       interface{}    `json:"localized"`
+	PreferredLocale linkedinLocale `json:"preferredLocale"`
+}
+
+type linkedinLocale struct {
+	Country  string `json:"country"`
+	Language string `json:"language"`
+}
+
+// See https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context#retrieving-member-email-address
+// for retrieving a member email address. This requires the r_email_address scope.
+type linkedinElements struct {
+	Elements []struct {
+		Handle      string `json:"handle"`
+		HandleTilde struct {
+			EmailAddress string `json:"emailAddress"`
+		} `json:"handle~"`
+	} `json:"elements"`
+}
+
+// NewLinkedinProvider creates a Linkedin account provider.
+func NewLinkedinProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuthProvider, error) {
+	if err := ext.ValidateOAuth(); err != nil {
+		return nil, err
+	}
+
+	apiPath := chooseHost(ext.URL, defaultLinkedinAPIBase)
+
+	oauthScopes := []string{
+		"r_emailaddress",
+		"r_liteprofile",
+	}
+
+	if scopes != "" {
+		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)
+	}
+
+	return &linkedinProvider{
+		Config: &oauth2.Config{
+			ClientID:     ext.ClientID[0],
+			ClientSecret: ext.Secret,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  apiPath + "/oauth/v2/authorization",
+				TokenURL: apiPath + "/oauth/v2/accessToken",
+			},
+			Scopes:      oauthScopes,
+			RedirectURL: ext.RedirectURI,
+		},
+		APIPath: apiPath,
+	}, nil
+}
+
+func (g linkedinProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
+	return g.Exchange(context.Background(), code)
+}
+
+func GetName(name linkedinName) string {
+	key := name.PreferredLocale.Language + "_" + name.PreferredLocale.Country
+	myMap := name.Localized.(map[string]interface{})
+	return myMap[key].(string)
+}
+
+func (g linkedinProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserProvidedData, error) {
+	var u linkedinUser
+	if err := makeRequest(ctx, tok, g.Config, g.APIPath+"/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))", &u); err != nil {
+		return nil, err
+	}
+
+	var e linkedinElements
+	// Note: Use primary contact api for handling phone numbers
+	if err := makeRequest(ctx, tok, g.Config, g.APIPath+"/v2/emailAddress?q=members&projection=(elements*(handle~))", &e); err != nil {
+		return nil, err
+	}
+
+	if len(e.Elements) <= 0 {
+		return nil, errors.New("unable to find email with Linkedin provider")
+	}
+
+	emails := []Email{}
+
+	if e.Elements[0].HandleTilde.EmailAddress != "" {
+		// linkedin only returns the primary email which is verified for the r_emailaddress scope.
+		emails = append(emails, Email{
+			Email:    e.Elements[0].HandleTilde.EmailAddress,
+			Primary:  true,
+			Verified: true,
+		})
+	}
+
+	avatarURL := u.getAvatarUrl()
+
+	return &UserProvidedData{
+		Metadata: &Claims{
+			Issuer:        g.APIPath,
+			Subject:       u.ID,
+			Name:          strings.TrimSpace(GetName(u.FirstName) + " " + GetName(u.LastName)),
+			Picture:       avatarURL,
+			Email:         e.Elements[0].HandleTilde.EmailAddress,
+			EmailVerified: true,
+
+			// To be deprecated
+			AvatarURL:  avatarURL,
+			FullName:   strings.TrimSpace(GetName(u.FirstName) + " " + GetName(u.LastName)),
+			ProviderId: u.ID,
+		},
+		Emails: emails,
+	}, nil
+}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -15,7 +15,7 @@ type ProviderSettings struct {
 	Keycloak     bool `json:"keycloak"`
 	Kakao        bool `json:"kakao"`
 	Linkedin     bool `json:"linkedin"`
-	LinkedinOIDC bool `json:"linkedinOIDC"`
+	LinkedinOIDC bool `json:"linkedin_oidc"`
 	Notion       bool `json:"notion"`
 	Spotify      bool `json:"spotify"`
 	Slack        bool `json:"slack"`

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -3,27 +3,28 @@ package api
 import "net/http"
 
 type ProviderSettings struct {
-	Apple     bool `json:"apple"`
-	Azure     bool `json:"azure"`
-	Bitbucket bool `json:"bitbucket"`
-	Discord   bool `json:"discord"`
-	Facebook  bool `json:"facebook"`
-	Figma     bool `json:"figma"`
-	GitHub    bool `json:"github"`
-	GitLab    bool `json:"gitlab"`
-	Google    bool `json:"google"`
-	Keycloak  bool `json:"keycloak"`
-	Kakao     bool `json:"kakao"`
-	Linkedin  bool `json:"linkedin"`
-	Notion    bool `json:"notion"`
-	Spotify   bool `json:"spotify"`
-	Slack     bool `json:"slack"`
-	WorkOS    bool `json:"workos"`
-	Twitch    bool `json:"twitch"`
-	Twitter   bool `json:"twitter"`
-	Email     bool `json:"email"`
-	Phone     bool `json:"phone"`
-	Zoom      bool `json:"zoom"`
+	Apple        bool `json:"apple"`
+	Azure        bool `json:"azure"`
+	Bitbucket    bool `json:"bitbucket"`
+	Discord      bool `json:"discord"`
+	Facebook     bool `json:"facebook"`
+	Figma        bool `json:"figma"`
+	GitHub       bool `json:"github"`
+	GitLab       bool `json:"gitlab"`
+	Google       bool `json:"google"`
+	Keycloak     bool `json:"keycloak"`
+	Kakao        bool `json:"kakao"`
+	Linkedin     bool `json:"linkedin"`
+	LinkedinOIDC bool `json:"linkedinOIDC"`
+	Notion       bool `json:"notion"`
+	Spotify      bool `json:"spotify"`
+	Slack        bool `json:"slack"`
+	WorkOS       bool `json:"workos"`
+	Twitch       bool `json:"twitch"`
+	Twitter      bool `json:"twitter"`
+	Email        bool `json:"email"`
+	Phone        bool `json:"phone"`
+	Zoom         bool `json:"zoom"`
 }
 
 type Settings struct {
@@ -41,27 +42,28 @@ func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
 
 	return sendJSON(w, http.StatusOK, &Settings{
 		ExternalProviders: ProviderSettings{
-			Apple:     config.External.Apple.Enabled,
-			Azure:     config.External.Azure.Enabled,
-			Bitbucket: config.External.Bitbucket.Enabled,
-			Discord:   config.External.Discord.Enabled,
-			Facebook:  config.External.Facebook.Enabled,
-			Figma:     config.External.Figma.Enabled,
-			GitHub:    config.External.Github.Enabled,
-			GitLab:    config.External.Gitlab.Enabled,
-			Google:    config.External.Google.Enabled,
-			Kakao:     config.External.Kakao.Enabled,
-			Keycloak:  config.External.Keycloak.Enabled,
-			Linkedin:  config.External.Linkedin.Enabled,
-			Notion:    config.External.Notion.Enabled,
-			Spotify:   config.External.Spotify.Enabled,
-			Slack:     config.External.Slack.Enabled,
-			Twitch:    config.External.Twitch.Enabled,
-			Twitter:   config.External.Twitter.Enabled,
-			WorkOS:    config.External.WorkOS.Enabled,
-			Email:     config.External.Email.Enabled,
-			Phone:     config.External.Phone.Enabled,
-			Zoom:      config.External.Zoom.Enabled,
+			Apple:        config.External.Apple.Enabled,
+			Azure:        config.External.Azure.Enabled,
+			Bitbucket:    config.External.Bitbucket.Enabled,
+			Discord:      config.External.Discord.Enabled,
+			Facebook:     config.External.Facebook.Enabled,
+			Figma:        config.External.Figma.Enabled,
+			GitHub:       config.External.Github.Enabled,
+			GitLab:       config.External.Gitlab.Enabled,
+			Google:       config.External.Google.Enabled,
+			Kakao:        config.External.Kakao.Enabled,
+			Keycloak:     config.External.Keycloak.Enabled,
+			Linkedin:     config.External.Linkedin.Enabled,
+			LinkedinOIDC: config.External.LinkedinOIDC.Enabled,
+			Notion:       config.External.Notion.Enabled,
+			Spotify:      config.External.Spotify.Enabled,
+			Slack:        config.External.Slack.Enabled,
+			Twitch:       config.External.Twitch.Enabled,
+			Twitter:      config.External.Twitter.Enabled,
+			WorkOS:       config.External.WorkOS.Enabled,
+			Email:        config.External.Email.Enabled,
+			Phone:        config.External.Phone.Enabled,
+			Zoom:         config.External.Zoom.Enabled,
 		},
 
 		DisableSignup:     config.DisableSignup,

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -196,7 +196,7 @@ type ProviderConfiguration struct {
 	Notion                  OAuthProviderConfiguration `json:"notion"`
 	Keycloak                OAuthProviderConfiguration `json:"keycloak"`
 	Linkedin                OAuthProviderConfiguration `json:"linkedin"`
-	LinkedinOIDC            OAuthProviderConfiguration `json:"linkedinOIDC"`
+	LinkedinOIDC            OAuthProviderConfiguration `json:"linkedin_oidc"`
 	Spotify                 OAuthProviderConfiguration `json:"spotify"`
 	Slack                   OAuthProviderConfiguration `json:"slack"`
 	Twitter                 OAuthProviderConfiguration `json:"twitter"`

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -196,6 +196,7 @@ type ProviderConfiguration struct {
 	Notion                  OAuthProviderConfiguration `json:"notion"`
 	Keycloak                OAuthProviderConfiguration `json:"keycloak"`
 	Linkedin                OAuthProviderConfiguration `json:"linkedin"`
+	LinkedinOIDC            OAuthProviderConfiguration `json:"linkedinOIDC"`
 	Spotify                 OAuthProviderConfiguration `json:"spotify"`
 	Slack                   OAuthProviderConfiguration `json:"slack"`
 	Twitter                 OAuthProviderConfiguration `json:"twitter"`

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -196,7 +196,7 @@ type ProviderConfiguration struct {
 	Notion                  OAuthProviderConfiguration `json:"notion"`
 	Keycloak                OAuthProviderConfiguration `json:"keycloak"`
 	Linkedin                OAuthProviderConfiguration `json:"linkedin"`
-	LinkedinOIDC            OAuthProviderConfiguration `json:"linkedin_oidc"`
+	LinkedinOIDC            OAuthProviderConfiguration `json:"linkedin_oidc" envconfig:"LINKEDIN_OIDC"`
 	Spotify                 OAuthProviderConfiguration `json:"spotify"`
 	Slack                   OAuthProviderConfiguration `json:"slack"`
 	Twitter                 OAuthProviderConfiguration `json:"twitter"`


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces a new linkedin provider to address issues related to the current LinkedIn provider no longer being available for new applications.

## What is the current behavior?

LinkedIn applications created after 1st of August experience difficulties while attempting to log in with GoTrue due to incorrect scope requests.

Relevant issue: https://github.com/supabase/gotrue/issues/1216#issuecomment-1688943690
Relevant initial fix however would lead to breaking existing apps - https://github.com/supabase/gotrue/pull/1232

## What is the new behavior?

This PR aims to rectify the issue by adding a new provider with the updated OAuth scopes. Specifically, the scopes openid, email, and profile will be utilized. Additionally, the method of collecting profile information is updated, employing the /v2/userinfo API endpoint.

Visual changes: No visual changes.

## Additional context

I've taken the initial updates from PR https://github.com/supabase/gotrue/pull/1232 into the new providers while also adding the relevant settings and provider implementations. I don't know much in terms of this library so would love to get additional feedback.

I validated that the - http://localhost:9999/authorize?provider=linkedin-oidc workflow worked locally and had the relevant information in the Claim
