### PR TITLE
feat: unlinking primary identity should update email

### DIFF
--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -105,3 +105,17 @@ type FlowStateNotFoundError struct{}
 func (e FlowStateNotFoundError) Error() string {
 	return "Flow State not found"
 }
+
+func IsUniqueConstraintViolatedError(err error) bool {
+	switch err.(type) {
+	case UserEmailUniqueConflictError, *UserEmailUniqueConflictError:
+		return true
+	}
+	return false
+}
+
+type UserEmailUniqueConflictError struct{}
+
+func (e UserEmailUniqueConflictError) Error() string {
+	return "User email unique constraint violated"
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* A primary identity is implicitly defined by the first identity created when the user signs up
* Addresses the issue where unlinking a primary identity results in the `auth.users.email` becoming stale. If the other identities do not have the same email, the `auth.users.email` column should be updated to use one of the existing identities emails
* Update the `FindProvidersByUser` method to remove duplicates if there is more than 1 identity that share the same provider