### PR TITLE
feat: clean up expired factors

### DIFF
--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -180,6 +180,33 @@ func (ts *MFATestSuite) TestDuplicateEnrollsReturnExpectedMessage() {
 
 }
 
+func (ts *MFATestSuite) TestMultipleEnrollsCleanupExpiredFactors() {
+	// All factors are deleted when a subsequent enroll is made
+	ts.API.config.MFA.FactorExpiryDuration = 0 * time.Second
+	// Verified factor should not be deleted (Factor 1)
+	_ = performTestSignupAndVerify(ts, ts.TestEmail, ts.TestPassword, true /* <- requireStatusOK */)
+	numFactors := 5
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, ts.TestUser, nil, models.TOTPSignIn)
+	require.NoError(ts.T(), err)
+
+	for i := 0; i < numFactors; i++ {
+		_ = performEnrollFlow(ts, token, "", models.TOTP, "https://issuer.com", http.StatusOK)
+	}
+
+	// All Factors except last factor should be expired
+	factors, err := models.FindFactorsByUser(ts.API.db, ts.TestUser)
+	require.NoError(ts.T(), err)
+
+	// Make a challenge so last, unverified factor isn't deleted on next enroll (Factor 2)
+	_ = performChallengeFlow(ts, factors[len(factors)-1].ID, token)
+
+	// Enroll another Factor (Factor 3)
+	_ = performEnrollFlow(ts, token, "", models.TOTP, "https://issuer.com", http.StatusOK)
+	factors, err = models.FindFactorsByUser(ts.API.db, ts.TestUser)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), 3, len(factors))
+}
+
 func (ts *MFATestSuite) TestChallengeFactor() {
 	f := ts.TestUser.Factors[0]
 	token := ts.generateAAL1Token(ts.TestUser, &ts.TestSession.ID)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -18,6 +18,7 @@ import (
 
 const defaultMinPasswordLength int = 6
 const defaultChallengeExpiryDuration float64 = 300
+const defaultFactorExpiryDuration time.Duration = 300 * time.Second
 const defaultFlowStateExpiryDuration time.Duration = 300 * time.Second
 
 // See: https://www.postgresql.org/docs/7.0/syntax525.htm
@@ -102,11 +103,12 @@ type JWTConfiguration struct {
 
 // MFAConfiguration holds all the MFA related Configuration
 type MFAConfiguration struct {
-	Enabled                     bool    `default:"false"`
-	ChallengeExpiryDuration     float64 `json:"challenge_expiry_duration" default:"300" split_words:"true"`
-	RateLimitChallengeAndVerify float64 `split_words:"true" default:"15"`
-	MaxEnrolledFactors          float64 `split_words:"true" default:"10"`
-	MaxVerifiedFactors          int     `split_words:"true" default:"10"`
+	Enabled                     bool          `default:"false"`
+	ChallengeExpiryDuration     float64       `json:"challenge_expiry_duration" default:"300" split_words:"true"`
+	FactorExpiryDuration        time.Duration `json:"factor_expiry_duration" default:"300s" split_words:"true"`
+	RateLimitChallengeAndVerify float64       `split_words:"true" default:"15"`
+	MaxEnrolledFactors          float64       `split_words:"true" default:"10"`
+	MaxVerifiedFactors          int           `split_words:"true" default:"10"`
 }
 
 type APIConfiguration struct {
@@ -710,6 +712,9 @@ func (config *GlobalConfiguration) ApplyDefaults() error {
 	}
 	if config.MFA.ChallengeExpiryDuration < defaultChallengeExpiryDuration {
 		config.MFA.ChallengeExpiryDuration = defaultChallengeExpiryDuration
+	}
+	if config.MFA.FactorExpiryDuration < defaultFactorExpiryDuration {
+		config.MFA.FactorExpiryDuration = defaultFactorExpiryDuration
 	}
 	if config.External.FlowStateExpiryDuration < defaultFlowStateExpiryDuration {
 		config.External.FlowStateExpiryDuration = defaultFlowStateExpiryDuration

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -225,14 +225,7 @@ func DeleteExpiredFactors(tx *storage.Connection, validityDuration time.Duration
 	factorTable := (&pop.Model{Value: Factor{}}).TableName()
 	challengeTable := (&pop.Model{Value: Challenge{}}).TableName()
 
-	query := fmt.Sprintf(`delete from %q
-where status != 'verified'
-and not exists (
-    select *
-    from %q
-    where %q.id = %q.factor_id
-)
-and created_at + %s < current_timestamp;`, factorTable, challengeTable, factorTable, challengeTable, validityInterval)
+	query := fmt.Sprintf(`delete from %q where status != 'verified' and not exists (select * from %q where %q.id = %q.factor_id ) and created_at + %s < current_timestamp;`, factorTable, challengeTable, factorTable, challengeTable, validityInterval)
 	if err := tx.RawQuery(query).Exec(); err != nil {
 		return err
 	}

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -144,7 +144,7 @@ func NewFactor(user *User, friendlyName string, factorType string, state FactorS
 // FindFactorsByUser returns all factors belonging to a user ordered by timestamp
 func FindFactorsByUser(tx *storage.Connection, user *User) ([]*Factor, error) {
 	factors := []*Factor{}
-	if err := tx.Q().Where("user_id = ?", user.ID).Order("created_at asc").All(&factors); err != nil {
+	if err := tx.Eager().Q().Where("user_id = ?", user.ID).Order("created_at asc").All(&factors); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return factors, nil
 		}
@@ -216,4 +216,8 @@ func DeleteFactorsByUserId(tx *storage.Connection, userId uuid.UUID) error {
 		return err
 	}
 	return nil
+}
+
+func (f *Factor) IsExpired(validityDuration time.Duration) bool {
+	return !f.IsVerified() && len(f.Challenge) == 0 && f.CreatedAt.Add(validityDuration).Before(time.Now())
 }

--- a/internal/models/factor.go
+++ b/internal/models/factor.go
@@ -225,12 +225,12 @@ func DeleteExpiredFactors(tx *storage.Connection, validityDuration time.Duration
 	factorTable := (&pop.Model{Value: Factor{}}).TableName()
 	challengeTable := (&pop.Model{Value: Challenge{}}).TableName()
 
-	query := fmt.Sprintf(`delete from %s
+	query := fmt.Sprintf(`delete from %q
 where status != 'verified'
 and not exists (
     select *
-    from %s
-    where %s.id = %s.factor_id
+    from %q
+    where %q.id = %q.factor_id
 )
 and created_at + %s < current_timestamp;`, factorTable, challengeTable, factorTable, challengeTable, validityInterval)
 	if err := tx.RawQuery(query).Exec(); err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, unverified MFA factors can build up in the database quickly. Supabase developers can toggle Maximum unverified factors ( `Maximum number of per-user MFA factors`) via the dashboard but developers will have to look for the toggle.  Developers can also call `unenroll` but it requires an additional step.


This PR proposes periodic cleanup of stale factors on each request.  A stale factor is:

- Unverified
- Has no associated Challenges 
- Older than five minutes

Why five minutes? 
- Most enrolment or verification flow should be completed within the five minute window

Factors which are unverified but have associated challenges will be cleaned up [after the developer makes successful verification](https://github.com/supabase/gotrue/blob/master/internal/api/mfa.go#L314)

Alternatives considered:
- Return the same factor and QR code if the same user calls `/enroll` twice. We unfortunately can't reuse the QR code as it poses a security risk.
- Increase the initial number of default unverified factors (currently 10)
- Drop the unverified factor check. I think this was initially introduced to prevent a malicious user from creating excessive entries in the database


Address #979. 