### PR TITLE
feat: add inactivity-timeout to sessions

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -156,6 +156,8 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	var grantParams models.GrantParams
 	var err error
 
+	grantParams.FillGrantParams(r)
+
 	if providerType == "twitter" {
 		// future OAuth1.0 providers will use this method
 		oAuthResponseData, err := a.oAuth1Callback(ctx, r, providerType)

--- a/internal/api/samlacs.go
+++ b/internal/api/samlacs.go
@@ -262,6 +262,8 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 
 	var grantParams models.GrantParams
 
+	grantParams.FillGrantParams(r)
+
 	if !notAfter.IsZero() {
 		grantParams.SessionNotAfter = &notAfter
 	}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -108,6 +108,9 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 
 	var user *models.User
 	var grantParams models.GrantParams
+
+	grantParams.FillGrantParams(r)
+
 	params.Aud = a.requestAud(ctx, r)
 
 	switch params.Provider {

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -113,6 +113,9 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	var user *models.User
 	var grantParams models.GrantParams
 	var provider string
+
+	grantParams.FillGrantParams(r)
+
 	if params.Email != "" {
 		provider = "email"
 		if !config.External.Email.Enabled {
@@ -180,6 +183,12 @@ func (a *API) PKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 	db := a.db.WithContext(ctx)
 	var grantParams models.GrantParams
 
+	// There is a slight problem with this as it will pick-up the
+	// User-Agent and IP addresses from the server if used on the server
+	// side. Currently there's no mechanism to distinguish, but the server
+	// can be told to at least propagate the User-Agent header.
+	grantParams.FillGrantParams(r)
+
 	params := &PKCEGrantParams{}
 	body, err := getBodyBytes(r)
 	if err != nil {
@@ -245,7 +254,6 @@ func (a *API) PKCE(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	return sendJSON(w, http.StatusOK, token)
-
 }
 
 func generateAccessToken(tx *storage.Connection, user *models.User, sessionId *uuid.UUID, config *conf.JWTConfiguration) (string, int64, error) {

--- a/internal/api/token_oidc.go
+++ b/internal/api/token_oidc.go
@@ -193,6 +193,8 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 	var token *AccessTokenResponse
 	var grantParams models.GrantParams
 
+	grantParams.FillGrantParams(r)
+
 	if err := db.Transaction(func(tx *storage.Connection) error {
 		var user *models.User
 		var terr error

--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -133,6 +133,9 @@ func (a *API) verifyGet(w http.ResponseWriter, r *http.Request, params *VerifyPa
 		token       *AccessTokenResponse
 		authCode    string
 	)
+
+	grantParams.FillGrantParams(r)
+
 	flowType := models.ImplicitFlow
 	var authenticationMethod models.AuthenticationMethod
 	if strings.HasPrefix(params.Token, PKCEPrefix) {
@@ -227,6 +230,8 @@ func (a *API) verifyPost(w http.ResponseWriter, r *http.Request, params *VerifyP
 		token       *AccessTokenResponse
 	)
 	var isSingleConfirmationResponse = false
+
+	grantParams.FillGrantParams(r)
 
 	err := db.Transaction(func(tx *storage.Connection) error {
 		var terr error

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -112,7 +112,8 @@ func (a *APIConfiguration) Validate() error {
 }
 
 type SessionsConfiguration struct {
-	Timebox *time.Duration `json:"timebox"`
+	Timebox           *time.Duration `json:"timebox"`
+	InactivityTimeout *time.Duration `json:"inactivity_timeout,omitempty" split_words:"true"`
 }
 
 func (c *SessionsConfiguration) Validate() error {

--- a/internal/utilities/request.go
+++ b/internal/utilities/request.go
@@ -24,7 +24,12 @@ func GetIPAddress(r *http.Request) string {
 
 			for _, ip := range ips {
 				if ip != "" {
-					return ip
+					parsed := net.ParseIP(ip)
+					if parsed == nil {
+						continue
+					}
+
+					return parsed.String()
 				}
 			}
 		}

--- a/migrations/20231027141322_add_session_refresh_columns.up.sql
+++ b/migrations/20231027141322_add_session_refresh_columns.up.sql
@@ -1,0 +1,4 @@
+alter table if exists {{ index .Options "Namespace" }}.sessions
+  add column if not exists refreshed_at timestamp without time zone,
+  add column if not exists user_agent text,
+  add column if not exists ip inet;


### PR DESCRIPTION
Adds the ability for sessions to time-out after a period of inactivity. "Activity" is defined as refreshing the session.

This can be configured by setting the `GOTRUE_SESSIONS_INACTIVITY_TIMEOUT` to a duration.

Since this PR modifies the database by adding a new `refreshed_at` nullable column to `sessions`, it also adds some useful columns to the `sessions` table to track the `User-Agent` and IP address that performed the refresh / session creation.