### PR TITLE
feat: find user by email address

### DIFF
--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -358,6 +358,58 @@ func (ts *AdminTestSuite) TestAdminUserCreate() {
 	}
 }
 
+// TestAdminUserFind_GetEmail tests API /admin/user/find?email=xyz route (GET)
+func (ts *AdminTestSuite) TestAdminUserFind_GetEmail() {
+	u, err := models.NewUser("12345678", "test1@example.com", "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test Get User by Email"})
+	require.NoError(ts.T(), err, "Error making new user")
+	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
+
+	// Setup request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/admin/users/find?email=%s", u.Email), nil)
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	data := make(map[string]interface{})
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+
+	assert.Equal(ts.T(), data["email"], "test1@example.com")
+	assert.NotNil(ts.T(), data["app_metadata"])
+	assert.NotNil(ts.T(), data["user_metadata"])
+	md := data["user_metadata"].(map[string]interface{})
+	assert.Len(ts.T(), md, 1)
+	assert.Equal(ts.T(), "Test Get User by Email", md["full_name"])
+}
+
+// TestAdminUserFind_GetUserID tests API /admin/user/find?email=xyz route (GET)
+func (ts *AdminTestSuite) TestAdminUserFind_GetUserID() {
+	u, err := models.NewUser("12345678", "test1@example.com", "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test Get User by ID"})
+	require.NoError(ts.T(), err, "Error making new user")
+	require.NoError(ts.T(), ts.API.db.Create(u), "Error creating user")
+
+	// Setup request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/admin/users/find?user_id=%s", u.ID), nil)
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	data := make(map[string]interface{})
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+
+	assert.Equal(ts.T(), data["email"], "test1@example.com")
+	assert.NotNil(ts.T(), data["app_metadata"])
+	assert.NotNil(ts.T(), data["user_metadata"])
+	md := data["user_metadata"].(map[string]interface{})
+	assert.Len(ts.T(), md, 1)
+	assert.Equal(ts.T(), "Test Get User by ID", md["full_name"])
+}
+
 // TestAdminUserGet tests API /admin/user route (GET)
 func (ts *AdminTestSuite) TestAdminUserGet() {
 	u, err := models.NewUser("12345678", "test1@example.com", "test", ts.Config.JWT.Aud, map[string]interface{}{"full_name": "Test Get User"})

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -249,6 +249,10 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 					r.Put("/", api.adminUserUpdate)
 					r.Delete("/", api.adminUserDelete)
 				})
+
+				r.Route("/find", func(r *router) {
+					r.Get("/", api.adminUserFind)
+				})
 			})
 
 			r.Post("/generate_link", api.adminGenerateLink)

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -453,6 +453,11 @@ func FindUserByID(tx *storage.Connection, id uuid.UUID) (*User, error) {
 	return findUser(tx, "instance_id = ? and id = ?", uuid.Nil, id)
 }
 
+// FindUserByEmail finds a user with the matching email address.
+func FindUserByEmail(tx *storage.Connection, email string) (*User, error) {
+	return findUser(tx, "instance_id = ? and LOWER(email) = ? and is_sso_user = false", uuid.Nil, strings.ToLower(email))
+}
+
 // FindUserByRecoveryToken finds a user with the matching recovery token.
 func FindUserByRecoveryToken(tx *storage.Connection, token string) (*User, error) {
 	return findUser(tx, "recovery_token = ? and is_sso_user = false", token)

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -133,6 +133,15 @@ func (ts *UserTestSuite) TestFindUserByID() {
 	require.Equal(ts.T(), u.ID, n.ID)
 }
 
+func (ts *UserTestSuite) TestFindUserByEmail() {
+	u := ts.createUser()
+
+	n, err := FindUserByEmail(ts.db, u.GetEmail())
+	require.NoError(ts.T(), err)
+
+	require.Equal(ts.T(), u.ID, n.ID)
+}
+
 func (ts *UserTestSuite) TestFindUserByRecoveryToken() {
 	u := ts.createUser()
 	u.RecoveryToken = "asdf"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1438,6 +1438,51 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorSchema"
 
+  /admin/users/find:
+    get:
+      summary: Find a user by email or user ID.
+      tags:
+        - admin
+      security:
+        - APIKeyAuth: []
+          AdminAuth: []
+      parameters:
+        - name: email
+          in: query
+          required: false
+          schema:
+            type: string
+            format: email
+        - name: user_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: User details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserSchema"
+        400:
+          description: Bad request. Either email or user_id must be provided, but not both.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSchema"
+        401:
+          $ref: "#/components/responses/UnauthorizedResponse"
+        403:
+          $ref: "#/components/responses/ForbiddenResponse"
+        404:
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSchema"
+
   /admin/sso/providers:
     get:
       summary: Fetch a list of all registered SSO providers.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: find user by their email address.

## What is the current behaviour?

Users cannot be found via their email address. 

## What is the new behaviour?

Users can be found via their email address using a new endpoint: `GET /admin/users/find`.

The new endpoint also supports returning a user by ID. Whilst it's already possible to return a user by their ID (`GET /admin/users/{userId}/`), owing to the structure of the endpoint, it cannot cleanly be extended to handle email (and likely telephone numbers in the future). It is logical that `/find` also services user IDs, and therefore it has been added.

`/admin/users/{userId}/` remains to prevent breaking changes.


## Additional context

https://github.com/orgs/supabase/discussions/19315#discussioncomment-7712527
