### PR TITLE
feat: pg function should use fully qualified name

### DIFF
--- a/migrations/20231117164230_add_id_pkey_identities.up.sql
+++ b/migrations/20231117164230_add_id_pkey_identities.up.sql
@@ -11,7 +11,7 @@ end$$;
 
 alter table if exists {{ index .Options "Namespace" }}.identities 
     drop constraint if exists identities_pkey,
-    add column if not exists id uuid default gen_random_uuid() primary key;
+    add column if not exists id uuid default public.gen_random_uuid() primary key;
 
 do $$
 begin


### PR DESCRIPTION
## What kind of change does this PR introduce?
* use the fully qualified name for `gen_random_uuid` instead of relying on the search path of the pg role
