### PR TITLE
feat: reinstate upgrade whatsapp support on Twilio Programmable Messaging to support Content API

### DIFF
--- a/internal/api/phone.go
+++ b/internal/api/phone.go
@@ -93,7 +93,7 @@ func (a *API) sendPhoneConfirmation(ctx context.Context, tx *storage.Connection,
 			return "", err
 		}
 
-		messageID, err = smsProvider.SendMessage(phone, message, channel)
+		messageID, err = smsProvider.SendMessage(phone, message, channel, otp)
 		if err != nil {
 			return messageID, err
 		}

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -32,7 +32,7 @@ type TestSmsProvider struct {
 	SentMessages int
 }
 
-func (t *TestSmsProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *TestSmsProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	t.SentMessages += 1
 	return "", nil
 }

--- a/internal/api/sms_provider/messagebird.go
+++ b/internal/api/sms_provider/messagebird.go
@@ -56,7 +56,7 @@ func NewMessagebirdProvider(config conf.MessagebirdProviderConfiguration) (SmsPr
 	}, nil
 }
 
-func (t *MessagebirdProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *MessagebirdProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)

--- a/internal/api/sms_provider/sms_provider.go
+++ b/internal/api/sms_provider/sms_provider.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 type SmsProvider interface {
-	SendMessage(phone, message, channel string) (string, error)
+	SendMessage(phone, message, channel, otp string) (string, error)
 }
 
 func GetSmsProvider(config conf.GlobalConfiguration) (SmsProvider, error) {

--- a/internal/api/sms_provider/sms_provider_test.go
+++ b/internal/api/sms_provider/sms_provider_test.go
@@ -84,6 +84,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 		Desc           string
 		TwilioResponse *gock.Response
 		ExpectedError  error
+		OTP            string
 	}{
 		{
 			Desc: "Successfully sent sms",
@@ -97,6 +98,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 				Body:       message,
 				MessageSID: "abcdef",
 			}),
+			OTP:           "123456",
 			ExpectedError: nil,
 		},
 		{
@@ -123,6 +125,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 				MoreInfo: "error",
 				Status:   500,
 			}),
+			OTP: "123456",
 			ExpectedError: &twilioErrResponse{
 				Code:     500,
 				Message:  "Internal server error",
@@ -134,7 +137,7 @@ func (ts *SmsProviderTestSuite) TestTwilioSendSms() {
 
 	for _, c := range cases {
 		ts.Run(c.Desc, func() {
-			_, err = twilioProvider.SendSms(phone, message, SMSProvider)
+			_, err = twilioProvider.SendSms(phone, message, SMSProvider, c.OTP)
 			require.Equal(ts.T(), c.ExpectedError, err)
 		})
 	}

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -49,7 +49,7 @@ func NewTextlocalProvider(config conf.TextlocalProviderConfiguration) (SmsProvid
 	}, nil
 }
 
-func (t *TextlocalProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *TextlocalProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)

--- a/internal/api/sms_provider/twilio_verify.go
+++ b/internal/api/sms_provider/twilio_verify.go
@@ -53,7 +53,7 @@ func NewTwilioVerifyProvider(config conf.TwilioVerifyProviderConfiguration) (Sms
 	}, nil
 }
 
-func (t *TwilioVerifyProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *TwilioVerifyProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	switch channel {
 	case SMSProvider, WhatsappProvider:
 		return t.SendSms(phone, message, channel)

--- a/internal/api/sms_provider/vonage.go
+++ b/internal/api/sms_provider/vonage.go
@@ -45,7 +45,7 @@ func NewVonageProvider(config conf.VonageProviderConfiguration) (SmsProvider, er
 	}, nil
 }
 
-func (t *VonageProvider) SendMessage(phone string, message string, channel string) (string, error) {
+func (t *VonageProvider) SendMessage(phone, message, channel, otp string) (string, error) {
 	switch channel {
 	case SMSProvider:
 		return t.SendSms(phone, message)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -271,6 +271,7 @@ type TwilioProviderConfiguration struct {
 	AccountSid        string `json:"account_sid" split_words:"true"`
 	AuthToken         string `json:"auth_token" split_words:"true"`
 	MessageServiceSid string `json:"message_service_sid" split_words:"true"`
+	ContentSid        string `json:"content_sid" split_words:"true"`
 }
 
 type TwilioVerifyProviderConfiguration struct {


### PR DESCRIPTION
Resinstates WhatsApp support for the content API by reinstating: https://github.com/supabase/gotrue/pull/1249


After further discussion, it looks like we do have users who are using custom SMS templates (e.g. "Your <company> code is {{.code}} ")

We were notified that this is required as alphanumeric senders require the company name in the  message. This means we will need to support the Content API as custom messages aren't allowed under Programmable Messaging API + WhatsApp Template


There will be 2 more PRs after this:
1. PR to allow for backward compatibility with Basic Authentication Template
2. PR to add ContentSid env var
3. Dashboard PR to expose variable