### PR TITLE
fix: disable allow unverified email sign ins if autoconfirm enabled

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -250,7 +250,7 @@ func (c *SMTPConfiguration) Validate() error {
 
 type MailerConfiguration struct {
 	Autoconfirm                 bool `json:"autoconfirm"`
-	AllowUnverifiedEmailSignIns bool `json:"allow_unverified_email_sign_ins" split_words:"true" default:"true"`
+	AllowUnverifiedEmailSignIns bool `json:"allow_unverified_email_sign_ins" split_words:"true" default:"false"`
 
 	Subjects  EmailContentConfiguration `json:"subjects"`
 	Templates EmailContentConfiguration `json:"templates"`


### PR DESCRIPTION
## What kind of change does this PR introduce?
* default `GOTRUE_MAILER_ALLOW_UNVERIFIED_EMAIL_SIGN_INS` to false