### PR TITLE
feat: refactor for central password strength check

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -144,7 +143,6 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 	user := getUser(ctx)
 	adminUser := getAdminUser(ctx)
 	params, err := a.getAdminParams(r)
-	config := a.config
 	if err != nil {
 		return err
 	}
@@ -176,6 +174,18 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	if params.Password != nil {
+		password := *params.Password
+
+		if err := a.checkPasswordStrength(ctx, password); err != nil {
+			return err
+		}
+
+		if err := user.SetPassword(ctx, password); err != nil {
+			return err
+		}
+	}
+
 	err = db.Transaction(func(tx *storage.Connection) error {
 		if params.Role != "" {
 			if terr := user.SetRole(tx, params.Role); terr != nil {
@@ -196,11 +206,7 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if params.Password != nil {
-			if len(*params.Password) < config.PasswordMinLength {
-				return invalidPasswordLengthError(config.PasswordMinLength)
-			}
-
-			if terr := user.UpdatePassword(tx, *params.Password, nil); terr != nil {
+			if terr := user.UpdatePassword(tx, nil); terr != nil {
 				return terr
 			}
 		}
@@ -284,9 +290,6 @@ func (a *API) adminUserUpdate(w http.ResponseWriter, r *http.Request) error {
 	})
 
 	if err != nil {
-		if errors.Is(err, invalidPasswordLengthError(config.PasswordMinLength)) {
-			return err
-		}
 		return internalServerError("Error updating user").WithInternalError(err)
 	}
 

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -350,7 +350,7 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 				expectedPassword = fmt.Sprintf("%v", c.params["password"])
 			}
 
-			assert.Equal(ts.T(), c.expected["isAuthenticated"], u.Authenticate(expectedPassword))
+			assert.Equal(ts.T(), c.expected["isAuthenticated"], u.Authenticate(context.Background(), expectedPassword))
 
 			// remove created user after each case
 			require.NoError(ts.T(), ts.API.db.Destroy(u))

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -97,18 +97,16 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 
 	var signupUser *models.User
 	if params.Type == signupVerification && user == nil {
-		if params.Password == "" {
-			return unprocessableEntityError("Signup requires a valid password")
-		}
-		if len(params.Password) < config.PasswordMinLength {
-			return invalidPasswordLengthError(config.PasswordMinLength)
-		}
 		signupParams := &SignupParams{
 			Email:    params.Email,
 			Password: params.Password,
 			Data:     params.Data,
 			Provider: "email",
 			Aud:      aud,
+		}
+
+		if err := a.validateSignupParams(ctx, signupParams); err != nil {
+			return err
 		}
 
 		signupUser, err = signupParams.ToUserModel(false /* <- isSSOUser */)

--- a/internal/api/password.go
+++ b/internal/api/password.go
@@ -1,0 +1,13 @@
+package api
+
+import "context"
+
+func (a *API) checkPasswordStrength(ctx context.Context, password string) error {
+	config := a.config
+
+	if len(password) < config.PasswordMinLength {
+		return invalidPasswordLengthError(config.PasswordMinLength)
+	}
+
+	return nil
+}

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -140,7 +140,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 		return internalServerError("Database error querying schema").WithInternalError(err)
 	}
 
-	if user.IsBanned() || !user.Authenticate(params.Password) {
+	if user.IsBanned() || !user.Authenticate(ctx, params.Password) {
 		return oauthError("invalid_grant", InvalidLoginMessage)
 	}
 

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -306,7 +307,7 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 			u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 
-			require.Equal(ts.T(), c.expected.isAuthenticated, u.Authenticate(c.newPassword))
+			require.Equal(ts.T(), c.expected.isAuthenticated, u.Authenticate(context.Background(), c.newPassword))
 		})
 	}
 }
@@ -363,7 +364,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	u, err = models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 
-	require.True(ts.T(), u.Authenticate("newpass"))
+	require.True(ts.T(), u.Authenticate(context.Background(), "newpass"))
 	require.Empty(ts.T(), u.ReauthenticationToken)
 	require.NotEmpty(ts.T(), u.ReauthenticationSentAt)
 }

--- a/internal/models/linking_test.go
+++ b/internal/models/linking_test.go
@@ -81,7 +81,7 @@ func (ts *AccountLinkingTestSuite) TestCreateAccountDecisionWithAccounts() {
 
 	// when the email doesn't exist in the system -- conventional provider
 	decision, err := DetermineAccountLinking(ts.db, ts.config, []provider.Email{
-		provider.Email{
+		{
 			Email:    "other@example.com",
 			Verified: true,
 			Primary:  true,
@@ -93,7 +93,7 @@ func (ts *AccountLinkingTestSuite) TestCreateAccountDecisionWithAccounts() {
 
 	// when looking for an email that doesn't exist in the SSO linking domain
 	decision, err = DetermineAccountLinking(ts.db, ts.config, []provider.Email{
-		provider.Email{
+		{
 			Email:    "other@samltest.id",
 			Verified: true,
 			Primary:  true,
@@ -116,7 +116,7 @@ func (ts *AccountLinkingTestSuite) TestAccountExists() {
 	require.NoError(ts.T(), ts.db.Create(identityA))
 
 	decision, err := DetermineAccountLinking(ts.db, ts.config, []provider.Email{
-		provider.Email{
+		{
 			Email:    "test@example.com",
 			Verified: true,
 			Primary:  true,
@@ -299,7 +299,7 @@ func (ts *AccountLinkingTestSuite) TestMultipleAccounts() {
 	// identities in the same "default" linking domain with the same email
 	// address pointing to two different user accounts
 	decision, err := DetermineAccountLinking(ts.db, ts.config, []provider.Email{
-		provider.Email{
+		{
 			Email:    "test@example.com",
 			Verified: true,
 			Primary:  true,


### PR DESCRIPTION
Refactors all places where the password strength check (right now just length check) is enforced to a single method on the API `checkPasswordStrength`.

To do this, both `SignupParams` and `UserUpdateParams` had to be reworked. Furthermore user update now splits basic validation logic from user update validation logic and the main updating transaction which should drastically speed up the method itself. 