### PR TITLE
fix: #1218 fixes existing migrations to allow namespaces!="auth"

### DIFF
--- a/migrations/00_init_auth_schema.up.sql
+++ b/migrations/00_init_auth_schema.up.sql
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS {{ index .Options "Namespace" }}.schema_migrations (
 	"version" varchar(255) NOT NULL,
 	CONSTRAINT schema_migrations_pkey PRIMARY KEY ("version")
 );
-comment on table auth.schema_migrations is 'Auth: Manages updates to the auth system.';
+comment on table {{ index .Options "Namespace" }}.schema_migrations is 'Auth: Manages updates to the auth system.';
 		
 -- Gets the User ID from the request cookie
 create or replace function {{ index .Options "Namespace" }}.uid() returns uuid as $$

--- a/migrations/20221003041349_add_mfa_schema.up.sql
+++ b/migrations/20221003041349_add_mfa_schema.up.sql
@@ -47,4 +47,4 @@ create table if not exists {{ index .Options "Namespace" }}.mfa_amr_claims(
     constraint mfa_amr_claims_session_id_authentication_method_pkey unique(session_id, authentication_method),
     constraint mfa_amr_claims_session_id_fkey foreign key(session_id) references {{ index .Options "Namespace" }}.sessions(id) on delete cascade
 );
-comment on table auth.mfa_amr_claims is 'auth: stores authenticator method reference claims for multi factor authentication';
+comment on table {{ index .Options "Namespace" }}.mfa_amr_claims is 'auth: stores authenticator method reference claims for multi factor authentication';

--- a/migrations/20221125140132_backfill_email_identity.up.sql
+++ b/migrations/20221125140132_backfill_email_identity.up.sql
@@ -1,7 +1,7 @@
 -- backfill the auth.identities column by adding an email identity 
 -- for all auth.users with an email and password 
 
-insert into auth.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
+insert into {{ index .Options "Namespace" }}.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
 select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2022-11-25' as created_at, '2022-11-25' as updated_at
-from auth.users as users
-where encrypted_password != '' and email is not null and not exists(select user_id from auth.identities where user_id = users.id);
+from {{ index .Options "Namespace" }}.users as users
+where encrypted_password != '' and email is not null and not exists(select user_id from {{ index .Options "Namespace" }}.identities where user_id = users.id);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix; Adapting existing migrations to allow other 'Namespaces' than Auth

## What is the current behavior?
If a 'Namespace' (DB-Schema) other than 'auth' should be used the migrations fail

Please link any relevant issues here.
#1218 

## What is the new behavior?
Other db-schemas might be used for gotrue. 

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
