### PR TITLE
feat: add single session per user with tags support

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -114,6 +114,9 @@ func (a *APIConfiguration) Validate() error {
 type SessionsConfiguration struct {
 	Timebox           *time.Duration `json:"timebox"`
 	InactivityTimeout *time.Duration `json:"inactivity_timeout,omitempty" split_words:"true"`
+
+	SinglePerUser bool     `json:"single_per_user" split_words:"true"`
+	Tags          []string `json:"tags,omitempty"`
 }
 
 func (c *SessionsConfiguration) Validate() error {

--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -42,6 +42,7 @@ type GrantParams struct {
 	FactorID *uuid.UUID
 
 	SessionNotAfter *time.Time
+	SessionTag      *string
 
 	UserAgent string
 	IP        string
@@ -143,6 +144,10 @@ func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshTok
 
 		if params.IP != "" {
 			session.IP = &params.IP
+		}
+
+		if params.SessionTag != nil && *params.SessionTag != "" {
+			session.Tag = params.SessionTag
 		}
 
 		if err := tx.Create(session); err != nil {

--- a/migrations/20231114161723_add_sessions_tag.up.sql
+++ b/migrations/20231114161723_add_sessions_tag.up.sql
@@ -1,0 +1,2 @@
+alter table if exists {{ index .Options "Namespace" }}.sessions
+  add column if not exists tag text;


### PR DESCRIPTION
Enforces a single session per user with optional tags. If a session has a tag, only the most recently refreshed session with the same tag can be refreshed. If no tags are configured, then only the most recently refreshed session of all of the user's sessions will be refreshed. 

Sessions that are invalid due to inactivity or timeboxing won't be considered.
