### PR TITLE
feat: add weak password check on sign in

### DIFF
--- a/internal/api/password.go
+++ b/internal/api/password.go
@@ -13,8 +13,8 @@ import (
 // a HTTPError with a special weak_password field that encodes the Reasons
 // slice.
 type WeakPasswordError struct {
-	Message string
-	Reasons []string
+	Message string   `json:"message,omitempty"`
+	Reasons []string `json:"reasons,omitempty"`
 }
 
 func (e *WeakPasswordError) Error() string {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1759,6 +1759,19 @@ components:
           type: string
           description: >
             A basic message describing the problem with the request. Usually missing if `error` is present.
+        weak_password:
+          type: object
+          description: >
+            Only returned on the `/signup` endpoint if the password used is too weak. Inspect the `reasons` and `msg` property to identify the causes.
+          properties:
+            reasons:
+              type: array
+              items:
+                type: string
+                enum:
+                  - length
+                  - characters
+                  - pwned
 
     UserSchema:
       type: object
@@ -1903,6 +1916,20 @@ components:
         expires_at:
           type: integer
           description: UNIX timestamp after which the `access_token` should be renewed by using the refresh token with the `refresh_token` grant type.
+        weak_password:
+          type: object
+          description: Only returned on the `/token?grant_type=password` endpoint. When present, it indicates that the password used is weak. Inspect the `reasons` and/or `message` properties to identify why.
+          properties:
+            reasons:
+              type: array
+              items:
+                type: string
+                enum:
+                  - length
+                  - characters
+                  - pwned
+            message:
+              type: string
         user:
           $ref: "#/components/schemas/UserSchema"
 


### PR DESCRIPTION
Adds the weak password check on sign in, after successfully verifying the password. Returns it as `weak_password` on the access token response.