### PR TITLE
feat: add time-boxed sessions

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -31,6 +31,17 @@ type API struct {
 	db      *storage.Connection
 	config  *conf.GlobalConfiguration
 	version string
+
+	// overrideTime can be used to override the clock used by handlers. Should only be used in tests!
+	overrideTime func() time.Time
+}
+
+func (a *API) Now() time.Time {
+	if a.overrideTime != nil {
+		return a.overrideTime()
+	}
+
+	return time.Now()
 }
 
 // NewAPI instantiates a new REST API

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -60,6 +60,40 @@ func (ts *TokenTestSuite) SetupTest() {
 	require.NoError(ts.T(), err, "Error creating refresh token")
 }
 
+func (ts *TokenTestSuite) TestSessionTimebox() {
+	timebox := 10 * time.Second
+
+	ts.API.config.Sessions.Timebox = &timebox
+	ts.API.overrideTime = func() time.Time {
+		return time.Now().Add(timebox).Add(time.Second)
+	}
+
+	defer func() {
+		ts.API.overrideTime = nil
+	}()
+
+	var buffer bytes.Buffer
+	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
+		"refresh_token": ts.RefreshToken.Token,
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/token?grant_type=refresh_token", &buffer)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	assert.Equal(ts.T(), http.StatusBadRequest, w.Code)
+
+	var firstResult struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+
+	assert.NoError(ts.T(), json.NewDecoder(w.Result().Body).Decode(&firstResult))
+	assert.Equal(ts.T(), "invalid_grant", firstResult.Error)
+	assert.Equal(ts.T(), "Invalid Refresh Token: Session Expired", firstResult.ErrorDescription)
+}
+
 func (ts *TokenTestSuite) TestFailedToSaveRefreshTokenResultCase() {
 	var buffer bytes.Buffer
 

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -111,6 +111,22 @@ func (a *APIConfiguration) Validate() error {
 	return nil
 }
 
+type SessionsConfiguration struct {
+	Timebox *time.Duration `json:"timebox"`
+}
+
+func (c *SessionsConfiguration) Validate() error {
+	if c.Timebox == nil {
+		return nil
+	}
+
+	if *c.Timebox <= time.Duration(0) {
+		return fmt.Errorf("conf: session timebox duration must be positive when set, was %v", (*c.Timebox).String())
+	}
+
+	return nil
+}
+
 // GlobalConfiguration holds all the configuration that applies to all instances.
 type GlobalConfiguration struct {
 	API                   APIConfiguration
@@ -139,6 +155,7 @@ type GlobalConfiguration struct {
 	DisableSignup     bool                     `json:"disable_signup" split_words:"true"`
 	Webhook           WebhookConfig            `json:"webhook" split_words:"true"`
 	Security          SecurityConfiguration    `json:"security"`
+	Sessions          SessionsConfiguration    `json:"sessions"`
 	MFA               MFAConfiguration         `json:"MFA"`
 	Cookie            struct {
 		Key      string `json:"key"`
@@ -516,6 +533,7 @@ func (c *GlobalConfiguration) Validate() error {
 		&c.SMTP,
 		&c.SAML,
 		&c.Security,
+		&c.Sessions,
 	}
 
 	for _, validatable := range validatables {

--- a/internal/models/sessions.go
+++ b/internal/models/sessions.go
@@ -58,9 +58,12 @@ func (s sortAMREntries) Swap(i, j int) {
 }
 
 type Session struct {
-	ID        uuid.UUID  `json:"-" db:"id"`
-	UserID    uuid.UUID  `json:"user_id" db:"user_id"`
-	NotAfter  *time.Time `json:"not_after,omitempty" db:"not_after"`
+	ID     uuid.UUID `json:"-" db:"id"`
+	UserID uuid.UUID `json:"user_id" db:"user_id"`
+
+	// NotAfter is overriden by timeboxed sessions.
+	NotAfter *time.Time `json:"not_after,omitempty" db:"not_after"`
+
 	CreatedAt time.Time  `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
 	FactorID  *uuid.UUID `json:"factor_id" db:"factor_id"`


### PR DESCRIPTION
Adds time-boxed sessions. These sessions time-out after a fixed amount of time configured via the `GOTRUE_SESSIONS_TIMEBOX` property (if set).