### PR TITLE
feat: use `DO` blocks around SQL statements in migrations

### DIFF
--- a/migrations/20221125140132_backfill_email_identity.up.sql
+++ b/migrations/20221125140132_backfill_email_identity.up.sql
@@ -1,7 +1,11 @@
 -- backfill the auth.identities column by adding an email identity 
 -- for all auth.users with an email and password 
 
-insert into {{ index .Options "Namespace" }}.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
-select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2022-11-25' as created_at, '2022-11-25' as updated_at
-from {{ index .Options "Namespace" }}.users as users
-where encrypted_password != '' and email is not null and not exists(select user_id from {{ index .Options "Namespace" }}.identities where user_id = users.id);
+do $$
+begin
+	insert into {{ index .Options "Namespace" }}.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
+	select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2022-11-25' as created_at, '2022-11-25' as updated_at
+	from {{ index .Options "Namespace" }}.users as users
+	where encrypted_password != '' and email is not null and not exists(select user_id from {{ index .Options "Namespace" }}.identities where user_id = users.id);
+end;
+$$;

--- a/migrations/20221208132122_backfill_email_last_sign_in_at.up.sql
+++ b/migrations/20221208132122_backfill_email_last_sign_in_at.up.sql
@@ -1,5 +1,7 @@
 -- previous backfill migration left last_sign_in_at to be null, which broke some projects
 
+do $$
+begin
 update {{ index .Options "Namespace" }}.identities
   set last_sign_in_at = '2022-11-25'
   where
@@ -8,3 +10,4 @@ update {{ index .Options "Namespace" }}.identities
     updated_at = '2022-11-25' and
     provider = 'email' and
     id = user_id::text;
+end $$;

--- a/migrations/20221215195800_add_identities_email_column.up.sql
+++ b/migrations/20221215195800_add_identities_email_column.up.sql
@@ -1,9 +1,12 @@
-update
-  {{ index .Options "Namespace" }}.identities as identities
-set
-  identity_data = identity_data || jsonb_build_object('email', (select email from {{ index .Options "Namespace" }}.users where id = identities.user_id)),
-  updated_at = '2022-11-25'
-where identities.provider = 'email' and identity_data->>'email' is null;
+do $$
+begin
+  update
+    {{ index .Options "Namespace" }}.identities as identities
+  set
+    identity_data = identity_data || jsonb_build_object('email', (select email from {{ index .Options "Namespace" }}.users where id = identities.user_id)),
+    updated_at = '2022-11-25'
+  where identities.provider = 'email' and identity_data->>'email' is null;
+end $$;
 
 alter table only {{ index .Options "Namespace" }}.identities
   add column if not exists email text generated always as (lower(identity_data->>'email')) stored;

--- a/migrations/20230131181311_backfill_invite_identities.up.sql
+++ b/migrations/20230131181311_backfill_invite_identities.up.sql
@@ -1,6 +1,9 @@
 -- backfills the missing email identity for invited users
 
-insert into {{ index .Options "Namespace" }}.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
-select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2023-01-25' as created_at, '2023-01-25' as updated_at
-from {{ index .Options "Namespace" }}.users as users
-where invited_at is not null and not exists (select user_id from {{ index .Options "Namespace" }}.identities where user_id = users.id and provider = 'email');
+do $$
+begin
+	insert into {{ index .Options "Namespace" }}.identities (id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
+	select id, id as user_id, jsonb_build_object('sub', id, 'email', email) as identity_data, 'email' as provider, null as last_sign_in_at, '2023-01-25' as created_at, '2023-01-25' as updated_at
+	from {{ index .Options "Namespace" }}.users as users
+	where invited_at is not null and not exists (select user_id from {{ index .Options "Namespace" }}.identities where user_id = users.id and provider = 'email');
+end $$;


### PR DESCRIPTION
Migrations that contain `SELECT`, `INSERT`, `UPDATE`, `DELETE` that are not already wrapped in a `DO` block, are wrapped. This is because anything that executes in a `DO` block _does not get counted as activity_ on the database.