### PR TITLE
Update defaults for RATE_LIMIT_TOKEN_REFRESH

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -143,7 +143,7 @@ type GlobalConfiguration struct {
 	RateLimitEmailSent    float64 `split_words:"true" default:"30"`
 	RateLimitSmsSent      float64 `split_words:"true" default:"30"`
 	RateLimitVerify       float64 `split_words:"true" default:"30"`
-	RateLimitTokenRefresh float64 `split_words:"true" default:"30"`
+	RateLimitTokenRefresh float64 `split_words:"true" default:"150"`
 	RateLimitSso          float64 `split_words:"true" default:"30"`
 
 	SiteURL           string   `json:"site_url" split_words:"true" required:"true"`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Change the defaults for`RATE_LIMIT_TOKEN_REFRESH` from 30 to 150 to allow for more token refreshes and also to match what is offered on the hosted platform.