### PR TITLE
feat: add idempotent refresh token algorithm

### DIFF
--- a/internal/models/sessions.go
+++ b/internal/models/sessions.go
@@ -227,3 +227,16 @@ func (s *Session) GetAAL() string {
 func (s *Session) IsAAL2() bool {
 	return s.GetAAL() == AAL2.String()
 }
+
+// FindCurrentlyActiveRefreshToken returns the currently active refresh
+// token in the session. This is the last created (ordered by the serial
+// primary key) non-revoked refresh token for the session.
+func (s *Session) FindCurrentlyActiveRefreshToken(tx *storage.Connection) (*RefreshToken, error) {
+	var activeRefreshToken RefreshToken
+
+	if err := tx.Q().Where("session_id = ? and revoked is false", s.ID).Order("id desc").First(&activeRefreshToken); err != nil {
+		return nil, err
+	}
+
+	return &activeRefreshToken, nil
+}

--- a/internal/storage/helper.go
+++ b/internal/storage/helper.go
@@ -25,3 +25,7 @@ func (s NullString) Value() (driver.Value, error) {
 	}
 	return string(s), nil
 }
+
+func (s NullString) String() string {
+	return string(s)
+}


### PR DESCRIPTION
Modifies the refresh token algorithm to support a limited form of idempotency. The lack of this behavior is documented to cause loss of session.

**Problem**

GoTrue, so far, assumes that clients calling the `POST /token?grant_type=refresh_token` endpoint are guaranteed to at least save the result of the response. Like all networked software, there are no guarantees that the sender of a request will receive the response, or act on it. This problem is exacerbated by network appliances like CDNs and reverse proxies which mask the TCP stream semantics from GoTrue. A properly closed TCP stream does not mean that the receiver of the response received the stream, but rather that a proxy in the chain buffered the response.

Furthermore, even if the receiver is able to receive _and parse_ the response, usually there are no guarantees that it will continue processing the response. With refresh tokens, it's incredbily important that the receiver successfully persists the new refresh token to durable storage. There are no guarantees of this as browsers and mobile apps (and the computers they run on) can die, go offline or just malfunction between sending a request and processing its response.

**Solution**

There are really only two solutions to this problem:

1. Idempotency. Where for the same inputs the same output is generated.
2. Double-commit. Where the receipt of the response needs to be acknowledged before the state changes.

We considered a double-commit protocol, but decided against it at this time as it introduces quite a bit of complexity. We may turn to it if the limited idempotency solution does not cover a sufficient number of the cases in real-world testing.

**Changes**

The refresh token algorithm is changed to offer a limited form of idempotency, such that:

1. An **active refresh token** is the last non-revoked refresh token in a session.  
  This is the token that should have been saved by the client. It can generally be only used once to generate a new active refresh token at which point it looses its status.
2. A non-active refresh token can sometimes be used again to issue a valid token:
2.1. If the non-active token is being _reused_ close to the time it was used again.
2.2. **NEW** If the non-active token is the parent of the currently active token.  
        This case adds limited idempotency by always returning the active token, and does not create a new active refresh token.