### PR TITLE
fix: check linking domain prefix

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -307,7 +307,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 		}
 
 		isSSOUser := false
-		if decision.LinkingDomain == "sso" {
+		if strings.HasPrefix(decision.LinkingDomain, "sso:") {
 			isSSOUser = true
 		}
 

--- a/internal/models/linking_test.go
+++ b/internal/models/linking_test.go
@@ -72,7 +72,8 @@ func (ts *AccountLinkingTestSuite) TestCreateAccountDecisionWithAccounts() {
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), ts.db.Create(userB))
 
-	identityB, err := NewIdentity(userB, "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387", map[string]interface{}{
+	ssoProvider := "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387"
+	identityB, err := NewIdentity(userB, ssoProvider, map[string]interface{}{
 		"sub":   userB.ID.String(),
 		"email": "test@samltest.id",
 	})
@@ -90,6 +91,7 @@ func (ts *AccountLinkingTestSuite) TestCreateAccountDecisionWithAccounts() {
 	require.NoError(ts.T(), err)
 
 	require.Equal(ts.T(), decision.Decision, CreateAccount)
+	require.Equal(ts.T(), decision.LinkingDomain, "default")
 
 	// when looking for an email that doesn't exist in the SSO linking domain
 	decision, err = DetermineAccountLinking(ts.db, ts.config, []provider.Email{
@@ -98,10 +100,11 @@ func (ts *AccountLinkingTestSuite) TestCreateAccountDecisionWithAccounts() {
 			Verified: true,
 			Primary:  true,
 		},
-	}, ts.config.JWT.Aud, "sso:f06f9e3d-ff92-4c47-a179-7acf1fda6387", "abcdefgh")
+	}, ts.config.JWT.Aud, ssoProvider, "abcdefgh")
 	require.NoError(ts.T(), err)
 
 	require.Equal(ts.T(), decision.Decision, CreateAccount)
+	require.Equal(ts.T(), decision.LinkingDomain, ssoProvider)
 }
 
 func (ts *AccountLinkingTestSuite) TestAccountExists() {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Should be checking the prefix of the linking domain instead of matching against the whole string
