### PR TITLE
fix: show proper error message on textlocal

### DIFF
--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	defaultTextLocalApiBase = "https://api.textlocal.in"
+	defaultTextLocalApiBase    = "https://api.textlocal.in"
+	textLocalTemplateErrorCode = 80
 )
 
 type TextlocalProvider struct {
@@ -90,6 +91,10 @@ func (t *TextlocalProvider) SendSms(phone string, message string) (string, error
 	if resp.Status != "success" {
 		if len(resp.Messages) > 0 {
 			messageID = resp.Messages[0].MessageID
+		}
+
+		if resp.Errors[0].Code == textLocalTemplateErrorCode {
+			return messageID, fmt.Errorf("textlocal error: %v (code: %v) template message: %s", resp.Errors[0].Message, resp.Errors[0].Code, message)
 		}
 
 		return messageID, fmt.Errorf("textlocal error: %v (code: %v) message %s", resp.Errors[0].Message, resp.Errors[0].Code, messageID)

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -93,7 +93,7 @@ func (t *TextlocalProvider) SendSms(phone string, message string) (string, error
 			messageID = resp.Messages[0].MessageID
 		}
 
-		if resp.Errors[0].Code == textLocalTemplateErrorCode {
+		if len(resp.Errors) > 0 && resp.Errors[0].Code == textLocalTemplateErrorCode {
 			return messageID, fmt.Errorf("textlocal error: %v (code: %v) template message: %s", resp.Errors[0].Message, resp.Errors[0].Code, message)
 		}
 

--- a/internal/api/sms_provider/textlocal.go
+++ b/internal/api/sms_provider/textlocal.go
@@ -2,7 +2,6 @@ package sms_provider
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -84,10 +83,6 @@ func (t *TextlocalProvider) SendSms(phone string, message string) (string, error
 	derr := json.NewDecoder(res.Body).Decode(resp)
 	if derr != nil {
 		return "", derr
-	}
-
-	if len(resp.Errors) > 0 {
-		return "", errors.New("textlocal error: Internal Error")
 	}
 
 	messageID := ""


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Improvement to error message when there is error when sending OTP using textlocal sms provider
- Log message if error is caused by template

## What is the current behavior?

shows generate internal server error message

## What is the new behavior?

shows error from the api

## Additional context
This will make debugging easier, currently there is no way to find out why the api is failing


