### PR TITLE
fix: check for pkce prefix

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -563,6 +563,8 @@ func (a *API) verifyUserAndToken(ctx context.Context, conn *storage.Connection, 
 	case smsVerification:
 		user, err = models.FindUserByPhoneAndAudience(conn, params.Phone, aud)
 	case emailChangeVerification:
+		// Since the email change could be trigger via the implicit or PKCE flow,
+		// the query used has to also check if the token saved in the db contains the pkce_ prefix
 		user, err = models.FindUserForEmailChange(conn, params.Email, tokenHash, aud, config.Mailer.SecureEmailChangeEnabled)
 	default:
 		user, err = models.FindUserByEmailAndAudience(conn, params.Email, aud)

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -531,8 +531,8 @@ func FindUsersInAudience(tx *storage.Connection, aud string, pageParams *Paginat
 func FindUserByEmailChangeCurrentAndAudience(tx *storage.Connection, email, token, aud string) (*User, error) {
 	return findUser(
 		tx,
-		"instance_id = ? and LOWER(email) = ? and email_change_token_current = ? and aud = ? and is_sso_user = false",
-		uuid.Nil, strings.ToLower(email), token, aud,
+		"instance_id = ? and LOWER(email) = ? and aud = ? and is_sso_user = false and (email_change_token_current = 'pkce_' || ? or email_change_token_current = ?)",
+		uuid.Nil, strings.ToLower(email), aud, token, token,
 	)
 }
 
@@ -540,8 +540,8 @@ func FindUserByEmailChangeCurrentAndAudience(tx *storage.Connection, email, toke
 func FindUserByEmailChangeNewAndAudience(tx *storage.Connection, email, token, aud string) (*User, error) {
 	return findUser(
 		tx,
-		"instance_id = ? and LOWER(email_change) = ? and email_change_token_new = ? and aud = ? and is_sso_user = false",
-		uuid.Nil, strings.ToLower(email), token, aud,
+		"instance_id = ? and LOWER(email_change) = ? and aud = ? and is_sso_user = false and (email_change_token_new = 'pkce_' || ? or email_change_token_new = ?)",
+		uuid.Nil, strings.ToLower(email), aud, token, token,
 	)
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #798 
* When a user requests for an email change via the `updateUser` method, it can use either the implicit or PKCE flow. However, when we verify the email change token, we should be checking for the `pkce_` prefix too. 