### PR TITLE
fix: add error handling for hook

### DIFF
--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -387,6 +387,11 @@ func (a *API) issueRefreshToken(ctx context.Context, conn *storage.Connection, u
 
 		tokenString, expiresAt, terr = a.generateAccessToken(ctx, tx, user, refreshToken.SessionId, authenticationMethod)
 		if terr != nil {
+			// Account for Hook Error
+			httpErr, ok := terr.(*HTTPError)
+			if ok {
+				return httpErr
+			}
 			return internalServerError("error generating jwt token").WithInternalError(terr)
 		}
 		return nil

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -850,7 +850,7 @@ $$;`
 			}
 
 			// Delete the function and cleanup
-			cleanupHookSQL := fmt.Sprintf("drop function if exists auth.custom_access_token")
+			cleanupHookSQL := fmt.Sprintf("drop function if exists %s", ts.Config.Hook.CustomAccessToken.HookName)
 			require.NoError(t, ts.API.db.RawQuery(cleanupHookSQL).Exec())
 			ts.Config.Hook.CustomAccessToken.Enabled = false
 		})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Properly bubble up the error from the HTTP hook during hte custom access token hook