### PR TITLE
feat: add `GOTRUE_<PROVIDER>_SKIP_NONCE_CHECK` to skip nonce checks in ODIC flow

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -41,12 +41,13 @@ func (t *Time) UnmarshalText(text []byte) error {
 
 // OAuthProviderConfiguration holds all config related to external account providers.
 type OAuthProviderConfiguration struct {
-	ClientID    []string `json:"client_id" split_words:"true"`
-	Secret      string   `json:"secret"`
-	RedirectURI string   `json:"redirect_uri" split_words:"true"`
-	URL         string   `json:"url"`
-	ApiURL      string   `json:"api_url" split_words:"true"`
-	Enabled     bool     `json:"enabled"`
+	ClientID       []string `json:"client_id" split_words:"true"`
+	Secret         string   `json:"secret"`
+	RedirectURI    string   `json:"redirect_uri" split_words:"true"`
+	URL            string   `json:"url"`
+	ApiURL         string   `json:"api_url" split_words:"true"`
+	Enabled        bool     `json:"enabled"`
+	SkipNonceCheck bool     `json:"skip_nonce_check" split_words:"true"`
 }
 
 type EmailProviderConfiguration struct {


### PR DESCRIPTION
It appears that in certain client libraries that deal with the OIDC authentication flow, such as [this one for React Native on iOS](https://github.com/google/GoogleSignIn-iOS/pull/244), the clients are unable to extract the nonce that is generated randomly by the library. 

This option allows to temporarily drop the enforcement at the GoTrue level when performing the OIDC flow. This does remove an important security barrier, which could potentially allow "stolen" ID tokens to be used on third-party services (that have opted in to this configuration) however in the interest of flexibility and broad platform support the option is being added.