### PR TITLE
feat: drop SAML RelayState IP address check

### DIFF
--- a/internal/api/samlacs.go
+++ b/internal/api/samlacs.go
@@ -80,14 +80,6 @@ func (a *API) SAMLACS(w http.ResponseWriter, r *http.Request) error {
 			return badRequestError("SAML RelayState has expired. Try loggin in again?")
 		}
 
-		if relayState.FromIPAddress != utilities.GetIPAddress(r) {
-			if err := a.samlDestroyRelayState(ctx, relayState); err != nil {
-				return internalServerError("SAML RelayState comes from another IP address and destroying it failed. Try logging in again?").WithInternalError(err)
-			}
-
-			return badRequestError("SAML RelayState comes from another IP address, try logging in again?")
-		}
-
 		// TODO: add abuse detection to bind the RelayState UUID with a
 		// HTTP-Only cookie
 

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
-	"github.com/supabase/auth/internal/utilities"
 )
 
 type SingleSignOnParams struct {

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -121,7 +121,6 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	relayState := models.SAMLRelayState{
 		SSOProviderID: ssoProvider.ID,
 		RequestID:     authnRequest.ID,
-		FromIPAddress: utilities.GetIPAddress(r),
 		RedirectTo:    params.RedirectTo,
 		FlowStateID:   flowStateID,
 	}

--- a/internal/models/sso.go
+++ b/internal/models/sso.go
@@ -148,8 +148,8 @@ type SAMLRelayState struct {
 
 	SSOProviderID uuid.UUID `db:"sso_provider_id"`
 
-	RequestID     string  `db:"request_id"`
-	ForEmail      *string `db:"for_email"`
+	RequestID string  `db:"request_id"`
+	ForEmail  *string `db:"for_email"`
 
 	RedirectTo string `db:"redirect_to"`
 

--- a/internal/models/sso.go
+++ b/internal/models/sso.go
@@ -150,7 +150,6 @@ type SAMLRelayState struct {
 
 	RequestID     string  `db:"request_id"`
 	ForEmail      *string `db:"for_email"`
-	FromIPAddress string  `db:"from_ip_address"`
 
 	RedirectTo string `db:"redirect_to"`
 

--- a/migrations/20240115144230_remove_ip_address_from_saml_relay_state.sql
+++ b/migrations/20240115144230_remove_ip_address_from_saml_relay_state.sql
@@ -1,0 +1,7 @@
+do $$
+begin
+   if exists (select from information_schema.columns where table_schema = '{{ index .Options "Namespace" }}' and table_name = 'saml_relay_states' and column_name = 'from_ip_address') then
+      alter table {{ index .Options "Namespace" }}.saml_relay_states drop column from_ip_address;
+   end if;
+end
+$$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

The SAML Relay State IP address check was originally introduced to increase security by guarding against man in the middle like attacks.

Unfortunately, mismatches can be quite common, especially when using a corporate network or a VPN when attempting to `signInWithSSO`.  After customer feedback and discussion, it seems like the SAMLRelayState might not add that much additional security value. Hence, we are removing the check.


We keep the IP Address field for now and can consider deprecating it in the future 