### PR TITLE
[#880] Add function to get user by email identities 

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -233,6 +233,10 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			r.Route("/users", func(r *router) {
 				r.Get("/", api.adminUsers)
 				r.Post("/", api.adminUserCreate)
+				
+				r.Route("/email", func(r *router) {
+					r.Get("/{email}", api.adminUsersGetByEmailIdentities)
+				})
 
 				r.Route("/{user_id}", func(r *router) {
 					r.Use(api.loadUser)

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -644,12 +644,15 @@ func FindUsersByEmailIdentities(tx *storage.Connection, email string) ([]*User, 
         return nil, err
     }
 
+	if len(identities) == 0 {
+		return make([]*User, 0), nil
+	}
+
     userIDs := make([]uuid.UUID, len(identities))
     for i, identity := range identities {
         userIDs[i] = identity.UserID
     }
 
-    // Fetch all users with the provided IDs
     users, err := FindUsersByIDs(tx, userIDs)
     if err != nil {
         return nil, err

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -133,6 +133,19 @@ func (ts *UserTestSuite) TestFindUserByID() {
 	require.Equal(ts.T(), u.ID, n.ID)
 }
 
+
+func (ts *UserTestSuite) TestFindUsersByEmailIdentities() {
+	u := ts.createUserWithEmail("foo@example.com")
+
+	n, err := FindUsersByEmailIdentities(ts.db, string(u.GetEmail()))
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), n, 1)
+
+	n, err = FindUsersByEmailIdentities(ts.db, "bar@example.com")
+	require.NoError(ts.T(), err)
+	require.Len(ts.T(), n, 0)
+}
+
 func (ts *UserTestSuite) TestFindUserByRecoveryToken() {
 	u := ts.createUser()
 	u.RecoveryToken = "asdf"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Resolves #880 

## What is the current behavior?

Currently, the only way to check if a user with a certain email exists before doing a signup is by doing `listUsers()`. 

## What is the new behavior?
Calling `GET /admin/users/email/{email}` returns an array of users whose identities have a matching `email` when a valid email is passed in the url.
![image](https://github.com/supabase/gotrue/assets/50147457/ed136cb9-b241-4649-af6a-bb5113519d89)

When the endpoint is called, `adminUsersGetByEmailIdentities` invokes `FindUsersByEmailIdentities`, which finds all identities with the matching email and then finds the users of those identities (using `FindUsersByIDs`), before returning it

Unit tests for the new functions `api/admin::adminUsersGetByEmailIdentities` and `models/user::FindUsersByEmailIdentities` have been added.

## Additional context

Some things I am unsure about:
* Do I need to check `email` of the `users` table, or is just identities sufficient?
  * Currently I am only checking the `identities` table, however in `IsDuplicatedEmail`, if nothing was found via the identities table, a final check on the users table is done as well.
* If pagination is needed? 
  * My personal view is that since it is unlikely to have that many records, pagination is required. However, it's might still be good practice to include pagination for consistency and to handle edge cases.
* Does `aud` need to be used to respond only with a list of all users in a given audience?
  * Currently I did not filter by `aud`, but noticed it is used for `api/admin::adminUsers`.
* Do I need to add this for `supabase/auth-py` and `supabase/supabase-py` as well?
  
If there is anything I missed or did wrongly please let me know and I will do my best to fix it. If this is implemented satisfactorily, I will add the method `auth.admin.listUsersForEmailIdentities` for both `supabase/gotrue-js` and `supabase/supabase-js`.