### PR TITLE
feat: return bad request error when factor with duplicate friendly name is registered

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -137,7 +137,7 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 		if terr := tx.Create(factor); terr != nil {
 			pgErr := utilities.NewPostgresError(terr)
 			if pgErr.IsUniqueConstraintViolated() {
-				return internalServerError(fmt.Sprintf("a factor with the friendly name %q for this user likely already exists", factor.FriendlyName))
+				return badRequestError(fmt.Sprintf("a factor with the friendly name %q for this user likely already exists", factor.FriendlyName))
 			}
 			return terr
 

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -163,7 +163,7 @@ func (ts *MFATestSuite) TestDuplicateEnrollsReturnExpectedMessage() {
 	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, ts.TestUser, nil, models.TOTPSignIn)
 	require.NoError(ts.T(), err)
 	_ = performEnrollFlow(ts, token, friendlyName, models.TOTP, "https://issuer.com", http.StatusOK)
-	response := performEnrollFlow(ts, token, friendlyName, models.TOTP, "https://issuer.com", http.StatusInternalServerError)
+	response := performEnrollFlow(ts, token, friendlyName, models.TOTP, "https://issuer.com", http.StatusBadRequest)
 
 	var errorResponse HTTPError
 	err = json.NewDecoder(response.Body).Decode(&errorResponse)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Swap `internalServerError` for `badRequestError` so as to allow user to make use of the status code and make adjustments