### PR TITLE
feat: upgrade whatsapp support on Twilio Programmable Messaging

### DIFF
--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -93,7 +93,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 			return "", err
 		}
 
-		messageID, err = smsProvider.SendMessage(phone, message, channel)
+		messageID, err = smsProvider.SendMessage(phone, message, channel, otp)
 		if err != nil {
 			return messageID, err
 		}

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -32,7 +32,7 @@ type TestSmsProvider struct {
 	SentMessages int
 }
 
-func (t *TestSmsProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *TestSmsProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	t.SentMessages += 1
 	return "", nil
 }

--- a/internal/api/sms_provider/messagebird.go
+++ b/internal/api/sms_provider/messagebird.go
@@ -56,7 +56,7 @@ func NewMessagebirdProvider(config conf.MessagebirdProviderConfiguration) (SmsPr
 	}, nil
 }
 
-func (t *MessagebirdProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *MessagebirdProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 type SmsProvider interface {
-	SendMessage(phone, message, channel string) (string, error)
+	SendMessage(phone, message, channel, otp string) (string, error)
 }
 
 func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {

--- a/internal/api/sms_provider/sms_provider_test.go
+++ b/internal/api/sms_provider/sms_provider_test.go
@@ -84,6 +84,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 		Desc           string
 		TwilioResponse *gock.Response
 		ExpectedError  error
+		OTP            string
 	}{
 		{
 			Desc: "Successfully sent sms",
@@ -97,6 +98,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 				Body:       message,
 				MessageSID: "abcdef",
 			}),
+			OTP:           "123456",
 			ExpectedError: nil,
 		},
 		{
@@ -123,6 +125,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 				MoreInfo: "error",
 				Status:   500,
 			}),
+			OTP: "123456",
 			ExpectedError: &twilioErrResponse{
 				Code:     500,
 				Message:  "Internal server error",
@@ -134,7 +137,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 
 	for _, c := range cases {
 		ts.Run(c.Desc, func() {
-			_, err = twilioProvider.SendSms(phone, message, SMSProvider)
+			_, err = twilioProvider.SendSms(phone, message, SMSProvider, c.OTP)
 			require.Equal(ts.T(), c.ExpectedError, err)
 		})
 	}

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -49,7 +49,7 @@ func NewTextlocalProvider(config conf.TextlocalProviderConfiguration) (SmsProvid
 	}, nil
 }
 
-func (t *TextlocalProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *TextlocalProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)

--- a/internal/api/sms_provider/twilio_verify.go
+++ b/internal/api/sms_provider/twilio_verify.go
@@ -53,7 +53,7 @@ func NewTwilioVerifyProvider(config conf.TwilioVerifyProviderConfiguration) (Sms
 	}, nil
 }
 
-func (t *TwilioVerifyProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *TwilioVerifyProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	switch channel {
 	case SMSProvider, WhatsappProvider:
 		return t.SendSms(phone, message, channel)

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -45,7 +45,7 @@ func NewVonageProvider(config conf.VonageProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
-func (t *VonageProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *VonageProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -269,6 +269,7 @@ type TwilioProviderConfiguration struct {
 	AccountSid        string `json:"account_sid" split_words:"true"`
 	AuthToken         string `json:"auth_token" split_words:"true"`
 	MessageServiceSid string `json:"message_service_sid" split_words:"true"`
+	ContentSid        string `json:"content_sid" split_words:"true"`
 }
 
 type TwilioVerifyProviderConfiguration struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

As of October, Meta will be having a separate category [for billing authentication related templates (such as OTP)](https://support.twilio.com/hc/en-us/articles/13550552351771-Notice-Changes-to-WhatsApp-Template-Approval-Workflows-April-2023-). Consequently, it looks like WhatsApp Authentication templates need to be [submitted for approval via the content API](https://www.twilio.com/docs/content/whatsappauthentication?code-sample=code-sending-wa-authentication-templates&code-language=Go&code-sdk-version=1.x).

Consequently, there are two new parameters `ContentSID` and `ContentVariables` that need to be passed in.  `ContentVariables` contains the OTP and can be passed down from the calling functions. These parameters are needed in order to allow for WhatsApp use  on Twilio Programmable Messaging after October

According to Twilio Support, Twilio Verify is unaffected by this change.

## What is the current behavior?

Programmable Messaging will use WhatsApp templates from Twilio Dashboard

## What is the new behavior?

Programmable Messaging (WhatsApp) will use templates from Content API

## Additional context

- It looks like [message Content on WhatsApp will be largely standardized](https://www.twilio.com/docs/content/whatsappauthentication) so message content can't be customized.

>Unlike other templates the body is preset by WhatsApp. Some modifications can be made by specifying certain parameters however custom authentication templates are not allowed.

will need to call this out on the dashboard

- This was tested manually by sending an OTP via toy application


## FLUPs required
- [ ] Update Dashboard to include `ContentSID`
- [ ] Update Twilio Programmable Messaging to advise users to submit templates for approval. Also advise devs that they will have to move any internationalization logic until further notice. They will also need to re-submit respective templates in each language. This also means that devs using WhatsApp with programmable messaging will only be able to use one language (English) unless we pass contentSID in as a parameter