### PR TITLE
feat: add custom access token hook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,10 +39,10 @@ require (
 
 require (
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
-	github.com/bits-and-blooms/bloom/v3 v3.6.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/gobuffalo/nulls v0.4.2 // indirect
-	github.com/supabase/hibp v0.0.0-20231124125943-d225752ae869 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 )
 
 require (
@@ -66,12 +66,15 @@ require (
 )
 
 require (
+	github.com/bits-and-blooms/bloom/v3 v3.6.0
 	github.com/crewjam/saml v0.4.14
 	github.com/deepmap/oapi-codegen v1.12.4
 	github.com/fatih/structs v1.1.0
 	github.com/gobuffalo/pop/v6 v6.1.1
 	github.com/jackc/pgx/v4 v4.17.2
+	github.com/supabase/hibp v0.0.0-20231124125943-d225752ae869
 	github.com/supabase/mailme v0.0.0-20230628061017-01f68480c747
+	github.com/xeipuuv/gojsonschema v1.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -491,7 +491,14 @@ github.com/supabase/hibp v0.0.0-20231124125943-d225752ae869 h1:VDuRtwen5Z7QQ5ctu
 github.com/supabase/hibp v0.0.0-20231124125943-d225752ae869/go.mod h1:eHX5nlSMSnyPjUrbYzeqrA8snCe2SKyfizKjU3dkfOw=
 github.com/supabase/mailme v0.0.0-20230628061017-01f68480c747 h1:FIUdLV4o5JLsJno4Poum157kAxDKINeJo6liBfauLrI=
 github.com/supabase/mailme v0.0.0-20230628061017-01f68480c747/go.mod h1:kWsnmPfUBZTavlXYkfJrE9unzmmRAIi/kqsxXfEWEY8=
+github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -49,7 +49,7 @@ func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
 	u.Role = "supabase_admin"
 
 	var token string
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.PasswordGrant)
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,7 +49,7 @@ func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
 	u.Role = "supabase_admin"
 
 	var token string
-	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}

--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -59,7 +60,7 @@ func (ts *InviteTestSuite) makeSuperAdmin(email string) string {
 	u.Role = "supabase_admin"
 
 	var token string
-	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
 
 	require.NoError(ts.T(), err, "Error generating access token")
 

--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -60,7 +60,7 @@ func (ts *InviteTestSuite) makeSuperAdmin(email string) string {
 	u.Role = "supabase_admin"
 
 	var token string
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.Invite)
 
 	require.NoError(ts.T(), err, "Error generating access token")
 

--- a/internal/api/logout_test.go
+++ b/internal/api/logout_test.go
@@ -43,7 +43,7 @@ func (ts *LogoutTestSuite) SetupTest() {
 
 	// generate access token to use for logout
 	var t string
-	t, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
+	t, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.PasswordGrant)
 	require.NoError(ts.T(), err)
 	ts.token = t
 }

--- a/internal/api/logout_test.go
+++ b/internal/api/logout_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,7 @@ func (ts *LogoutTestSuite) SetupTest() {
 
 	// generate access token to use for logout
 	var t string
-	t, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	t, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
 	require.NoError(ts.T(), err)
 	ts.token = t
 }

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -313,6 +313,20 @@ func (a *API) invokeHook(ctx context.Context, input, output any) error {
 
 			return httpError.WithInternalError(&hookOutput.HookError)
 		}
+		if err := validateClaims(hookOutput.Claims); err != nil {
+			httpCode := hookOutput.HookError.HTTPCode
+
+			if httpCode == 0 {
+				httpCode = http.StatusInternalServerError
+			}
+
+			httpError := &HTTPError{
+				Code:    httpCode,
+				Message: err.Error(),
+			}
+
+			return httpError
+		}
 		return nil
 
 	default:

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -313,6 +313,7 @@ func (a *API) invokeHook(ctx context.Context, input, output any) error {
 
 			return httpError.WithInternalError(&hookOutput.HookError)
 		}
+		return nil
 
 	default:
 		panic("unknown hook input type")

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -313,7 +313,7 @@ func (a *API) invokeHook(ctx context.Context, input, output any) error {
 
 			return httpError.WithInternalError(&hookOutput.HookError)
 		}
-		if err := validateClaims(hookOutput.Claims); err != nil {
+		if err := validateTokenClaims(hookOutput.Claims); err != nil {
 			httpCode := hookOutput.HookError.HTTPCode
 
 			if httpCode == 0 {

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -87,7 +87,7 @@ func (ts *MFATestSuite) SetupTest() {
 }
 
 func (ts *MFATestSuite) generateToken(user *models.User, sessionId *uuid.UUID) string {
-	token, _, err := generateAccessToken(ts.API.db, user, sessionId, &ts.Config.JWT)
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionId)
 	require.NoError(ts.T(), err, "Error generating access token")
 	return token
 }
@@ -96,7 +96,7 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 	testFriendlyName := "bob"
 	alternativeFriendlyName := "john"
 
-	token, _, err := generateAccessToken(ts.API.db, ts.TestUser, nil, &ts.Config.JWT)
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, ts.TestUser, nil)
 	require.NoError(ts.T(), err)
 
 	var cases = []struct {

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -87,7 +87,7 @@ func (ts *MFATestSuite) SetupTest() {
 }
 
 func (ts *MFATestSuite) generateToken(user *models.User, sessionId *uuid.UUID) string {
-	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionId)
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionId, models.TOTPSignIn)
 	require.NoError(ts.T(), err, "Error generating access token")
 	return token
 }
@@ -96,7 +96,7 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 	testFriendlyName := "bob"
 	alternativeFriendlyName := "john"
 
-	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, ts.TestUser, nil)
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, ts.TestUser, nil, models.TOTPSignIn)
 	require.NoError(ts.T(), err)
 
 	var cases = []struct {

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -157,7 +157,7 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
 	var token string
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.OTP)
 	require.NoError(ts.T(), err)
 
 	cases := []struct {

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -157,7 +157,7 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
 	var token string
-	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
 	require.NoError(ts.T(), err)
 
 	cases := []struct {

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -517,7 +517,7 @@ func (a *API) clearCookieToken(config *conf.GlobalConfiguration, name string, w 
 	})
 }
 
-func validateClaims(outputClaims map[string]interface{}) error {
+func validateTokenClaims(outputClaims map[string]interface{}) error {
 	schemaLoader := gojsonschema.NewStringLoader(hooks.MinimumViableTokenSchema)
 
 	documentLoader := gojsonschema.NewGoLoader(outputClaims)

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -320,6 +320,18 @@ func generateAccessToken(tx *storage.Connection, user *models.User, sessionId *u
 		AuthenticatorAssuranceLevel:   aal,
 		AuthenticationMethodReference: amr,
 	}
+	if config.Hook.CustomAccessToken.Enabled {
+		input := hooks.CustomAccessTokenInput{
+			UserID: user.ID,
+		}
+
+		output := hooks.CustomAccessTokenOutput{}
+
+		err := a.invokeHook(ctx, &input, &output)
+		if err != nil {
+			return err
+		}
+	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -327,8 +327,8 @@ func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, u
 	var token *jwt.Token
 	if config.Hook.CustomAccessToken.Enabled {
 		input := hooks.CustomAccessTokenInput{
-			UserID: user.ID,
-			Claims: claims,
+			UserID:               user.ID,
+			Claims:               claims,
 			AuthenticationMethod: authenticationMethod.String(),
 		}
 
@@ -385,7 +385,7 @@ func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, u
 			return terr
 		}
 
-		tokenString, expiresAt, terr = a.generateAccessToken(ctx, tx, user,refreshToken.SessionId, authenticationMethod)
+		tokenString, expiresAt, terr = a.generateAccessToken(ctx, tx, user, refreshToken.SessionId, authenticationMethod)
 		if terr != nil {
 			return internalServerError("error generating jwt token").WithInternalError(terr)
 		}

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -337,10 +337,6 @@ func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, u
 		if err != nil {
 			return "", 0, err
 		}
-
-		if err := validateClaims(output.Claims); err != nil {
-			return "", 0, err
-		}
 		goTrueClaims := jwt.MapClaims(output.Claims)
 
 		token = jwt.NewWithClaims(jwt.SigningMethodHS256, goTrueClaims)

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -331,6 +331,13 @@ func generateAccessToken(tx *storage.Connection, user *models.User, sessionId *u
 		if err != nil {
 			return err
 		}
+
+		// Validate the claims on the output
+		// documentLoader := gojsonschema.NewStringLoader(output)
+		// schemaLoader := gojsonschema.NewStringLoader(hooks.AccessTokenSchema)
+		// claims := string(output)
+		// stringLoader := gojsonschema.NewStringLoader(jsonString)
+		// strin
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -346,7 +346,6 @@ func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, u
 		token = jwt.NewWithClaims(jwt.SigningMethodHS256, goTrueClaims)
 
 	} else {
-
 		token = jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	}
 
@@ -534,10 +533,14 @@ func validateClaims(outputClaims map[string]interface{}) error {
 	}
 
 	if !result.Valid() {
+		var errorMessages string
+
 		for _, desc := range result.Errors() {
+			errorMessages += fmt.Sprintf("- %s\n", desc)
 			fmt.Printf("- %s\n", desc)
 		}
-		return fmt.Errorf("output claims do not conform to the expected schema")
+		return fmt.Errorf("output claims do not conform to the expected schema: \n%s", errorMessages)
+
 	}
 
 	return nil

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -518,8 +518,7 @@ func (a *API) clearCookieToken(config *conf.GlobalConfiguration, name string, w 
 }
 
 func validateClaims(outputClaims map[string]interface{}) error {
-	schemaString := hooks.MinimumViableTokenSchema
-	schemaLoader := gojsonschema.NewStringLoader(schemaString)
+	schemaLoader := gojsonschema.NewStringLoader(hooks.MinimumViableTokenSchema)
 
 	documentLoader := gojsonschema.NewGoLoader(outputClaims)
 

--- a/internal/api/token_refresh.go
+++ b/internal/api/token_refresh.go
@@ -217,7 +217,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 				issuedToken = newToken
 			}
 
-			tokenString, expiresAt, terr = a.generateAccessToken(ctx, tx, user, issuedToken.SessionId)
+			tokenString, expiresAt, terr = a.generateAccessToken(ctx, tx, user, issuedToken.SessionId, models.TokenRefresh)
 			if terr != nil {
 				return internalServerError("error generating jwt token").WithInternalError(terr)
 			}

--- a/internal/api/token_refresh.go
+++ b/internal/api/token_refresh.go
@@ -217,7 +217,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 				issuedToken = newToken
 			}
 
-			tokenString, expiresAt, terr = generateAccessToken(tx, user, issuedToken.SessionId, &config.JWT)
+			tokenString, expiresAt, terr = a.generateAccessToken(ctx, tx, user, issuedToken.SessionId)
 			if terr != nil {
 				return internalServerError("error generating jwt token").WithInternalError(terr)
 			}

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -700,6 +700,7 @@ begin
     result := jsonb_build_object('claims', input->'claims');
     return result;
 end; $$ language plpgsql;`,
+			// Not used
 			expectedClaims: map[string]interface{}{
 				"user_metadata": nil,
 			},
@@ -730,12 +731,9 @@ end; $$ language plpgsql;`,
 				AccessToken string `json:"access_token"`
 			}
 			require.NoError(t, json.NewDecoder(w.Result().Body).Decode(&tokenResponse))
-
 			if c.shouldError {
-				require.Equal(t, w.Code, http.StatusInternalServerError)
+				require.Equal(t, http.StatusInternalServerError, w.Code)
 			} else {
-				require.NoError(t, err)
-
 				parts := strings.Split(tokenResponse.AccessToken, ".")
 				require.Equal(t, 3, len(parts), "Token should have 3 parts")
 
@@ -747,12 +745,9 @@ end; $$ language plpgsql;`,
 
 				for key, expectedValue := range c.expectedClaims {
 					if expectedValue == nil {
+						// Since c.shouldError is false here, we only need to check if the claim should be removed
 						_, exists := responseClaims[key]
-						if c.shouldError {
-							assert.True(t, exists, "Claim should not be removed")
-						} else {
-							assert.False(t, exists, "Claim should be removed")
-						}
+						assert.False(t, exists, "Claim should be removed")
 					} else {
 						assert.Equal(t, expectedValue, responseClaims[key])
 					}

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -47,7 +47,7 @@ func (ts *UserTestSuite) SetupTest() {
 }
 
 func (ts *UserTestSuite) generateToken(user *models.User, sessionId *uuid.UUID) string {
-	token, _, err := generateAccessToken(ts.API.db, user, sessionId, &ts.Config.JWT)
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionId)
 	require.NoError(ts.T(), err, "Error generating access token")
 	return token
 }

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -47,7 +47,7 @@ func (ts *UserTestSuite) SetupTest() {
 }
 
 func (ts *UserTestSuite) generateToken(user *models.User, sessionId *uuid.UUID) string {
-	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionId)
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionId, models.PasswordGrant)
 	require.NoError(ts.T(), err, "Error generating access token")
 	return token
 }

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -178,7 +179,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 
 		// Generate access token for request
 		var token string
-		token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+		token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
 		require.NoError(ts.T(), err)
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -179,7 +179,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 
 		// Generate access token for request
 		var token string
-		token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil)
+		token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.MagicLink)
 		require.NoError(ts.T(), err)
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -443,6 +443,7 @@ type WebhookConfig struct {
 type HookConfiguration struct {
 	MFAVerificationAttempt      ExtensibilityPointConfiguration `json:"mfa_verification_attempt" split_words:"true"`
 	PasswordVerificationAttempt ExtensibilityPointConfiguration `json:"password_verification_attempt" split_words:"true"`
+	CustomAccessToken           ExtensibilityPointConfiguration `json:"custom_access_token" split_words:"true"`
 }
 
 type ExtensibilityPointConfiguration struct {
@@ -455,6 +456,7 @@ func (h *HookConfiguration) Validate() error {
 	points := []ExtensibilityPointConfiguration{
 		h.MFAVerificationAttempt,
 		h.PasswordVerificationAttempt,
+		h.CustomAccessToken,
 	}
 	for _, point := range points {
 		if err := point.ValidateAndPopulateExtensibilityPoint(); err != nil {

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -10,6 +10,42 @@ const (
 	PostgresHook HookType = "pg-functions"
 )
 
+const AccessTokenSchema = `{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "Subject": {"type": "string"},
+        "Audience": {"type": "array", "items": {"type": "string"}},
+        "IssuedAt": {"type": "integer"},
+        "ExpiresAt": {"type": "integer"},
+        "Issuer": {"type": "string"},
+        "Email": {"type": "string", "format": "email"},
+        "Phone": {"type": "string"}, // Assuming phone is in string format
+        "AppMetaData": {"type": "object"}, // Assuming AppMetaData is a JSON object
+        "UserMetaData": {"type": "object"}, // Assuming UserMetaData is a JSON object
+        "Role": {"type": "string"},
+        "SessionId": {"type": "string"},
+        "AuthenticatorAssuranceLevel": {"type": "integer"},
+        "AuthenticationMethodReference": {"type": "array", "items": {"type": "string"}}
+    },
+    "required": [
+        "Subject",
+        "Audience",
+        "IssuedAt",
+        "ExpiresAt",
+        "Issuer",
+        "Email",
+        "Phone",
+        "AppMetaData",
+        "UserMetaData",
+        "Role",
+        "SessionId",
+        "AuthenticatorAssuranceLevel",
+        "AuthenticationMethodReference"
+    ],
+    "additionalProperties": true
+}`
+
 const (
 	// In Miliseconds
 	DefaultTimeout = 2000
@@ -74,7 +110,7 @@ func (p *PasswordVerificationAttemptOutput) Error() string {
 	return p.HookError.Message
 }
 
-func (ca *CustomAccessTokenInput) IsError() bool {
+func (ca *CustomAccessTokenOutput) IsError() bool {
 	return ca.HookError.Message != ""
 }
 

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -27,6 +27,65 @@ type HookOutput interface {
 	Error() string
 }
 
+// #nosec
+const MinimumViableTokenSchema = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "aud": {
+      "type": "string"
+    },
+    "exp": {
+      "type": "integer"
+    },
+    "jti": {
+      "type": "string"
+    },
+    "iat": {
+      "type": "integer"
+    },
+    "iss": {
+      "type": "string"
+    },
+    "nbf": {
+      "type": "integer"
+    },
+    "sub": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "phone": {
+      "type": "string"
+    },
+    "app_metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "user_metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "role": {
+      "type": "string"
+    },
+    "aal": {
+      "type": "string"
+    },
+    "amr": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "session_id": {
+      "type": "string"
+    }
+  },
+  "required": ["aud", "exp", "iat", "sub", "email", "phone", "role", "aal"]
+}`
+
 // GoTrueClaims is a struct thats used for JWT claims
 type GoTrueClaims struct {
 	jwt.StandardClaims

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -124,9 +124,9 @@ type PasswordVerificationAttemptOutput struct {
 }
 
 type CustomAccessTokenInput struct {
-	UserID uuid.UUID     `json:"user_id"`
-	Claims *GoTrueClaims `json:"claims"`
-	AuthenticationMethod string `json:"authentication_method"`
+	UserID               uuid.UUID     `json:"user_id"`
+	Claims               *GoTrueClaims `json:"claims"`
+	AuthenticationMethod string        `json:"authentication_method"`
 }
 
 type CustomAccessTokenOutput struct {

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -49,6 +49,15 @@ type PasswordVerificationAttemptOutput struct {
 	HookError        AuthHookError `json:"error"`
 }
 
+type CustomAccessTokenInput struct {
+	UserID      uuid.UUID `json:"user_id"`
+	AccessToken string    `json:"access_token"`
+}
+
+type CustomAccessTokenOutput struct {
+	HookError AuthHookError `json:"error,omitempty"`
+}
+
 func (mf *MFAVerificationAttemptOutput) IsError() bool {
 	return mf.HookError.Message != ""
 }
@@ -63,6 +72,14 @@ func (p *PasswordVerificationAttemptOutput) IsError() bool {
 
 func (p *PasswordVerificationAttemptOutput) Error() string {
 	return p.HookError.Message
+}
+
+func (ca *CustomAccessTokenInput) IsError() bool {
+	return ca.HookError.Message != ""
+}
+
+func (ca *CustomAccessTokenOutput) Error() string {
+	return ca.HookError.Message
 }
 
 type AuthHookError struct {

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -126,6 +126,7 @@ type PasswordVerificationAttemptOutput struct {
 type CustomAccessTokenInput struct {
 	UserID uuid.UUID     `json:"user_id"`
 	Claims *GoTrueClaims `json:"claims"`
+	AuthenticationMethod string `json:"authentication_method"`
 }
 
 type CustomAccessTokenOutput struct {

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -10,42 +10,6 @@ const (
 	PostgresHook HookType = "pg-functions"
 )
 
-const AccessTokenSchema = `{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "Subject": {"type": "string"},
-        "Audience": {"type": "array", "items": {"type": "string"}},
-        "IssuedAt": {"type": "integer"},
-        "ExpiresAt": {"type": "integer"},
-        "Issuer": {"type": "string"},
-        "Email": {"type": "string", "format": "email"},
-        "Phone": {"type": "string"}, // Assuming phone is in string format
-        "AppMetaData": {"type": "object"}, // Assuming AppMetaData is a JSON object
-        "UserMetaData": {"type": "object"}, // Assuming UserMetaData is a JSON object
-        "Role": {"type": "string"},
-        "SessionId": {"type": "string"},
-        "AuthenticatorAssuranceLevel": {"type": "integer"},
-        "AuthenticationMethodReference": {"type": "array", "items": {"type": "string"}}
-    },
-    "required": [
-        "Subject",
-        "Audience",
-        "IssuedAt",
-        "ExpiresAt",
-        "Issuer",
-        "Email",
-        "Phone",
-        "AppMetaData",
-        "UserMetaData",
-        "Role",
-        "SessionId",
-        "AuthenticatorAssuranceLevel",
-        "AuthenticationMethodReference"
-    ],
-    "additionalProperties": true
-}`
-
 const (
 	// In Miliseconds
 	DefaultTimeout = 2000

--- a/internal/hooks/auth_hooks.go
+++ b/internal/hooks/auth_hooks.go
@@ -2,6 +2,8 @@ package hooks
 
 import (
 	"github.com/gofrs/uuid"
+	"github.com/golang-jwt/jwt"
+	"github.com/supabase/gotrue/internal/models"
 )
 
 type HookType string
@@ -23,6 +25,19 @@ const (
 type HookOutput interface {
 	IsError() bool
 	Error() string
+}
+
+// GoTrueClaims is a struct thats used for JWT claims
+type GoTrueClaims struct {
+	jwt.StandardClaims
+	Email                         string                 `json:"email"`
+	Phone                         string                 `json:"phone"`
+	AppMetaData                   map[string]interface{} `json:"app_metadata"`
+	UserMetaData                  map[string]interface{} `json:"user_metadata"`
+	Role                          string                 `json:"role"`
+	AuthenticatorAssuranceLevel   string                 `json:"aal,omitempty"`
+	AuthenticationMethodReference []models.AMREntry      `json:"amr,omitempty"`
+	SessionId                     string                 `json:"session_id,omitempty"`
 }
 
 type MFAVerificationAttemptInput struct {
@@ -50,12 +65,13 @@ type PasswordVerificationAttemptOutput struct {
 }
 
 type CustomAccessTokenInput struct {
-	UserID      uuid.UUID `json:"user_id"`
-	AccessToken string    `json:"access_token"`
+	UserID uuid.UUID     `json:"user_id"`
+	Claims *GoTrueClaims `json:"claims"`
 }
 
 type CustomAccessTokenOutput struct {
-	HookError AuthHookError `json:"error,omitempty"`
+	Claims    map[string]interface{} `json:"claims"`
+	HookError AuthHookError          `json:"error,omitempty"`
 }
 
 func (mf *MFAVerificationAttemptOutput) IsError() bool {

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -70,7 +70,7 @@ func (authMethod AuthenticationMethod) String() string {
 	case EmailChange:
 		return "email_change"
 	case TokenRefresh:
-		return "refresh_token"
+		return "token_refresh"
 	}
 	return ""
 }

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -44,6 +44,7 @@ const (
 	MagicLink
 	EmailSignup
 	EmailChange
+	TokenRefresh
 )
 
 func (authMethod AuthenticationMethod) String() string {
@@ -68,6 +69,8 @@ func (authMethod AuthenticationMethod) String() string {
 		return "email/signup"
 	case EmailChange:
 		return "email_change"
+	case TokenRefresh:
+		return "refresh_token"
 	}
 	return ""
 }
@@ -97,6 +100,8 @@ func ParseAuthenticationMethod(authMethod string) (AuthenticationMethod, error) 
 		return EmailSignup, nil
 	case "email_change":
 		return EmailChange, nil
+	case "token_refresh":
+		return TokenRefresh, nil
 	}
 	return 0, fmt.Errorf("unsupported authentication method %q", authMethod)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow developers to customize access token by adding claims or altering metadata

Other affected changes:
 - `generateAccessToken` is moved to a method on `API` and now takes in a `context`. In tests we use a default `context.Background()` 
