### PR TITLE
feat: azure oidc fix

### DIFF
--- a/internal/api/provider/azure.go
+++ b/internal/api/provider/azure.go
@@ -90,7 +90,7 @@ func (g azureProvider) GetOAuthToken(code string) (*oauth2.Token, error) {
 	return g.Exchange(context.Background(), code)
 }
 
-func (g azureProvider) detectIDTokenIssuer(ctx context.Context, idToken string) (string, error) {
+func DetectAzureIDTokenIssuer(ctx context.Context, idToken string) (string, error) {
 	var payload struct {
 		Issuer string `json:"iss"`
 	}
@@ -116,7 +116,7 @@ func (g azureProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*Use
 	idToken := tok.Extra("id_token")
 
 	if idToken != nil {
-		issuer, err := g.detectIDTokenIssuer(ctx, idToken.(string))
+		issuer, err := DetectAzureIDTokenIssuer(ctx, idToken.(string))
 		if err != nil {
 			return nil, err
 		}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -119,10 +119,14 @@ paths:
                   enum:
                     - google
                     - apple
+                    - azure
+                    - facebook
+                    - keycloak
                 client_id:
                   type: string
                 issuer:
                   type: string
+                  description: If `provider` is `azure` then you can specify any Azure OIDC issuer string here, which will be used for verification.
                 gotrue_meta_security:
                   $ref: "#/components/schemas/GoTrueMetaSecurity"
                 auth_code:


### PR DESCRIPTION
Allows the use of Azure ID tokens with various Azure issuers, and defaults to the common issuer.