### PR TITLE
fix: preserve backward compatibility with Twilio Existing API

### DIFF
--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -94,11 +94,14 @@ func (t *TwilioProvider) SendSms(phone, message, channel, otp string) (string, e
 			"Channel": {channel},
 			"From":    {sender},
 		}
-		// Used to substitute OTP. See https://www.twilio.com/docs/content/whatsappauthentication for more details
+		// For backward compatibility with old API.
 		if t.Config.ContentSid != "" {
+			// Used to substitute OTP. See https://www.twilio.com/docs/content/whatsappauthentication for more details
 			contentVariables := fmt.Sprintf(`{"1": "%s"}`, otp)
 			body.Set("ContentSid", t.Config.ContentSid)
 			body.Set("ContentVariables", contentVariables)
+		} else {
+			body.Set("Body", message)
 		}
 	}
 	client := &http.Client{Timeout: defaultTimeout}

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -87,15 +87,18 @@ func (t *TwilioProvider) SendSms(phone, message, channel, otp string) (string, e
 		if isPhoneNumber.MatchString(formatPhoneNumber(sender)) {
 			sender = channel + ":" + sender
 		}
-		// Used to substitute OTP. See https://www.twilio.com/docs/content/whatsappauthentication for more details
-		contentVariables := fmt.Sprintf(`{"1": "%s"}`, otp)
+
 		// Programmable Messaging (WhatsApp) takes in different set of inputs
 		body = url.Values{
-			"To":               {receiver}, // twilio api requires "+" extension to be included
-			"Channel":          {channel},
-			"From":             {sender},
-			"ContentSid":       {t.Config.ContentSid},
-			"ContentVariables": {contentVariables},
+			"To":      {receiver}, // twilio api requires "+" extension to be included
+			"Channel": {channel},
+			"From":    {sender},
+		}
+		// Used to substitute OTP. See https://www.twilio.com/docs/content/whatsappauthentication for more details
+		if t.Config.ContentSid != "" {
+			contentVariables := fmt.Sprintf(`{"1": "%s"}`, otp)
+			body.Set("ContentSid", t.Config.ContentSid)
+			body.Set("ContentVariables", contentVariables)
 		}
 	}
 	client := &http.Client{Timeout: defaultTimeout}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Twilio has come back with clarification that Legacy WhatsApp Template can contain compliant authentication template

> The compliant authentication template format is supported in Content API, Content Editor and Legacy WhatsApp Templates. 

> Legacy Templates: Support for basic authentication message only.

This means that we'd have to preserve support for messages which don't include ContentSid/ContentVariables. Namely this would be messages which are using the Legacy WhatsApp template with the message: `*{{1}}* is your verification code. For your security, do not share this code.` . It seems like anything else will be rejected.

Full article: https://support.twilio.com/hc/en-us/articles/15596541039771-New-WhatsApp-Authentication-Template-Requirements-May-2023

<img width="673" alt="CleanShot 2023-10-10 at 23 30 08@2x" src="https://github.com/supabase/gotrue/assets/8011761/c8028671-9b91-484e-9223-15da25eddfa6">

