### PR TITLE
feat: add two phase refresh token algorithm

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -369,7 +369,7 @@ func (a *API) updateMFASessionAndClaims(r *http.Request, tx *storage.Connection,
 			return terr
 		}
 		// Swap to ensure current token is the latest one
-		refreshToken, terr = models.GrantRefreshTokenSwap(r, tx, user, currentToken)
+		refreshToken, terr = models.GrantRefreshTokenSwap(r, tx, user, currentToken, true)
 		if terr != nil {
 			return terr
 		}

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -212,7 +212,7 @@ func (ts *TokenTestSuite) TestTokenRefreshTokenRotation() {
 
 	first, err := models.GrantAuthenticatedUser(ts.API.db, u, models.GrantParams{})
 	require.NoError(ts.T(), err)
-	second, err := models.GrantRefreshTokenSwap(&http.Request{}, ts.API.db, u, first)
+	second, err := models.GrantRefreshTokenSwap(&http.Request{}, ts.API.db, u, first, true)
 	require.NoError(ts.T(), err)
 
 	cases := []struct {

--- a/internal/models/refresh_token_test.go
+++ b/internal/models/refresh_token_test.go
@@ -49,7 +49,7 @@ func (ts *RefreshTokenTestSuite) TestGrantRefreshTokenSwap() {
 	r, err := GrantAuthenticatedUser(ts.db, u, GrantParams{})
 	require.NoError(ts.T(), err)
 
-	s, err := GrantRefreshTokenSwap(&http.Request{}, ts.db, u, r)
+	s, err := GrantRefreshTokenSwap(&http.Request{}, ts.db, u, r, true)
 	require.NoError(ts.T(), err)
 
 	_, nr, _, err := FindUserWithRefreshToken(ts.db, r.Token, false)


### PR DESCRIPTION
Many clients that use GoTrue have virtually no reliability guarantees that they will be able to receive or process results from requests. This is especially challenging for the refresh token flows.

Suppose the following scenario:

1. A client (browser tab) begins refreshing a session with a refresh token. It sends out a request.
2. While the request is being processed, the browser tab is closed.
3. GoTrue will successfully process the refresh token request, by issuing a new access token, revoking the old refresh token and issuing a new one.
4. Since the tab is closed, it is unable to receive the new refresh token and thus its local storage state is inconsistent.
5. When the client comes back, it will use an already used refresh token which will kick the user out.

(This has been observed and confirmed in the wild. It's actually more common than you may think, since people usually first make a tab visible -- which starts the refresh token flow -- and then quickly close it.)

This change allows the client to choose whether the refresh token flow will be immediate, or with a two-step process.

In the two step process, the client sends out a refresh token request with the `phase` property set to `pre-commit`. A new refresh and access token is generated, but the token being refreshed is *not marked as revoked.*

Once the client receives and more importantly saves the result from the `pre-commit` phase, it sends the same refresh token request but with the `phase` property set to `commit` which finally marks the refresh token as revoked.