### PR TITLE
ci: include `gotrue` symlink to `auth` in release archives, docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,10 @@ jobs:
 
       - run: make deps
       - run: make all
-      - run: tar -czvf auth-v${{ needs.release.outputs.version }}-x86.tar.gz auth migrations/
+      - run: ln -s auth gotrue
+      - run: tar -czvf auth-v${{ needs.release.outputs.version }}-x86.tar.gz auth gotrue migrations/
       - run: mv auth-arm64 auth
-      - run: tar -czvf auth-v${{ needs.release.outputs.version }}-arm64.tar.gz auth migrations/
+      - run: tar -czvf auth-v${{ needs.release.outputs.version }}-arm64.tar.gz auth gotrue migrations/
 
       - uses: AButler/upload-release-assets@v2.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN adduser -D -u 1000 supabase
 RUN apk add --no-cache ca-certificates
 COPY --from=build /go/src/github.com/supabase/auth/auth /usr/local/bin/auth
 COPY --from=build /go/src/github.com/supabase/auth/migrations /usr/local/etc/auth/migrations/
+RUN ln -s /usr/local/bin/auth /usr/local/bin/gotrue
 
 ENV GOTRUE_DB_MIGRATIONS_PATH /usr/local/etc/auth/migrations
 


### PR DESCRIPTION
Realized that too many things depend on the executable being called `gotrue` so it will be a symlink to `auth` instead.