### PR TITLE
refactor: rename `GenerateLink` to `adminGenerateLink`

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -223,7 +223,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 				})
 			})
 
-			r.Post("/generate_link", api.GenerateLink)
+			r.Post("/generate_link", api.adminGenerateLink)
 
 			r.Route("/sso", func(r *router) {
 				r.Route("/providers", func(r *router) {

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -42,7 +42,7 @@ type GenerateLinkResponse struct {
 	RedirectTo       string `json:"redirect_to"`
 }
 
-func (a *API) GenerateLink(w http.ResponseWriter, r *http.Request) error {
+func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	db := a.db.WithContext(ctx)
 	config := a.config


### PR DESCRIPTION
Follows the pattern where all admin handlers are named `adminXYZ`.