### PR TITLE
fix: use linkedin oidc endpoint

### DIFF
--- a/internal/api/provider/linkedin_oidc.go
+++ b/internal/api/provider/linkedin_oidc.go
@@ -16,10 +16,8 @@ const (
 
 type linkedinOIDCProvider struct {
 	*oauth2.Config
-	oidc         *oidc.Provider
-	APIPath      string
-	UserInfoURL  string
-	UserEmailUrl string
+	oidc    *oidc.Provider
+	APIPath string
 }
 
 // NewLinkedinOIDCProvider creates a Linkedin account provider via OIDC.


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Add OIDC support for the linkedin provider as highlighted [here](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2#validating-id-tokens) 
* Addresses #1216 