### PR TITLE
refactor: reduce amount of test setup code in mfa tests

### DIFF
--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -156,9 +156,7 @@ func (ts *MFATestSuite) TestEnrollFactor() {
 }
 
 func (ts *MFATestSuite) TestChallengeFactor() {
-	factors, err := models.FindFactorsByUser(ts.API.db, ts.TestUser)
-	require.NoError(ts.T(), err)
-	f := factors[0]
+	f := ts.TestUser.Factors[0]
 
 	token, _, err := generateAccessToken(ts.API.db, ts.TestUser, nil, &ts.Config.JWT)
 	require.NoError(ts.T(), err, "Error generating access token")

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -328,10 +328,8 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 
 func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 	var secondarySession *models.Session
-	factors, err := models.FindFactorsByUser(ts.API.db, ts.TestUser)
-	require.NoError(ts.T(), err, "error finding factors")
-	f := factors[0]
-	secondarySession, err = models.NewSession()
+	f := ts.TestUser.Factors[0]
+	secondarySession, err := models.NewSession()
 	require.NoError(ts.T(), err, "Error creating test session")
 	secondarySession.UserID = ts.TestUser.ID
 	secondarySession.FactorID = &f.ID

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -305,8 +305,7 @@ func (ts *MFATestSuite) TestUnenrollVerifiedFactor() {
 
 			var buffer bytes.Buffer
 
-			token, _, err := generateAccessToken(ts.API.db, ts.TestUser, &ts.TestSession.ID, &ts.Config.JWT)
-			require.NoError(ts.T(), err)
+			token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/factors/%s/", f.ID), &buffer)
@@ -341,7 +340,7 @@ func (ts *MFATestSuite) TestUnenrollUnverifiedFactor() {
 
 	var buffer bytes.Buffer
 
-	token, _, err := generateAccessToken(ts.API.db, ts.TestUser, &ts.TestSession.ID, &ts.Config.JWT)
+	token := ts.generateToken(ts.TestUser, &ts.TestSession.ID)
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(map[string]interface{}{
 		"factor_id": f.ID,

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -87,7 +87,7 @@ func (ts *MFATestSuite) SetupTest() {
 }
 
 func (ts *MFATestSuite) generateToken(user *models.User, sessionId *uuid.UUID) string {
-	token, _, err := generateAccessToken(ts.API.db, ts.TestUser, sessionId, &ts.Config.JWT)
+	token, _, err := generateAccessToken(ts.API.db, user, sessionId, &ts.Config.JWT)
 	require.NoError(ts.T(), err, "Error generating access token")
 	return token
 }

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -46,11 +46,16 @@ func (ts *UserTestSuite) SetupTest() {
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 }
 
+func (ts *UserTestSuite) generateToken(user *models.User, sessionId *uuid.UUID) string {
+	token, _, err := generateAccessToken(ts.API.db, user, sessionId, &ts.Config.JWT)
+	require.NoError(ts.T(), err, "Error generating access token")
+	return token
+}
+
 func (ts *UserTestSuite) TestUserGet() {
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err, "Error finding user")
-	var token string
-	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token := ts.generateToken(u, nil)
 
 	require.NoError(ts.T(), err, "Error generating access token")
 
@@ -115,8 +120,7 @@ func (ts *UserTestSuite) TestUserUpdateEmail() {
 			require.NoError(ts.T(), u.SetPhone(ts.API.db, c.userData["phone"]), "Error setting user phone")
 			require.NoError(ts.T(), ts.API.db.Create(u), "Error saving test user")
 
-			var token string
-			token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+			token := ts.generateToken(u, nil)
 
 			require.NoError(ts.T(), err, "Error generating access token")
 
@@ -179,8 +183,7 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
-			var token string
-			token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+			token := ts.generateToken(u, nil)
 			require.NoError(ts.T(), err, "Error generating access token")
 
 			var buffer bytes.Buffer
@@ -291,11 +294,8 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 
 			req := httptest.NewRequest(http.MethodPut, "http://localhost/user", &buffer)
 			req.Header.Set("Content-Type", "application/json")
+			token := ts.generateToken(u, c.sessionId)
 
-			var token string
-
-			token, _, err = generateAccessToken(ts.API.db, u, c.sessionId, &ts.Config.JWT)
-			require.NoError(ts.T(), err)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
 			// Setup response recorder
@@ -323,9 +323,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	u.EmailConfirmedAt = &now
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
-	var token string
-	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
-	require.NoError(ts.T(), err)
+	token := ts.generateToken(u, nil)
 
 	// request for reauthentication nonce
 	req := httptest.NewRequest(http.MethodGet, "http://localhost/reauthenticate", nil)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Primary goal of this refactor is to reduce number of calls to `generateAccessToken` to ease refactoring of `generateAccessToken`. This PR centralizes a few commonly used functions/objects:

- `generateAccessToken`
- `models.User`
- It also directly accesses `models.Factors` on `ts.TestUser` instead of fetching it from the DB via `models.FindFactorsByUserID`

Tests with multiple cases were left untouched as they have interleaving interactions in some cases  