### PR TITLE
refactor: centralize generateAccessToken for user tests

### DIFF
--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -46,11 +46,16 @@ func (ts *UserTestSuite) SetupTest() {
 	require.NoError(ts.T(), ts.API.db.Create(u), "Error saving new test user")
 }
 
+func (ts *UserTestSuite) generateToken(user *models.User, sessionId *uuid.UUID) string {
+	token, _, err := generateAccessToken(ts.API.db, user, sessionId, &ts.Config.JWT)
+	require.NoError(ts.T(), err, "Error generating access token")
+	return token
+}
+
 func (ts *UserTestSuite) TestUserGet() {
 	u, err := models.FindUserByEmailAndAudience(ts.API.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err, "Error finding user")
-	var token string
-	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+	token := ts.generateToken(u, nil)
 
 	require.NoError(ts.T(), err, "Error generating access token")
 
@@ -115,8 +120,7 @@ func (ts *UserTestSuite) TestUserUpdateEmail() {
 			require.NoError(ts.T(), u.SetPhone(ts.API.db, c.userData["phone"]), "Error setting user phone")
 			require.NoError(ts.T(), ts.API.db.Create(u), "Error saving test user")
 
-			var token string
-			token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+			token := ts.generateToken(u, nil)
 
 			require.NoError(ts.T(), err, "Error generating access token")
 
@@ -179,8 +183,7 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 
 	for _, c := range cases {
 		ts.Run(c.desc, func() {
-			var token string
-			token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
+			token := ts.generateToken(u, nil)
 			require.NoError(ts.T(), err, "Error generating access token")
 
 			var buffer bytes.Buffer
@@ -291,11 +294,8 @@ func (ts *UserTestSuite) TestUserUpdatePassword() {
 
 			req := httptest.NewRequest(http.MethodPut, "http://localhost/user", &buffer)
 			req.Header.Set("Content-Type", "application/json")
+			token := ts.generateToken(u, c.sessionId)
 
-			var token string
-
-			token, _, err = generateAccessToken(ts.API.db, u, c.sessionId, &ts.Config.JWT)
-			require.NoError(ts.T(), err)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
 			// Setup response recorder
@@ -323,9 +323,7 @@ func (ts *UserTestSuite) TestUserUpdatePasswordReauthentication() {
 	u.EmailConfirmedAt = &now
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
-	var token string
-	token, _, err = generateAccessToken(ts.API.db, u, nil, &ts.Config.JWT)
-	require.NoError(ts.T(), err)
+	token := ts.generateToken(u, nil)
 
 	// request for reauthentication nonce
 	req := httptest.NewRequest(http.MethodGet, "http://localhost/reauthenticate", nil)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Similar to #1333 we centralize the setup around `generateAccessToken`
