### PR TITLE
fix: include symbols in generated password

### DIFF
--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -80,7 +80,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	if isNewUser {
 		// User either doesn't exist or hasn't completed the signup process.
 		// Sign them up with temporary password.
-		password, err := password.Generate(64, 10, 0, false, true)
+		password, err := password.Generate(64, 10, 1, false, true)
 		if err != nil {
 			internalServerError("error creating user").WithInternalError(err)
 		}

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -74,7 +74,7 @@ func (a *API) adminGenerateLink(w http.ResponseWriter, r *http.Request) error {
 		if models.IsNotFoundError(err) {
 			if params.Type == magicLinkVerification {
 				params.Type = signupVerification
-				params.Password, err = password.Generate(64, 10, 0, false, true)
+				params.Password, err = password.Generate(64, 10, 1, false, true)
 				if err != nil {
 					return internalServerError("error creating user").WithInternalError(err)
 				}

--- a/internal/api/otp.go
+++ b/internal/api/otp.go
@@ -149,7 +149,7 @@ func (a *API) SmsOtp(w http.ResponseWriter, r *http.Request) error {
 	if isNewUser {
 		// User either doesn't exist or hasn't completed the signup process.
 		// Sign them up with temporary password.
-		password, err := password.Generate(64, 10, 0, false, true)
+		password, err := password.Generate(64, 10, 1, false, true)
 		if err != nil {
 			internalServerError("error creating user").WithInternalError(err)
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* If `GOTRUE_PASSWORD_REQUIRED_CHARACTERS` includes symbols, it prevents users signing up via passwordless methods (magiclink / sms OTP) because those routes make an internal call to the `/signup` endpoint with a generated password.
* The generated password doesn't include symbols which will cause it to fail the character requirement check