### PR TITLE
feat: ignore common Azure issuer for ID tokens

### DIFF
--- a/internal/api/provider/azure.go
+++ b/internal/api/provider/azure.go
@@ -61,9 +61,11 @@ func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 	if ext.URL != "" {
 		expectedIssuer = authHost + "/v2.0"
 
-		if !IsAzureIssuer(expectedIssuer) {
+		if !IsAzureIssuer(expectedIssuer) || expectedIssuer == IssuerAzure {
 			// in tests, the URL is a local server which should not
 			// be the expected issuer
+			// also, IssuerAzure (common) never actually issues any
+			// ID tokens so it needs to be ignored
 			expectedIssuer = ""
 		}
 	}


### PR DESCRIPTION
If the developer has configured `GOTRUE_AZURE_URL` to be `https://login.microsoftonline.com/common` then the expected issuer setting is set to `https://login.microsoftonline.com/common/v2.0`. However this is not an issuer so no ID tokens will be issued by it, but rather from all other multi-tenant apps and tenants, so it needs to be ignored from the expected issuer setting.