### PR TITLE
feat: remove non-SSO restriction for MFA

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -75,10 +75,6 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("invalid body: unable to parse JSON").WithInternalError(err)
 	}
 
-	if user.IsSSOUser {
-		return unprocessableEntityError("MFA enrollment only supported for non-SSO users at this time")
-	}
-
 	if params.FactorType != models.TOTP {
 		return badRequestError("factor_type needs to be totp")
 	}


### PR DESCRIPTION
Removes the restriction for enabling MFA on SSO accounts. It is unnecessary and an artificial limitation.