### PR TITLE
refactor: rename `Session.UpdateRefresh` to `UpdateRefreshInfo`

### DIFF
--- a/internal/api/token_refresh.go
+++ b/internal/api/token_refresh.go
@@ -198,7 +198,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 				session.IP = nil
 			}
 
-			if terr := session.UpdateRefresh(tx); terr != nil {
+			if terr := session.UpdateOnlyRefreshInfo(tx); terr != nil {
 				return internalServerError("failed to update session information").WithInternalError(terr)
 			}
 

--- a/internal/models/sessions.go
+++ b/internal/models/sessions.go
@@ -100,7 +100,7 @@ func (s *Session) LastRefreshedAt(refreshTokenTime *time.Time) time.Time {
 	return *refreshedAt
 }
 
-func (s *Session) UpdateRefresh(tx *storage.Connection) error {
+func (s *Session) UpdateOnlyRefreshInfo(tx *storage.Connection) error {
 	return tx.UpdateOnly(s, "refreshed_at", "user_agent", "ip")
 }
 


### PR DESCRIPTION
My previous force-push didn't succeed but I accidentally merged thinking it did.