### PR TITLE
feat: initial fix for invite followed by signup.

### DIFF
--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -94,6 +94,55 @@ func (ts *InviteTestSuite) TestInvite() {
 	assert.Equal(ts.T(), http.StatusOK, w.Code)
 }
 
+func (ts *InviteTestSuite) TestInviteAfterSignupShouldNotReturnSensitiveFields() {
+	// To allow us to send signup and invite request in succession
+	ts.Config.SMTP.MaxFrequency = 5
+	// Request body
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email": "test@example.com",
+		"data": map[string]interface{}{
+			"a": 1,
+		},
+	}))
+
+	// Setup request
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/invite", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+
+	// Setup response recorder
+	w := httptest.NewRecorder()
+
+	ts.API.handler.ServeHTTP(w, req)
+	assert.Equal(ts.T(), http.StatusOK, w.Code)
+
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"email":    "test@example.com",
+		"password": "test123",
+		"data": map[string]interface{}{
+			"a": 1,
+		},
+	}))
+
+	// Setup request
+	req = httptest.NewRequest(http.MethodPost, "/signup", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Setup response recorder
+	x := httptest.NewRecorder()
+
+	ts.API.handler.ServeHTTP(x, req)
+
+	require.Equal(ts.T(), http.StatusOK, x.Code)
+
+	data := models.User{}
+	require.NoError(ts.T(), json.NewDecoder(x.Body).Decode(&data))
+	// Sensitive fields
+	require.Equal(ts.T(), 0, len(data.Identities))
+	require.Equal(ts.T(), 0, len(data.UserMetaData))
+}
+
 func (ts *InviteTestSuite) TestInvite_WithoutAccess() {
 	// Request body
 	var buffer bytes.Buffer

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -289,8 +289,8 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	}
 	if user.HasBeenInvited() {
 		// Remove sensitive fields
-		user.UserMetaData = nil
-		user.Identities = nil
+		user.UserMetaData = make(map[string]interface{}, 0)
+		user.Identities = make([]models.Identity, 0)
 	}
 	return sendJSON(w, http.StatusOK, user)
 }

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -289,8 +289,8 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 	}
 	if user.HasBeenInvited() {
 		// Remove sensitive fields
-		user.UserMetaData = make(map[string]interface{}, 0)
-		user.Identities = make([]models.Identity, 0)
+		user.UserMetaData = map[string]interface{}{}
+		user.Identities = []models.Identity{}
 	}
 	return sendJSON(w, http.StatusOK, user)
 }

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -287,6 +287,11 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 		metering.RecordLogin("password", user.ID)
 		return sendJSON(w, http.StatusOK, token)
 	}
+	if user.HasBeenInvited() {
+		// Remove sensitive fields
+		user.UserMetaData = nil
+		user.Identities = nil
+	}
 	return sendJSON(w, http.StatusOK, user)
 }
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -138,6 +138,11 @@ func (u *User) IsConfirmed() bool {
 	return u.EmailConfirmedAt != nil
 }
 
+// HasBeenInvited checks if user has been invited
+func (u *User) HasBeenInvited() bool {
+	return u.InvitedAt != nil
+}
+
 // IsPhoneConfirmed checks if a user's phone has already been
 // registered and confirmed.
 func (u *User) IsPhoneConfirmed() bool {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, sending an `invite` request followed by a `signup` request  w/o  confirmation between invite and signup will expose metadata on UserMetadata and Identities which may be perceived as a leak of sensitive information.

This PR aims to clear out such metadata for cases where the dev has been invited before a signup


## Testing Instructions
How to test locally:

Use this admin bearer `jwt` 

1. Call  http://localhost:9999/invite to `myemail@gmail.com`
2. Wait 60s 
3. Call http://localhost:9999/signup with `myemail@gmail.com` and check that `identities` field is blanked out