### PR TITLE
fix: handle oauth email check separately

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -187,7 +187,22 @@ func (a *API) internalExternalProviderCallback(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return err
 	}
+
 	userData := data.userData
+	if len(userData.Emails) <= 0 {
+		return internalServerError("Error getting user email from external provider")
+	}
+	userData.Metadata.EmailVerified = false
+	for _, email := range userData.Emails {
+		if email.Primary {
+			userData.Metadata.Email = email.Email
+			userData.Metadata.EmailVerified = email.Verified
+			break
+		} else {
+			userData.Metadata.Email = email.Email
+			userData.Metadata.EmailVerified = email.Verified
+		}
+	}
 	providerAccessToken := data.token
 	providerRefreshToken := data.refreshToken
 

--- a/internal/api/external_google_test.go
+++ b/internal/api/external_google_test.go
@@ -15,7 +15,7 @@ import (
 const (
 	googleUser           string = `{"id":"googleTestId","name":"Google Test","picture":"http://example.com/avatar","email":"google@example.com","verified_email":true}}`
 	googleUserWrongEmail string = `{"id":"googleTestId","name":"Google Test","picture":"http://example.com/avatar","email":"other@example.com","verified_email":true}}`
-	googleUserNoEmail    string = `{"id":"googleTestId","name":"Google Test","picture":"http://example.com/avatar","verified_email":true}}`
+	googleUserNoEmail    string = `{"id":"googleTestId","name":"Google Test","picture":"http://example.com/avatar","verified_email":false}}`
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalGoogle() {

--- a/internal/api/external_kakao_test.go
+++ b/internal/api/external_kakao_test.go
@@ -63,25 +63,33 @@ func KakaoTestSignupSetup(ts *ExternalTestSuite, tokenCount *int, userCount *int
 				}
 			}
 
-			if email == nil {
-				w.WriteHeader(400)
-				return
-			}
-
 			w.Header().Add("Content-Type", "application/json")
-			fmt.Fprintf(w, `
-				{
-					"id":123, 
-					"kakao_account": {
-						"profile": {
-							"nickname":"Kakao Test",
-							"profile_image_url":"http://example.com/avatar"
-						},
-						"email": "%v",
-						"is_email_valid": %v,
-						"is_email_verified": %v
-					}
-				}`, email.Email, email.Verified, email.Verified)
+			if email != nil {
+				fmt.Fprintf(w, `
+					{
+						"id":123, 
+						"kakao_account": {
+							"profile": {
+								"nickname":"Kakao Test",
+								"profile_image_url":"http://example.com/avatar"
+							},
+							"email": "%v",
+							"is_email_valid": %v,
+							"is_email_verified": %v
+						}
+					}`, email.Email, email.Verified, email.Verified)
+			} else {
+				fmt.Fprint(w, `
+					{
+						"id":123, 
+						"kakao_account": {
+							"profile": {
+								"nickname":"Kakao Test",
+								"profile_image_url":"http://example.com/avatar"
+							}
+						}
+					}`)
+			}
 		default:
 			w.WriteHeader(500)
 			ts.Fail("unknown kakao oauth call %s", r.URL.Path)

--- a/internal/api/external_notion_test.go
+++ b/internal/api/external_notion_test.go
@@ -12,7 +12,7 @@ import (
 const (
 	notionUser           string = `{"bot":{"owner":{"user":{"id":"notionTestId","name":"Notion Test","avatar_url":"http://example.com/avatar","person":{"email":"notion@example.com"},"verified_email":true}}}}`
 	notionUserWrongEmail string = `{"bot":{"owner":{"user":{"id":"notionTestId","name":"Notion Test","avatar_url":"http://example.com/avatar","person":{"email":"other@example.com"},"verified_email":true}}}}`
-	notionUserNoEmail    string = `{"bot":{"owner":{"user":{"id":"notionTestId","name":"Notion Test","avatar_url":"http://example.com/avatar","verified_email":true}}}}}`
+	notionUserNoEmail    string = `{"bot":{"owner":{"user":{"id":"notionTestId","name":"Notion Test","avatar_url":"http://example.com/avatar","verified_email":true}}}}`
 )
 
 func (ts *ExternalTestSuite) TestSignupExternalNotion() {

--- a/internal/api/external_oauth.go
+++ b/internal/api/external_oauth.go
@@ -82,7 +82,7 @@ func (a *API) oAuthCallback(ctx context.Context, r *http.Request, providerType s
 
 	userData, err := oAuthProvider.GetUserData(ctx, token)
 	if err != nil {
-		return nil, internalServerError("Error getting user email from external provider").WithInternalError(err)
+		return nil, internalServerError("Error getting user profile from external provider").WithInternalError(err)
 	}
 
 	switch externalProvider := oAuthProvider.(type) {

--- a/internal/api/provider/bitbucket.go
+++ b/internal/api/provider/bitbucket.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 
 	"github.com/supabase/auth/internal/conf"
 	"golang.org/x/oauth2"
@@ -87,10 +86,6 @@ func (g bitbucketProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (
 				})
 			}
 		}
-	}
-
-	if len(data.Emails) <= 0 {
-		return nil, errors.New("unable to find email with Bitbucket provider")
 	}
 
 	data.Metadata = &Claims{

--- a/internal/api/provider/figma.go
+++ b/internal/api/provider/figma.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/supabase/auth/internal/conf"
@@ -72,27 +71,26 @@ func (p figmaProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 		return nil, err
 	}
 
-	if u.Email == "" {
-		return nil, errors.New("unable to find email with Figma provider")
-	}
-
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        p.APIHost,
-			Subject:       u.ID,
-			Name:          u.Name,
-			Email:         u.Email,
-			EmailVerified: true,
-
-			// To be deprecated
-			AvatarURL:  u.AvatarURL,
-			FullName:   u.Name,
-			ProviderId: u.ID,
-		},
-		Emails: []Email{{
+	data := &UserProvidedData{}
+	if u.Email != "" {
+		data.Emails = []Email{{
 			Email:    u.Email,
 			Verified: true,
 			Primary:  true,
-		}},
-	}, nil
+		}}
+	}
+
+	data.Metadata = &Claims{
+		Issuer:        p.APIHost,
+		Subject:       u.ID,
+		Name:          u.Name,
+		Email:         u.Email,
+		EmailVerified: true,
+
+		// To be deprecated
+		AvatarURL:  u.AvatarURL,
+		FullName:   u.Name,
+		ProviderId: u.ID,
+	}
+	return data, nil
 }

--- a/internal/api/provider/fly.go
+++ b/internal/api/provider/fly.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/supabase/auth/internal/conf"
@@ -76,30 +75,29 @@ func (p flyProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*UserP
 		return nil, err
 	}
 
-	if u.Email == "" {
-		return nil, errors.New("unable to find email with Fly provider")
-	}
-
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        p.APIPath,
-			Subject:       u.UserID,
-			FullName:      u.UserName,
-			Email:         u.Email,
-			EmailVerified: true,
-			ProviderId:    u.UserID,
-			CustomClaims: map[string]interface{}{
-				"resource_owner_id": u.ResourceOwnerID,
-				"organizations":     u.Organizations,
-				"application":       u.Application,
-				"scope":             u.Scope,
-				"created_at":        u.CreatedAt,
-			},
-		},
-		Emails: []Email{{
+	data := &UserProvidedData{}
+	if u.Email != "" {
+		data.Emails = []Email{{
 			Email:    u.Email,
 			Verified: true,
 			Primary:  true,
-		}},
-	}, nil
+		}}
+	}
+
+	data.Metadata = &Claims{
+		Issuer:        p.APIPath,
+		Subject:       u.UserID,
+		FullName:      u.UserName,
+		Email:         u.Email,
+		EmailVerified: true,
+		ProviderId:    u.UserID,
+		CustomClaims: map[string]interface{}{
+			"resource_owner_id": u.ResourceOwnerID,
+			"organizations":     u.Organizations,
+			"application":       u.Application,
+			"scope":             u.Scope,
+			"created_at":        u.CreatedAt,
+		},
+	}
+	return data, nil
 }

--- a/internal/api/provider/github.go
+++ b/internal/api/provider/github.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"strconv"
 	"strings"
 
@@ -105,15 +104,6 @@ func (g githubProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 		if e.Email != "" {
 			data.Emails = append(data.Emails, Email{Email: e.Email, Verified: e.Verified, Primary: e.Primary})
 		}
-
-		if e.Primary {
-			data.Metadata.Email = e.Email
-			data.Metadata.EmailVerified = e.Verified
-		}
-	}
-
-	if len(data.Emails) <= 0 {
-		return nil, errors.New("unable to find email with GitHub provider")
 	}
 
 	return data, nil

--- a/internal/api/provider/gitlab.go
+++ b/internal/api/provider/gitlab.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"strconv"
 	"strings"
 
@@ -92,17 +91,11 @@ func (g gitlabProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 		data.Emails = append(data.Emails, Email{Email: u.Email, Verified: verified, Primary: true})
 	}
 
-	if len(data.Emails) <= 0 {
-		return nil, errors.New("unable to find email with GitLab provider")
-	}
-
 	data.Metadata = &Claims{
-		Issuer:        g.Host,
-		Subject:       strconv.Itoa(u.ID),
-		Name:          u.Name,
-		Picture:       u.AvatarURL,
-		Email:         u.Email,
-		EmailVerified: true,
+		Issuer:  g.Host,
+		Subject: strconv.Itoa(u.ID),
+		Name:    u.Name,
+		Picture: u.AvatarURL,
 
 		// To be deprecated
 		AvatarURL:  u.AvatarURL,

--- a/internal/api/provider/google.go
+++ b/internal/api/provider/google.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -113,10 +112,6 @@ func (g googleProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 			Verified: u.IsEmailVerified(),
 			Primary:  true,
 		})
-	}
-
-	if len(data.Emails) <= 0 {
-		return nil, errors.New("provider: Google OAuth2 user info endpoint did not return an email address")
 	}
 
 	data.Metadata = &Claims{

--- a/internal/api/provider/kakao.go
+++ b/internal/api/provider/kakao.go
@@ -43,29 +43,30 @@ func (p kakaoProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 		return nil, err
 	}
 
-	data := &UserProvidedData{
-		Emails: []Email{
+	data := &UserProvidedData{}
+
+	if u.Account.Email != "" {
+		data.Emails = []Email{
 			{
 				Email:    u.Account.Email,
 				Verified: u.Account.EmailVerified && u.Account.EmailValid,
 				Primary:  true,
 			},
-		},
-		Metadata: &Claims{
-			Issuer:        p.APIHost,
-			Subject:       strconv.Itoa(u.ID),
-			Email:         u.Account.Email,
-			EmailVerified: u.Account.EmailVerified && u.Account.EmailValid,
+		}
+	}
 
-			Name:              u.Account.Profile.Name,
-			PreferredUsername: u.Account.Profile.Name,
+	data.Metadata = &Claims{
+		Issuer:  p.APIHost,
+		Subject: strconv.Itoa(u.ID),
 
-			// To be deprecated
-			AvatarURL:   u.Account.Profile.ProfileImageURL,
-			FullName:    u.Account.Profile.Name,
-			ProviderId:  strconv.Itoa(u.ID),
-			UserNameKey: u.Account.Profile.Name,
-		},
+		Name:              u.Account.Profile.Name,
+		PreferredUsername: u.Account.Profile.Name,
+
+		// To be deprecated
+		AvatarURL:   u.Account.Profile.ProfileImageURL,
+		FullName:    u.Account.Profile.Name,
+		ProviderId:  strconv.Itoa(u.ID),
+		UserNameKey: u.Account.Profile.Name,
 	}
 	return data, nil
 }

--- a/internal/api/provider/keycloak.go
+++ b/internal/api/provider/keycloak.go
@@ -72,27 +72,27 @@ func (g keycloakProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 		return nil, err
 	}
 
-	if u.Email == "" {
-		return nil, errors.New("unable to find email with Keycloak provider")
-	}
-
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        g.Host,
-			Subject:       u.Sub,
-			Name:          u.Name,
-			Email:         u.Email,
-			EmailVerified: u.EmailVerified,
-
-			// To be deprecated
-			FullName:   u.Name,
-			ProviderId: u.Sub,
-		},
-		Emails: []Email{{
+	data := &UserProvidedData{}
+	if u.Email != "" {
+		data.Emails = []Email{{
 			Email:    u.Email,
 			Verified: u.EmailVerified,
 			Primary:  true,
-		}},
-	}, nil
+		}}
+	}
+
+	data.Metadata = &Claims{
+		Issuer:        g.Host,
+		Subject:       u.Sub,
+		Name:          u.Name,
+		Email:         u.Email,
+		EmailVerified: u.EmailVerified,
+
+		// To be deprecated
+		FullName:   u.Name,
+		ProviderId: u.Sub,
+	}
+
+	return data, nil
 
 }

--- a/internal/api/provider/linkedin.go
+++ b/internal/api/provider/linkedin.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/supabase/auth/internal/conf"
@@ -120,37 +119,31 @@ func (g linkedinProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*
 		return nil, err
 	}
 
-	if len(e.Elements) <= 0 {
-		return nil, errors.New("unable to find email with Linkedin provider")
-	}
-
-	emails := []Email{}
+	data := &UserProvidedData{}
 
 	if e.Elements[0].HandleTilde.EmailAddress != "" {
 		// linkedin only returns the primary email which is verified for the r_emailaddress scope.
-		emails = append(emails, Email{
+		data.Emails = []Email{{
 			Email:    e.Elements[0].HandleTilde.EmailAddress,
 			Primary:  true,
 			Verified: true,
-		})
+		}}
 	}
 
 	avatarURL := u.getAvatarUrl()
 
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        g.APIPath,
-			Subject:       u.ID,
-			Name:          strings.TrimSpace(GetName(u.FirstName) + " " + GetName(u.LastName)),
-			Picture:       avatarURL,
-			Email:         e.Elements[0].HandleTilde.EmailAddress,
-			EmailVerified: true,
+	data.Metadata = &Claims{
+		Issuer:        g.APIPath,
+		Subject:       u.ID,
+		Name:          strings.TrimSpace(GetName(u.FirstName) + " " + GetName(u.LastName)),
+		Picture:       avatarURL,
+		Email:         e.Elements[0].HandleTilde.EmailAddress,
+		EmailVerified: true,
 
-			// To be deprecated
-			AvatarURL:  avatarURL,
-			FullName:   strings.TrimSpace(GetName(u.FirstName) + " " + GetName(u.LastName)),
-			ProviderId: u.ID,
-		},
-		Emails: emails,
-	}, nil
+		// To be deprecated
+		AvatarURL:  avatarURL,
+		FullName:   strings.TrimSpace(GetName(u.FirstName) + " " + GetName(u.LastName)),
+		ProviderId: u.ID,
+	}
+	return data, nil
 }

--- a/internal/api/provider/notion.go
+++ b/internal/api/provider/notion.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -98,28 +97,25 @@ func (g notionProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 		return nil, err
 	}
 
-	if u.Bot.Owner.User.Person.Email == "" {
-		return nil, errors.New("unable to find email with notion provider")
-	}
-
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        g.APIPath,
-			Subject:       u.Bot.Owner.User.ID,
-			Name:          u.Bot.Owner.User.Name,
-			Picture:       u.Bot.Owner.User.AvatarURL,
-			Email:         u.Bot.Owner.User.Person.Email,
-			EmailVerified: true, // Notion dosen't provide data on if email is verified.
-
-			// To be deprecated
-			AvatarURL:  u.Bot.Owner.User.AvatarURL,
-			FullName:   u.Bot.Owner.User.Name,
-			ProviderId: u.Bot.Owner.User.ID,
-		},
-		Emails: []Email{{
+	data := &UserProvidedData{}
+	if u.Bot.Owner.User.Person.Email != "" {
+		data.Emails = []Email{{
 			Email:    u.Bot.Owner.User.Person.Email,
 			Verified: true, // Notion dosen't provide data on if email is verified.
 			Primary:  true,
-		}},
-	}, nil
+		}}
+	}
+
+	data.Metadata = &Claims{
+		Issuer:  g.APIPath,
+		Subject: u.Bot.Owner.User.ID,
+		Name:    u.Bot.Owner.User.Name,
+		Picture: u.Bot.Owner.User.AvatarURL,
+
+		// To be deprecated
+		AvatarURL:  u.Bot.Owner.User.AvatarURL,
+		FullName:   u.Bot.Owner.User.Name,
+		ProviderId: u.Bot.Owner.User.ID,
+	}
+	return data, nil
 }

--- a/internal/api/provider/slack.go
+++ b/internal/api/provider/slack.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/supabase/auth/internal/conf"
@@ -68,31 +67,28 @@ func (g slackProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 		return nil, err
 	}
 
-	if u.Email == "" {
-		return nil, errors.New("unable to find email with Slack provider")
-	}
-
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        g.APIPath,
-			Subject:       u.ID,
-			Name:          u.Name,
-			Picture:       u.AvatarURL,
-			Email:         u.Email,
-			EmailVerified: true, // Slack dosen't provide data on if email is verified.
-			CustomClaims: map[string]interface{}{
-				"https://slack.com/team_id": u.TeamID,
-			},
-
-			// To be deprecated
-			AvatarURL:  u.AvatarURL,
-			FullName:   u.Name,
-			ProviderId: u.ID,
-		},
-		Emails: []Email{{
+	data := &UserProvidedData{}
+	if u.Email != "" {
+		data.Emails = []Email{{
 			Email:    u.Email,
 			Verified: true, // Slack dosen't provide data on if email is verified.
 			Primary:  true,
-		}},
-	}, nil
+		}}
+	}
+
+	data.Metadata = &Claims{
+		Issuer:  g.APIPath,
+		Subject: u.ID,
+		Name:    u.Name,
+		Picture: u.AvatarURL,
+		CustomClaims: map[string]interface{}{
+			"https://slack.com/team_id": u.TeamID,
+		},
+
+		// To be deprecated
+		AvatarURL:  u.AvatarURL,
+		FullName:   u.Name,
+		ProviderId: u.ID,
+	}
+	return data, nil
 }

--- a/internal/api/provider/twitch.go
+++ b/internal/api/provider/twitch.go
@@ -120,38 +120,34 @@ func (t twitchProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 
 	user := u.Data[0]
 
-	if user.Email == "" {
-		return nil, errors.New("unable to find email with twitch provider")
-	}
-
-	data := &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        t.APIHost,
-			Subject:       user.ID,
-			Picture:       user.ProfileImageURL,
-			Name:          user.Login,
-			NickName:      user.DisplayName,
-			Email:         user.Email,
-			EmailVerified: true,
-			CustomClaims: map[string]interface{}{
-				"broadcaster_type":  user.BroadcasterType,
-				"description":       user.Description,
-				"type":              user.Type,
-				"offline_image_url": user.OfflineImageURL,
-				"view_count":        user.ViewCount,
-			},
-
-			// To be deprecated
-			Slug:       user.DisplayName,
-			AvatarURL:  user.ProfileImageURL,
-			FullName:   user.Login,
-			ProviderId: user.ID,
-		},
-		Emails: []Email{{
+	data := &UserProvidedData{}
+	if user.Email != "" {
+		data.Emails = []Email{{
 			Email:    user.Email,
 			Verified: true,
 			Primary:  true,
-		}},
+		}}
+	}
+
+	data.Metadata = &Claims{
+		Issuer:   t.APIHost,
+		Subject:  user.ID,
+		Picture:  user.ProfileImageURL,
+		Name:     user.Login,
+		NickName: user.DisplayName,
+		CustomClaims: map[string]interface{}{
+			"broadcaster_type":  user.BroadcasterType,
+			"description":       user.Description,
+			"type":              user.Type,
+			"offline_image_url": user.OfflineImageURL,
+			"view_count":        user.ViewCount,
+		},
+
+		// To be deprecated
+		Slug:       user.DisplayName,
+		AvatarURL:  user.ProfileImageURL,
+		FullName:   user.Login,
+		ProviderId: user.ID,
 	}
 
 	return data, nil

--- a/internal/api/provider/twitter.go
+++ b/internal/api/provider/twitter.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -91,31 +90,27 @@ func (t TwitterProvider) FetchUserData(ctx context.Context, tok *oauth.AccessTok
 	}
 	_ = json.NewDecoder(bytes.NewReader(bits)).Decode(&u)
 
-	if u.Email == "" {
-		return nil, errors.New("unable to find email with Twitter provider")
-	}
-
-	data := &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:            t.UserInfoURL,
-			Subject:           u.ID,
-			Name:              u.Name,
-			Picture:           u.AvatarURL,
-			PreferredUsername: u.UserName,
-			Email:             u.Email,
-			EmailVerified:     true,
-
-			// To be deprecated
-			UserNameKey: u.UserName,
-			FullName:    u.Name,
-			AvatarURL:   u.AvatarURL,
-			ProviderId:  u.ID,
-		},
-		Emails: []Email{{
+	data := &UserProvidedData{}
+	if u.Email != "" {
+		data.Emails = []Email{{
 			Email:    u.Email,
 			Verified: true,
 			Primary:  true,
-		}},
+		}}
+	}
+
+	data.Metadata = &Claims{
+		Issuer:            t.UserInfoURL,
+		Subject:           u.ID,
+		Name:              u.Name,
+		Picture:           u.AvatarURL,
+		PreferredUsername: u.UserName,
+
+		// To be deprecated
+		UserNameKey: u.UserName,
+		FullName:    u.Name,
+		AvatarURL:   u.AvatarURL,
+		ProviderId:  u.ID,
 	}
 
 	return data, nil

--- a/internal/api/provider/workos.go
+++ b/internal/api/provider/workos.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -72,30 +71,28 @@ func (g workosProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Us
 		return nil, err
 	}
 
-	if u.Email == "" {
-		return nil, errors.New("unable to find email with WorkOS provider")
-	}
-
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        g.APIPath,
-			Subject:       u.ID,
-			Name:          strings.TrimSpace(u.FirstName + " " + u.LastName),
-			Email:         u.Email,
-			EmailVerified: true,
-			CustomClaims: map[string]interface{}{
-				"connection_id":   u.ConnectionID,
-				"organization_id": u.OrganizationID,
-			},
-
-			// To be deprecated
-			FullName:   strings.TrimSpace(u.FirstName + " " + u.LastName),
-			ProviderId: u.ID,
-		},
-		Emails: []Email{{
+	data := &UserProvidedData{}
+	if u.Email != "" {
+		data.Emails = []Email{{
 			Email:    u.Email,
 			Verified: true,
 			Primary:  true,
-		}},
-	}, nil
+		}}
+	}
+
+	data.Metadata = &Claims{
+		Issuer:  g.APIPath,
+		Subject: u.ID,
+		Name:    strings.TrimSpace(u.FirstName + " " + u.LastName),
+		CustomClaims: map[string]interface{}{
+			"connection_id":   u.ConnectionID,
+			"organization_id": u.OrganizationID,
+		},
+
+		// To be deprecated
+		FullName:   strings.TrimSpace(u.FirstName + " " + u.LastName),
+		ProviderId: u.ID,
+	}
+
+	return data, nil
 }

--- a/internal/api/provider/zoom.go
+++ b/internal/api/provider/zoom.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/supabase/auth/internal/conf"
@@ -62,38 +61,31 @@ func (g zoomProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*User
 		return nil, err
 	}
 
-	if u.Email == "" {
-		return nil, errors.New("unable to find email with Zoom provider")
+	data := &UserProvidedData{}
+	if u.Email != "" {
+		email := Email{}
+		email.Email = u.Email
+		email.Primary = true
+		// A login_type of "100" refers to email-based logins, not oauth.
+		// A user is verified (type 1) only if they received an email when their profile was created and confirmed the link.
+		// A zoom user will only be sent an email confirmation link if they signed up using their zoom work email and not oauth.
+		// See: https://devforum.zoom.us/t/how-to-determine-if-a-zoom-user-actually-owns-their-email-address/44430
+		if u.LoginType != "100" || u.EmailVerified != 0 {
+			email.Verified = true
+		}
+		data.Emails = []Email{email}
 	}
 
-	verified := true
+	data.Metadata = &Claims{
+		Issuer:  g.APIPath,
+		Subject: u.ID,
+		Name:    strings.TrimSpace(u.FirstName + " " + u.LastName),
+		Picture: u.AvatarURL,
 
-	// A login_type of "100" refers to email-based logins, not oauth.
-	// A user is verified (type 1) only if they received an email when their profile was created and confirmed the link.
-	// A zoom user will only be sent an email confirmation link if they signed up using their zoom work email and not oauth.
-	// See: https://devforum.zoom.us/t/how-to-determine-if-a-zoom-user-actually-owns-their-email-address/44430
-	if u.LoginType == "100" && u.EmailVerified == 0 {
-		verified = false
+		// To be deprecated
+		AvatarURL:  u.AvatarURL,
+		FullName:   strings.TrimSpace(u.FirstName + " " + u.LastName),
+		ProviderId: u.ID,
 	}
-
-	return &UserProvidedData{
-		Metadata: &Claims{
-			Issuer:        g.APIPath,
-			Subject:       u.ID,
-			Name:          strings.TrimSpace(u.FirstName + " " + u.LastName),
-			Picture:       u.AvatarURL,
-			Email:         u.Email,
-			EmailVerified: verified,
-
-			// To be deprecated
-			AvatarURL:  u.AvatarURL,
-			FullName:   strings.TrimSpace(u.FirstName + " " + u.LastName),
-			ProviderId: u.ID,
-		},
-		Emails: []Email{{
-			Email:    u.Email,
-			Verified: verified,
-			Primary:  true,
-		}},
-	}, nil
+	return data, nil
 }

--- a/internal/api/token_oidc.go
+++ b/internal/api/token_oidc.go
@@ -138,6 +138,18 @@ func (a *API) IdTokenGrant(ctx context.Context, w http.ResponseWriter, r *http.R
 		return oauthError("invalid request", "Bad ID token").WithInternalError(err)
 	}
 
+	userData.Metadata.EmailVerified = false
+	for _, email := range userData.Emails {
+		if email.Primary {
+			userData.Metadata.Email = email.Email
+			userData.Metadata.EmailVerified = email.Verified
+			break
+		} else {
+			userData.Metadata.Email = email.Email
+			userData.Metadata.EmailVerified = email.Verified
+		}
+	}
+
 	if idToken.Subject == "" {
 		return oauthError("invalid request", "Missing sub claim in id_token")
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Instead of returning an error in every provider if the email doesn't exist, we check if the email exists in `internalExternalProviderCallback` instead
* Setting the `Email` and `EmailVerified` claims in the `Claims` struct is redundant since we are tracking it separately in `Emails`. 
 
```go
type UserProvidedData struct {
	Emails   []Email
	Metadata *Claims
}
```

* Fix buggy oauth tests that appear to pass but they were actually returning the wrong value / wrong expected error
* This PR lays the foundation for removing the dependency on the email returned by the oauth provider
