### PR TITLE
feat: add cleanup of unverified factors in 24 hour window

### DIFF
--- a/internal/models/cleanup.go
+++ b/internal/models/cleanup.go
@@ -36,6 +36,7 @@ func (c *Cleanup) Setup() {
 	tableRelayStates := SAMLRelayState{}.TableName()
 	tableFlowStates := FlowState{}.TableName()
 	tableMFAChallenges := Challenge{}.TableName()
+	tableMFAFactors := Factor{}.TableName()
 
 	// These statements intentionally use SELECT ... FOR UPDATE SKIP LOCKED
 	// as this makes sure that only rows that are not being used in another
@@ -51,6 +52,7 @@ func (c *Cleanup) Setup() {
 		fmt.Sprintf("delete from %q where id in (select id from %q where created_at < now() - interval '24 hours' limit 100 for update skip locked);", tableRelayStates, tableRelayStates),
 		fmt.Sprintf("delete from %q where id in (select id from %q where created_at < now() - interval '24 hours' limit 100 for update skip locked);", tableFlowStates, tableFlowStates),
 		fmt.Sprintf("delete from %q where id in (select id from %q where created_at < now() - interval '24 hours' limit 100 for update skip locked);", tableMFAChallenges, tableMFAChallenges),
+		fmt.Sprintf("delete from %q where id in (select id from %q where created_at < now() - interval '24 hours' and status = 'unverified' limit 100 for update skip locked);", tableMFAFactors, tableMFAFactors),
 	)
 
 	if c.SessionTimebox != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Unverified Factors are unlikely to be relevant after a 24 hour window. This PR cleans up unverified factors so they don't clog the database.

We cleanup `unverified` factors after 24 hours but this doesn't catch users who abandon the setup process midway (e.g. enroll and then leave)