### PR TITLE
ci: remove push to ghcr.io/auth until repo rename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
             646182064048.dkr.ecr.us-east-1.amazonaws.com/gotrue
             supabase/auth
             public.ecr.aws/supabase/auth
-            ghcr.io/supabase/auth
             436098097459.dkr.ecr.us-east-1.amazonaws.com/auth
             646182064048.dkr.ecr.us-east-1.amazonaws.com/auth
           flavor: |


### PR DESCRIPTION
Until the repo is renamed to `auth` we can't push to ghcr.io/auth.