### PR TITLE
fix: include `/organizations` in expected issuer exemption

### DIFF
--- a/internal/api/provider/azure.go
+++ b/internal/api/provider/azure.go
@@ -13,7 +13,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const IssuerAzure = "https://login.microsoftonline.com/common/v2.0"
+const IssuerAzureCommon = "https://login.microsoftonline.com/common/v2.0"
+const IssuerAzureOrganizations = "https://login.microsoftonline.com/organizations/v2.0"
 
 // IssuerAzureMicrosoft is the OIDC issuer for microsoft.com accounts:
 // https://learn.microsoft.com/en-us/azure/active-directory/develop/id-token-claims-reference#payload-claims
@@ -61,7 +62,7 @@ func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 	if ext.URL != "" {
 		expectedIssuer = authHost + "/v2.0"
 
-		if !IsAzureIssuer(expectedIssuer) || expectedIssuer == IssuerAzure {
+		if !IsAzureIssuer(expectedIssuer) || expectedIssuer == IssuerAzureCommon || expectedIssuer == IssuerAzureOrganizations {
 			// in tests, the URL is a local server which should not
 			// be the expected issuer
 			// also, IssuerAzure (common) never actually issues any

--- a/internal/api/token_oidc.go
+++ b/internal/api/token_oidc.go
@@ -51,10 +51,10 @@ func (p *IdTokenGrantParams) getProvider(ctx context.Context, config *conf.Globa
 		issuer = provider.IssuerGoogle
 		acceptableClientIDs = append(acceptableClientIDs, config.External.Google.ClientID...)
 
-	case p.Provider == "azure" || p.Issuer == provider.IssuerAzure:
+	case p.Provider == "azure" || p.Issuer == provider.IssuerAzureCommon || p.Issuer == provider.IssuerAzureOrganizations:
 		cfg = &config.External.Azure
 		providerType = "azure"
-		issuer = provider.IssuerAzure
+		issuer = p.Issuer
 		acceptableClientIDs = append(acceptableClientIDs, config.External.Azure.ClientID...)
 
 	case p.Provider == "facebook" || p.Issuer == provider.IssuerFacebook:


### PR DESCRIPTION
## What kind of change does this PR introduce?
* The issuer can also be https://login.microsoftonline.com/organizations for applications processing accounts in any organizational directory (any Microsoft Entra directory) (see [here](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-convert-app-to-be-multi-tenant))
* Fixes #1274