### PR TITLE
Revert "feat: upgrade whatsapp support on Twilio Programmable Messagi…

### DIFF
--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -93,7 +93,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 			return "", err
 		}
 
-		messageID, err = smsProvider.SendMessage(phone, message, channel, otp)
+		messageID, err = smsProvider.SendMessage(phone, message, channel)
 		if err != nil {
 			return messageID, err
 		}

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -32,7 +32,7 @@ type TestSmsProvider struct {
 	SentMessages int
 }
 
-func (t *TestSmsProvider) SendMessage(phone, message, channel, otp string) (string, error) {
+func (t *TestSmsProvider) SendMessage(phone string, message string, channel string) (string, error) {
 	t.SentMessages += 1
 	return "", nil
 }

--- a/internal/api/sms_provider/messagebird.go
+++ b/internal/api/sms_provider/messagebird.go
@@ -56,7 +56,7 @@ func NewMessagebirdProvider(config conf.MessagebirdProviderConfiguration) (SmsPr
 	}, nil
 }
 
-func (t *MessagebirdProvider) SendMessage(phone, message, channel, otp string) (string, error) {
+func (t *MessagebirdProvider) SendMessage(phone string, message string, channel string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 type SmsProvider interface {
-	SendMessage(phone, message, channel, otp string) (string, error)
+	SendMessage(phone, message, channel string) (string, error)
 }
 
 func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {

--- a/internal/api/sms_provider/sms_provider_test.go
+++ b/internal/api/sms_provider/sms_provider_test.go
@@ -84,7 +84,6 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 		Desc           string
 		TwilioResponse *gock.Response
 		ExpectedError  error
-		OTP            string
 	}{
 		{
 			Desc: "Successfully sent sms",
@@ -98,7 +97,6 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 				Body:       message,
 				MessageSID: "abcdef",
 			}),
-			OTP:           "123456",
 			ExpectedError: nil,
 		},
 		{
@@ -125,7 +123,6 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 				MoreInfo: "error",
 				Status:   500,
 			}),
-			OTP: "123456",
 			ExpectedError: &twilioErrResponse{
 				Code:     500,
 				Message:  "Internal server error",
@@ -137,7 +134,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 
 	for _, c := range cases {
 		ts.Run(c.Desc, func() {
-			_, err = twilioProvider.SendSms(phone, message, SMSProvider, c.OTP)
+			_, err = twilioProvider.SendSms(phone, message, SMSProvider)
 			require.Equal(ts.T(), c.ExpectedError, err)
 		})
 	}

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -49,7 +49,7 @@ func NewTextlocalProvider(config conf.TextlocalProviderConfiguration) (SmsProvid
 	}, nil
 }
 
-func (t *TextlocalProvider) SendMessage(phone, message, channel, otp string) (string, error) {
+func (t *TextlocalProvider) SendMessage(phone string, message string, channel string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -63,40 +63,30 @@ func NewTwilioProvider(config conf.TwilioProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
-func (t *TwilioProvider) SendMessage(phone, message, channel, otp string) (string, error) {
+func (t *TwilioProvider) SendMessage(phone string, message string, channel string) (string, error) {
 	switch channel {
 	case SMSProvider, WhatsappProvider:
-		return t.SendSms(phone, message, channel, otp)
+		return t.SendSms(phone, message, channel)
 	default:
 		return "", fmt.Errorf("channel type %q is not supported for Twilio", channel)
 	}
 }
 
 // Send an SMS containing the OTP with Twilio's API
-func (t *TwilioProvider) SendSms(phone, message, channel, otp string) (string, error) {
+func (t *TwilioProvider) SendSms(phone, message, channel string) (string, error) {
 	sender := t.Config.MessageServiceSid
 	receiver := "+" + phone
-	body := url.Values{
-		"To":      {receiver}, // twilio api requires "+" extension to be included
-		"Channel": {channel},
-		"From":    {sender},
-		"Body":    {message},
-	}
 	if channel == WhatsappProvider {
 		receiver = channel + ":" + receiver
 		if isPhoneNumber.MatchString(formatPhoneNumber(sender)) {
 			sender = channel + ":" + sender
 		}
-		// Used to substitute OTP. See https://www.twilio.com/docs/content/whatsappauthentication for more details
-		contentVariables := fmt.Sprintf(`{"1": "%s"}`, otp)
-		// Programmable Messaging (WhatsApp) takes in different set of inputs
-		body = url.Values{
-			"To":               {receiver}, // twilio api requires "+" extension to be included
-			"Channel":          {channel},
-			"From":             {sender},
-			"ContentSid":       {t.Config.ContentSid},
-			"ContentVariables": {contentVariables},
-		}
+	}
+	body := url.Values{
+		"To":      {receiver}, // twilio api requires "+" extension to be included
+		"Channel": {channel},
+		"From":    {sender},
+		"Body":    {message},
 	}
 	client := &http.Client{Timeout: defaultTimeout}
 	r, err := http.NewRequest("POST", t.APIPath, strings.NewReader(body.Encode()))

--- a/internal/api/sms_provider/twilio_verify.go
+++ b/internal/api/sms_provider/twilio_verify.go
@@ -53,7 +53,7 @@ func NewTwilioVerifyProvider(config conf.TwilioVerifyProviderConfiguration) (Sms
 	}, nil
 }
 
-func (t *TwilioVerifyProvider) SendMessage(phone, message, channel, otp string) (string, error) {
+func (t *TwilioVerifyProvider) SendMessage(phone string, message string, channel string) (string, error) {
 	switch channel {
 	case SMSProvider, WhatsappProvider:
 		return t.SendSms(phone, message, channel)

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -45,7 +45,7 @@ func NewVonageProvider(config conf.VonageProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
-func (t *VonageProvider) SendMessage(phone, message, channel, otp string) (string, error) {
+func (t *VonageProvider) SendMessage(phone string, message string, channel string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -270,7 +270,6 @@ type TwilioProviderConfiguration struct {
 	AccountSid        string `json:"account_sid" split_words:"true"`
 	AuthToken         string `json:"auth_token" split_words:"true"`
 	MessageServiceSid string `json:"message_service_sid" split_words:"true"`
-	ContentSid        string `json:"content_sid" split_words:"true"`
 }
 
 type TwilioVerifyProviderConfiguration struct {


### PR DESCRIPTION
…ng (#1249)"

This reverts commit c58febed896c7152a03634ac32b7f596b7b65d6f.

Twilio recently [updated](https://support.twilio.com/hc/en-us/articles/15596541039771-New-WhatsApp-Authentication-Template-Requirements-May-2023)  that they will support the basic, legacy, message for WhatsApp Twilio API (e.g. "Your Code is 123456") This means that existing devs using WhatsApp should be able to continue to use WhatsApp if they don't  require customization in the message (e.g. "Your Code is 123456, for more information visit bestboats.com"). In the latter use case, developers can opt to make use of Twilio Verify which has limited restrictions around template structure

Devs will more advanced use cases can move to Twilio Verify

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
