### PR TITLE
feat: add `GOTRUE_SPOTIFY_ASSUME_EMAIL_IS_VERIFIED` option

### DIFF
--- a/internal/api/provider/spotify.go
+++ b/internal/api/provider/spotify.go
@@ -73,13 +73,18 @@ func (g spotifyProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*U
 		return nil, err
 	}
 
+	// Spotify dosen't provide data on whether the user's email is verified.
+	// https://developer.spotify.com/documentation/web-api/reference/get-current-users-profile
+	emailVerified := false
+	if g.Config.AssumeEmailIsVerified != nil {
+		emailVerified = *g.Config.AssumeEmailIsVerified
+	}
+
 	data := &UserProvidedData{}
 	if u.Email != "" {
 		data.Emails = []Email{{
-			Email: u.Email,
-			// Spotify dosen't provide data on whether the user's email is verified.
-			// https://developer.spotify.com/documentation/web-api/reference/get-current-users-profile
-			Verified: false,
+			Email:    u.Email,
+			Verified: emailVerified,
 			Primary:  true,
 		}}
 	}
@@ -91,10 +96,11 @@ func (g spotifyProvider) GetUserData(ctx context.Context, tok *oauth2.Token) (*U
 	}
 
 	data.Metadata = &Claims{
-		Issuer:  g.APIPath,
-		Subject: u.ID,
-		Name:    u.DisplayName,
-		Picture: avatarURL,
+		Issuer:        g.APIPath,
+		Subject:       u.ID,
+		Name:          u.DisplayName,
+		Picture:       avatarURL,
+		EmailVerified: emailVerified,
 
 		// To be deprecated
 		AvatarURL:  avatarURL,

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -51,6 +51,9 @@ type OAuthProviderConfiguration struct {
 	ApiURL         string   `json:"api_url" split_words:"true"`
 	Enabled        bool     `json:"enabled"`
 	SkipNonceCheck bool     `json:"skip_nonce_check" split_words:"true"`
+
+	// AssumEmailIsVerified is only used in the Spotify provider for now.
+	AssumeEmailIsVerified *bool `json:"assume_email_is_verified" split_words:"true"`
 }
 
 type EmailProviderConfiguration struct {


### PR DESCRIPTION
Some projects may want to use the insecure Spotify OAuth functionality. This was fixed in #1296.

Adds the `GOTRUE_SPOTIFY_ASSUME_EMAIL_IS_VERIFIED` option which when set, can treat the emails as verified.