### PR TITLE
[#1365] Fix signUp leaking user role

### DIFF
--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -351,6 +351,7 @@ func sanitizeUser(u *models.User, params *SignupParams) (*models.User, error) {
 
 	u.ID = uuid.Must(uuid.NewV4())
 
+	u.Role = ""
 	u.CreatedAt, u.UpdatedAt, u.ConfirmationSentAt = now, now, &now
 	u.LastSignInAt, u.ConfirmedAt, u.EmailConfirmedAt, u.PhoneConfirmedAt = nil, nil, nil, nil
 	u.Identities = make([]models.Identity, 0)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #1365 

## What is the current behavior?

An existing user's role in `sanitizeUser` does not get sanitized and is revealed when a new user tries to signup with the same email.

## What is the new behavior?

The existing user's role is sanitized to an empty string to avoid revealing the information. 

Previous Behavior:
![image](https://github.com/supabase/gotrue/assets/50147457/de5c55c6-af22-4849-85c8-c5c91b2c9361)


Fixed Behavior:
![image](https://github.com/supabase/gotrue/assets/50147457/ffeebb55-61d0-4081-99ba-4dc343104de1)

