### PR TITLE
fix: allow transactions to be committed while returning a custom error

### DIFF
--- a/internal/api/external_github_test.go
+++ b/internal/api/external_github_test.go
@@ -276,12 +276,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGitHubErrorWhenVerifiedFalse() {
 
 	u := performAuthorization(ts, "github", code, "")
 
-	v, err := url.ParseQuery(u.Fragment)
-	ts.Require().NoError(err)
-	ts.Equal("unauthorized_client", v.Get("error"))
-	ts.Equal("401", v.Get("error_code"))
-	ts.Equal("Unverified email with github. A confirmation email has been sent to your github email", v.Get("error_description"))
-	assertAuthorizationFailure(ts, u, "", "", "")
+	assertAuthorizationFailure(ts, u, "Unverified email with github. A confirmation email has been sent to your github email", "unauthorized_client", "")
 }
 
 func (ts *ExternalTestSuite) TestSignupExternalGitHubErrorWhenUserBanned() {

--- a/internal/api/external_kakao_test.go
+++ b/internal/api/external_kakao_test.go
@@ -206,12 +206,7 @@ func (ts *ExternalTestSuite) TestSignupExternalKakaoErrorWhenVerifiedFalse() {
 
 	u := performAuthorization(ts, "kakao", code, "")
 
-	v, err := url.ParseQuery(u.Fragment)
-	ts.Require().NoError(err)
-	ts.Equal("unauthorized_client", v.Get("error"))
-	ts.Equal("401", v.Get("error_code"))
-	ts.Equal("Unverified email with kakao. A confirmation email has been sent to your kakao email", v.Get("error_description"))
-	assertAuthorizationFailure(ts, u, "", "", "")
+	assertAuthorizationFailure(ts, u, "Unverified email with kakao. A confirmation email has been sent to your kakao email", "unauthorized_client", "")
 }
 
 func (ts *ExternalTestSuite) TestSignupExternalKakaoErrorWhenUserBanned() {

--- a/internal/storage/dial.go
+++ b/internal/storage/dial.go
@@ -112,11 +112,42 @@ func registerOpenTelemetryDatabaseStats(db *pop.Connection) {
 	}
 }
 
+type CommitWithError struct {
+	Err error
+}
+
+func (e *CommitWithError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *CommitWithError) Cause() error {
+	return e.Err
+}
+
+// NewCommitWithError creates an error that can be returned in a pop transaction
+// without rolling back the transaction. This should only be used in cases where
+// you want the transaction to commit but return an error message to the user.
+func NewCommitWithError(err error) *CommitWithError {
+	return &CommitWithError{Err: err}
+}
+
 func (c *Connection) Transaction(fn func(*Connection) error) error {
 	if c.TX == nil {
-		return c.Connection.Transaction(func(tx *pop.Connection) error {
-			return fn(&Connection{tx})
+		var returnErr error
+		terr := c.Connection.Transaction(func(tx *pop.Connection) error {
+			err := fn(&Connection{tx})
+			switch err.(type) {
+			case *CommitWithError:
+				returnErr = err
+				return nil
+			default:
+				return err
+			}
 		})
+		if terr != nil {
+			return terr
+		}
+		return returnErr
 	}
 	return fn(c)
 }

--- a/internal/storage/dial.go
+++ b/internal/storage/dial.go
@@ -134,7 +134,7 @@ func NewCommitWithError(err error) *CommitWithError {
 func (c *Connection) Transaction(fn func(*Connection) error) error {
 	if c.TX == nil {
 		var returnErr error
-		terr := c.Connection.Transaction(func(tx *pop.Connection) error {
+		if terr := c.Connection.Transaction(func(tx *pop.Connection) error {
 			err := fn(&Connection{tx})
 			switch err.(type) {
 			case *CommitWithError:
@@ -143,8 +143,7 @@ func (c *Connection) Transaction(fn func(*Connection) error) error {
 			default:
 				return err
 			}
-		})
-		if terr != nil {
+		}); terr != nil {
 			return terr
 		}
 		return returnErr

--- a/internal/storage/dial_test.go
+++ b/internal/storage/dial_test.go
@@ -1,10 +1,12 @@
 package storage
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/supabase/gotrue/internal/conf"
 )
 
 type TestUser struct {
@@ -25,4 +27,34 @@ func TestGetExcludedColumns_InvalidName(t *testing.T) {
 	u := TestUser{}
 	_, err := getExcludedColumns(u, "adsf")
 	require.Error(t, err)
+}
+
+func TestTransaction(t *testing.T) {
+	apiTestConfig := "../../hack/test.env"
+	config, err := conf.LoadGlobal(apiTestConfig)
+	require.NoError(t, err)
+	conn, err := Dial(config)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	defer func() {
+		// clean up the test table created
+		require.NoError(t, conn.RawQuery("drop table if exists test").Exec(), "Error removing table")
+	}()
+
+	commitWithError := NewCommitWithError(errors.New("commit with error"))
+	err = conn.Transaction(func(tx *Connection) error {
+		require.NoError(t, tx.RawQuery("create table if not exists test()").Exec(), "Error saving creating test table")
+		return commitWithError
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, commitWithError)
+
+	type TestData struct{}
+
+	// check that transaction is still being committed despite returning an error above
+	data := []TestData{}
+	err = conn.RawQuery("select * from test").All(&data)
+	require.NoError(t, err)
+	require.Empty(t, data)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* This PR introduces a new error type `CommitWithError` that allows one to commit a transaction but also return an error. 
* This is useful in situations where `GOTRUE_MAILER_ALLOW_UNVERIFIED_EMAIL_SIGN_INS="false"` since oauth users with an unverified email will require email confirmation before being allowed to sign-in. If the transaction doesn't get committed, the new user doesn't get created and the email confirmation sent out will not be mapped to a user in the database.