### PR TITLE
feat: split validation and population of hook name

### DIFF
--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -623,7 +623,7 @@ func (ts *MFATestSuite) TestVerificationHooks() {
 		ts.T().Run(c.desc, func(t *testing.T) {
 			ts.Config.Hook.MFAVerificationAttempt.Enabled = c.enabled
 			ts.Config.Hook.MFAVerificationAttempt.URI = c.uri
-			require.NoError(ts.T(), ts.Config.Hook.MFAVerificationAttempt.ValidateAndPopulateExtensibilityPoint())
+			require.NoError(ts.T(), ts.Config.Hook.MFAVerificationAttempt.PopulateExtensibilityPoint())
 
 			err := ts.API.db.RawQuery(c.hookFunctionSQL).Exec()
 			require.NoError(t, err)

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -40,9 +40,9 @@ type Settings struct {
 }
 
 type HookSettings struct {
-	MFAVerificationAttempt      bool `json:"mfa_verification_attempt_enabled"`
-	PasswordVerificationAttempt bool `json:"password_verification_attempt_enabled"`
-	CustomAccessToken           bool `json:"custom_access_token_enabled"`
+	MFAVerificationAttempt      bool `json:"mfa_verification_attempt"`
+	PasswordVerificationAttempt bool `json:"password_verification_attempt"`
+	CustomAccessToken           bool `json:"custom_access_token"`
 }
 
 func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -36,13 +36,6 @@ type Settings struct {
 	SmsProvider       string           `json:"sms_provider"`
 	MFAEnabled        bool             `json:"mfa_enabled"`
 	SAMLEnabled       bool             `json:"saml_enabled"`
-	HookConfiguration HookSettings     `json:"hook"`
-}
-
-type HookSettings struct {
-	MFAVerificationAttempt      bool `json:"mfa_verification_attempt"`
-	PasswordVerificationAttempt bool `json:"password_verification_attempt"`
-	CustomAccessToken           bool `json:"custom_access_token"`
 }
 
 func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
@@ -74,12 +67,6 @@ func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
 			Phone:        config.External.Phone.Enabled,
 			Zoom:         config.External.Zoom.Enabled,
 		},
-		HookConfiguration: HookSettings{
-			MFAVerificationAttempt:      config.Hook.MFAVerificationAttempt.Enabled,
-			PasswordVerificationAttempt: config.Hook.PasswordVerificationAttempt.Enabled,
-			CustomAccessToken:           config.Hook.CustomAccessToken.Enabled,
-		},
-
 		DisableSignup:     config.DisableSignup,
 		MailerAutoconfirm: config.Mailer.Autoconfirm,
 		PhoneAutoconfirm:  config.Sms.Autoconfirm,

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -40,7 +40,9 @@ type Settings struct {
 }
 
 type HookSettings struct {
-	MFAVerification bool `json:"mfa"`
+	MFAVerificationAttempt      bool `json:"mfa_verification_attempt_enabled"`
+	PasswordVerificationAttempt bool `json:"password_verification_attempt_enabled"`
+	CustomAccessToken           bool `json:"custom_access_token_enabled"`
 }
 
 func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
@@ -73,7 +75,9 @@ func (a *API) Settings(w http.ResponseWriter, r *http.Request) error {
 			Zoom:         config.External.Zoom.Enabled,
 		},
 		HookConfiguration: HookSettings{
-			MFAVerification: config.Hook.MFAVerificationAttempt.Enabled,
+			MFAVerificationAttempt:      config.Hook.MFAVerificationAttempt.Enabled,
+			PasswordVerificationAttempt: config.Hook.PasswordVerificationAttempt.Enabled,
+			CustomAccessToken:           config.Hook.CustomAccessToken.Enabled,
 		},
 
 		DisableSignup:     config.DisableSignup,

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -44,6 +44,7 @@ func TestSettings_DefaultProviders(t *testing.T) {
 	require.True(t, p.Twitch)
 	require.True(t, p.WorkOS)
 	require.True(t, p.Zoom)
+
 }
 
 func TestSettings_EmailDisabled(t *testing.T) {
@@ -67,4 +68,24 @@ func TestSettings_EmailDisabled(t *testing.T) {
 
 	p := resp.ExternalProviders
 	require.False(t, p.Email)
+}
+
+func TestSettings_HooksDisabled(t *testing.T) {
+	api, _, err := setupAPIForTest()
+	require.NoError(t, err)
+
+	// Setup request
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/settings", nil)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	api.handler.ServeHTTP(w, req)
+	require.Equal(t, w.Code, http.StatusOK)
+	resp := Settings{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	p := resp.HookConfiguration
+	require.False(t, p.MFAVerificationAttempt)
+	require.False(t, p.PasswordVerificationAttempt)
+	require.False(t, p.CustomAccessToken)
 }

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -69,23 +69,3 @@ func TestSettings_EmailDisabled(t *testing.T) {
 	p := resp.ExternalProviders
 	require.False(t, p.Email)
 }
-
-func TestSettings_HooksDisabled(t *testing.T) {
-	api, _, err := setupAPIForTest()
-	require.NoError(t, err)
-
-	// Setup request
-	req := httptest.NewRequest(http.MethodGet, "http://localhost/settings", nil)
-	req.Header.Set("Content-Type", "application/json")
-
-	w := httptest.NewRecorder()
-	api.handler.ServeHTTP(w, req)
-	require.Equal(t, w.Code, http.StatusOK)
-	resp := Settings{}
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-
-	p := resp.HookConfiguration
-	require.False(t, p.MFAVerificationAttempt)
-	require.False(t, p.PasswordVerificationAttempt)
-	require.False(t, p.CustomAccessToken)
-}

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -626,7 +626,7 @@ func (ts *TokenTestSuite) TestPasswordVerificationHook() {
 		ts.T().Run(c.desc, func(t *testing.T) {
 			ts.Config.Hook.PasswordVerificationAttempt.Enabled = true
 			ts.Config.Hook.PasswordVerificationAttempt.URI = c.uri
-			require.NoError(ts.T(), ts.Config.Hook.PasswordVerificationAttempt.ValidateAndPopulateExtensibilityPoint())
+			require.NoError(ts.T(), ts.Config.Hook.PasswordVerificationAttempt.PopulateExtensibilityPoint())
 
 			err := ts.API.db.RawQuery(c.hookFunctionSQL).Exec()
 			require.NoError(t, err)
@@ -711,7 +711,7 @@ end; $$ language plpgsql;`,
 		ts.T().Run(c.desc, func(t *testing.T) {
 			ts.Config.Hook.CustomAccessToken.Enabled = true
 			ts.Config.Hook.CustomAccessToken.URI = c.uri
-			require.NoError(t, ts.Config.Hook.CustomAccessToken.ValidateAndPopulateExtensibilityPoint())
+			require.NoError(t, ts.Config.Hook.CustomAccessToken.PopulateExtensibilityPoint())
 
 			err := ts.API.db.RawQuery(c.hookFunctionSQL).Exec()
 			require.NoError(t, err)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -476,6 +476,9 @@ func (e *ExtensibilityPointConfiguration) ValidateAndPopulateExtensibilityPoint(
 		if len(pathParts) < 3 {
 			return fmt.Errorf("URI path does not contain enough parts")
 		}
+		if u.Scheme != "pg-functions" {
+			return fmt.Errorf("only postgres hooks are supported at the moment")
+		}
 		schema := pathParts[1]
 		table := pathParts[2]
 		// Validate schema and table names

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -98,32 +98,30 @@ func TestPasswordRequiredCharactersDecode(t *testing.T) {
 	}
 }
 
-func TestValidateAndPopulateExtensibilityPoint(t *testing.T) {
+func TestValidateExtensibilityPoint(t *testing.T) {
 	cases := []struct {
-		desc           string
-		uri            string
-		expectedResult string
+		desc        string
+		uri         string
+		expectError bool
 	}{
 		// Positive test cases
-		{desc: "Valid URI", uri: "pg-functions://postgres/auth/verification_hook_reject", expectedResult: `"auth"."verification_hook_reject"`},
-		{desc: "Another Valid URI", uri: "pg-functions://postgres/user_management/add_user", expectedResult: `"user_management"."add_user"`},
-		{desc: "Another Valid URI", uri: "pg-functions://postgres/MySpeCial/FUNCTION_THAT_YELLS_AT_YOU", expectedResult: `"MySpeCial"."FUNCTION_THAT_YELLS_AT_YOU"`},
+		{desc: "Valid URI", uri: "pg-functions://postgres/auth/verification_hook_reject", expectError: false},
+		{desc: "Another Valid URI", uri: "pg-functions://postgres/user_management/add_user", expectError: false},
+		{desc: "Another Valid URI", uri: "pg-functions://postgres/MySpeCial/FUNCTION_THAT_YELLS_AT_YOU", expectError: false},
 
 		// Negative test cases
-		{desc: "Invalid Schema Name", uri: "pg-functions://postgres/123auth/verification_hook_reject", expectedResult: ""},
-		{desc: "Invalid Function Name", uri: "pg-functions://postgres/auth/123verification_hook_reject", expectedResult: ""},
-		{desc: "Insufficient Path Parts", uri: "pg-functions://postgres/auth", expectedResult: ""},
+		{desc: "Invalid Schema Name", uri: "pg-functions://postgres/123auth/verification_hook_reject", expectError: true},
+		{desc: "Invalid Function Name", uri: "pg-functions://postgres/auth/123verification_hook_reject", expectError: true},
+		{desc: "Insufficient Path Parts", uri: "pg-functions://postgres/auth", expectError: true},
 	}
 
 	for _, tc := range cases {
 		ep := ExtensibilityPointConfiguration{URI: tc.uri}
-		err := ep.ValidateAndPopulateExtensibilityPoint()
-		if tc.expectedResult != "" {
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedResult, ep.HookName)
-		} else {
+		err := ep.ValidateExtensibilityPoint()
+		if tc.expectError {
 			require.Error(t, err)
-			require.Empty(t, ep.HookName)
+		} else {
+			require.NoError(t, err)
 		}
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the HookName is not properly populated which leads to improper invocation of the function. The `HookName` was not set on the global config but was set locally on hook config.

To fix this we split out `Validation` and `Population` into 2 separate steps and populate the `HookName` in `LoadGlobal`
