### PR TITLE
fix: potential panics on error

### DIFF
--- a/internal/api/provider/provider.go
+++ b/internal/api/provider/provider.go
@@ -114,7 +114,6 @@ func makeRequest(ctx context.Context, tok *oauth2.Token, g *oauth2.Config, url s
 	defer utilities.SafeClose(res.Body)
 
 	bodyBytes, _ := io.ReadAll(res.Body)
-	defer utilities.SafeClose(res.Body)
 	res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {

--- a/internal/api/sms_provider/twilio.go
+++ b/internal/api/sms_provider/twilio.go
@@ -112,10 +112,10 @@ func (t *TwilioProvider) SendSms(phone, message, channel, otp string) (string, e
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	r.SetBasicAuth(t.Config.AccountSid, t.Config.AuthToken)
 	res, err := client.Do(r)
-	defer utilities.SafeClose(res.Body)
 	if err != nil {
 		return "", err
 	}
+	defer utilities.SafeClose(res.Body)
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		resp := &twilioErrResponse{}
 		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {

--- a/internal/api/sms_provider/twilio_verify.go
+++ b/internal/api/sms_provider/twilio_verify.go
@@ -78,10 +78,10 @@ func (t *TwilioVerifyProvider) SendSms(phone, message, channel string) (string, 
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	r.SetBasicAuth(t.Config.AccountSid, t.Config.AuthToken)
 	res, err := client.Do(r)
-	defer utilities.SafeClose(res.Body)
 	if err != nil {
 		return "", err
 	}
+	defer utilities.SafeClose(res.Body)
 	if !(res.StatusCode == http.StatusOK || res.StatusCode == http.StatusCreated) {
 		resp := &twilioErrResponse{}
 		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
@@ -114,10 +114,10 @@ func (t *TwilioVerifyProvider) VerifyOTP(phone, code string) error {
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	r.SetBasicAuth(t.Config.AccountSid, t.Config.AuthToken)
 	res, err := client.Do(r)
-	defer utilities.SafeClose(res.Body)
 	if err != nil {
 		return err
 	}
+	defer utilities.SafeClose(res.Body)
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		resp := &twilioErrResponse{}
 		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* In the [`net/http` Do method](https://pkg.go.dev/net/http#Client.Do), if an error is returned, the http response should be ignored. Currently, we defer closing the response body which leads to a nil pointer error