### PR TITLE
feat: update primary key for identities table

### DIFF
--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -438,7 +438,7 @@ func (ts *AdminTestSuite) TestAdminUserUpdate() {
 
 	for _, identity := range u.Identities {
 		// for email & phone identities, the providerId is the same as the userId
-		require.Equal(ts.T(), u.ID.String(), identity.ID)
+		require.Equal(ts.T(), u.ID.String(), identity.ProviderID)
 		require.Equal(ts.T(), u.ID, identity.UserID)
 		if identity.Provider == "email" {
 			require.Equal(ts.T(), newEmail, identity.IdentityData["email"])

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -673,9 +673,7 @@ func (u *User) RemoveUnconfirmedIdentities(tx *storage.Connection, identity *Ide
 
 	// finally, remove all identities except the current identity being authenticated
 	for i := range u.Identities {
-		identityId := u.Identities[i].Provider + u.Identities[i].ID
-		identityIdToKeep := identity.Provider + identity.ID
-		if identityId != identityIdToKeep {
+		if u.Identities[i].ID != identity.ID {
 			if terr := tx.Destroy(&u.Identities[i]); terr != nil {
 				return terr
 			}
@@ -762,10 +760,9 @@ func (u *User) SoftDeleteUserIdentities(tx *storage.Connection) error {
 		if err := tx.RawQuery(
 			"update "+
 				(&pop.Model{Value: Identity{}}).TableName()+
-				" set id = ? where id = ? and provider = ?",
-			obfuscateIdentityId(identity),
+				" set provider_id = ? where id = ?",
+			obfuscateIdentityProviderId(identity),
 			identity.ID,
-			identity.Provider,
 		).Exec(); err != nil {
 			return err
 		}
@@ -787,6 +784,6 @@ func obfuscatePhone(u *User, phone string) string {
 	return obfuscateValue(u.ID, phone)[:15]
 }
 
-func obfuscateIdentityId(identity *Identity) string {
-	return obfuscateValue(identity.UserID, identity.Provider+":"+identity.ID)
+func obfuscateIdentityProviderId(identity *Identity) string {
+	return obfuscateValue(identity.UserID, identity.Provider+":"+identity.ProviderID)
 }

--- a/migrations/20231117164230_add_id_pkey_identities.up.sql
+++ b/migrations/20231117164230_add_id_pkey_identities.up.sql
@@ -1,0 +1,31 @@
+do $$
+begin
+    if not exists(select * 
+        from information_schema.columns
+        where table_schema = '{{ index .Options "Namespace" }}' and table_name='identities' and column_name='provider_id')
+    then
+        alter table if exists {{ index .Options "Namespace" }}.identities 
+        rename column id to provider_id;
+    end if;
+end$$;
+
+alter table if exists {{ index .Options "Namespace" }}.identities 
+    drop constraint if exists identities_pkey;
+
+alter table if exists {{ index .Options "Namespace" }}.identities 
+    add column if not exists id uuid default gen_random_uuid() primary key;
+
+do $$
+begin
+  if not exists
+     (select constraint_name
+      from information_schema.table_constraints
+      where table_schema = '{{ index .Options "Namespace" }}'
+      and table_name = 'identities'
+      and constraint_name = 'identities_provider_id_provider_unique')
+  then
+    alter table if exists {{ index .Options "Namespace" }}.identities 
+    add constraint identities_provider_id_provider_unique 
+    unique(provider_id, provider);
+  end if;
+end $$;

--- a/migrations/20231117164230_add_id_pkey_identities.up.sql
+++ b/migrations/20231117164230_add_id_pkey_identities.up.sql
@@ -10,9 +10,7 @@ begin
 end$$;
 
 alter table if exists {{ index .Options "Namespace" }}.identities 
-    drop constraint if exists identities_pkey;
-
-alter table if exists {{ index .Options "Namespace" }}.identities 
+    drop constraint if exists identities_pkey,
     add column if not exists id uuid default gen_random_uuid() primary key;
 
 do $$


### PR DESCRIPTION
## What kind of change does this PR introduce?
* We need to be able to have a consistent identifier to fetch an identity from the database. The current approach for using a composite primary key isn't sufficient and not ideal for exposing through the API.
* Remove the composite primary key on (`auth.identities.id`, `auth.identities.provider`)
* Rename `auth.identities.id` to `auth.identities.provider_id`
* Add a new primary key called `auth.identities.id` 
* Add a unique constraint on (`auth.identities.provider_id`, `auth.identities.provider`)