### PR TITLE
ci: add new release process using release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,65 +1,135 @@
-name: Build and Release on Push to Master
+name: Release
 
 on:
-  workflow_dispatch:
-
-  workflow_run:
-    workflows: [Test]
-    types: [completed]
+  push:
     branches:
       - master
-      - zerosessionidfix
-      - lastsigninatfix
+      - release/*
 
 jobs:
-  release:
-    outputs:
-      status: ${{ steps.semantic.outputs.new_release_published }}
-      version: ${{ steps.semantic.outputs.new_release_version }}
-
-    runs-on: ubuntu-20.04
+  release_please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v3
-      - name: Release on GitHub
-        id: semantic
-        uses: cycjimmy/semantic-release-action@v3
+      - uses: google-github-actions/release-please-action@v4
+        id: release
         with:
-          semantic_version: 18
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          release-type: go
+          target-branch: ${{ github.ref_name }}
 
-  deploy:
-    needs: release
-    runs-on: ubuntu-20.04
-    if: success() && needs.release.outputs.status == 'true'
-    steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
         with:
           fetch-depth: 0
 
+      - if: ${{ steps.release.outputs }}
+        id: versions
+        run: |
+          set -ex
+
+          RELEASE_CANDIDATE=true
+          NOT_RELEASE_CANDIDATE='${{ steps.release.outputs.release_created }}'
+          if [ "$NOT_RELEASE_CANDIDATE" == "true" ]
+          then
+            RELEASE_CANDIDATE=false
+          fi
+
+          MAIN_RELEASE_VERSION=x
+          RELEASE_VERSION=y
+
+          if [ "$RELEASE_CANDIDATE" == "true" ]
+          then
+            # Release please doesn't tell you the candidate version when it
+            # creates the PR, so we have to take it from the title.
+            MAIN_RELEASE_VERSION=$(node -e "console.log('${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).title }}'.split(' ').reverse().find(x => x.match(/[0-9]+[.][0-9]+[.][0-9]+/)))")
+
+            # Use git describe tags to identify the number of commits the branch
+            # is ahead of the most recent non-release-candidate tag, which is
+            # part of the rc.<commits> value.
+            RELEASE_VERSION=$MAIN_RELEASE_VERSION-rc.$(node -e "console.log('$(git describe --tags --exclude *rc*)'.split('-')[1])")
+
+            # release-please only ignores releases that have a form like [A-Z0-9]<version>, so prefixing with rc<version>
+            RELEASE_NAME="rc$RELEASE_VERSION"
+          else
+            MAIN_RELEASE_VERSION=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
+            RELEASE_VERSION="$MAIN_RELEASE_VERSION"
+            RELEASE_NAME="v$RELEASE_VERSION"
+          fi
+
+          echo "MAIN_RELEASE_VERSION=${MAIN_RELEASE_VERSION}" >> "${GITHUB_ENV}"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_ENV}"
+          echo "RELEASE_CANDIDATE=${RELEASE_CANDIDATE}" >> "${GITHUB_ENV}"
+          echo "RELEASE_NAME=${RELEASE_NAME}" >> "${GITHUB_ENV}"
+
+          echo "MAIN_RELEASE_VERSION=${MAIN_RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "RELEASE_CANDIDATE=${RELEASE_CANDIDATE}" >> "${GITHUB_OUTPUT}"
+          echo "RELEASE_NAME=${RELEASE_NAME}" >> "${GITHUB_OUTPUT}"
+
       - uses: actions/setup-go@v3
+        if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
         with:
           go-version: "^1.21.0" # The Go version to download (if necessary) and use.
 
-      - run: make deps
-      - run: make all
-      - run: ln -s auth gotrue
-      - run: tar -czvf auth-v${{ needs.release.outputs.version }}-x86.tar.gz auth gotrue migrations/
-      - run: mv auth-arm64 auth
-      - run: tar -czvf auth-v${{ needs.release.outputs.version }}-arm64.tar.gz auth gotrue migrations/
+      - name: Build release artifacts
+        if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
+        run: |
+          set -ex
 
-      - uses: AButler/upload-release-assets@v2.0
-        with:
-          files: "auth-v${{ needs.release.outputs.version }}*.tar.gz"
-          release-tag: v${{ needs.release.outputs.version }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION=$RELEASE_VERSION make deps
+          RELEASE_VERSION=$RELEASE_VERSION make all
+          ln -s auth gotrue
+          tar -czvf auth-v$RELEASE_VERSION-x86.tar.gz auth gotrue migrations/
+          mv auth-arm64 auth
+          tar -czvf auth-v$RELEASE_VERSION-arm64.tar.gz auth gotrue migrations/
+
+      - name: Upload release artifacts
+        if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
+        run: |
+          set -ex
+
+          if [ "$RELEASE_CANDIDATE" == "true" ]
+          then
+            PR_NUMBER='${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).number }}'
+
+            GH_TOKEN='${{ github.token }}' gh release \
+              create $RELEASE_NAME \
+              --title "v$RELEASE_VERSION" \
+              --prerelease \
+              -n "This is a release candidate. See release-please PR #$PR_NUMBER for context."
+
+            GH_TOKEN='${{ github.token }}' gh pr comment "$PR_NUMBER" \
+              -b "Release candidate [v$RELEASE_VERSION](https://github.com/hf/gotrue-release-please-test/releases/tag/$RELEASE_NAME) published."
+          else
+            if [ "$GITHUB_REF" == "refs/heads/main" ] || [ "$GITHUB_REF" == "refs/heads/master" ]
+            then
+              IS_PATCH_ZERO=$(node -e "console.log('$RELEASE_VERSION'.endsWith('.0'))")
+
+              if [ "$IS_PATCH_ZERO" == "true" ]
+              then
+                # Only create release branch if patch version is 0, as this
+                # means that the release can be patched in the future.
+
+                GH_TOKEN='${{ github.token }}' gh api \
+                  --method POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  /repos/hf/gotrue-release-please-test/git/refs \
+                  -f "ref=refs/heads/release/${RELEASE_VERSION}" \
+                  -f "sha=$GITHUB_SHA"
+                fi
+              fi
+          fi
+
+          GH_TOKEN='${{ github.token }}' gh release upload $RELEASE_NAME ./auth-v$RELEASE_VERSION-x86.tar.gz ./auth-v$RELEASE_VERSION-arm64.tar.gz
 
   publish:
     needs:
-      - release
-    if: success() && needs.release.outputs.status == 'true'
-    # Call publish explicitly because events from actions cannot trigger more actions
+      - release_please
+    if: ${{ success() && needs.release_please.outputs.RELEASE_NAME }}
     uses: ./.github/workflows/publish.yml
-    with:
-      version: v${{ needs.release.outputs.version }}
     secrets: inherit
+    with:
+      version: ${{ needs.release_please.outputs.RELEASE_NAME }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 .PHONY: all build deps dev-deps image migrate test vet sec format unused
 CHECK_FILES?=./...
-FLAGS?=-ldflags "-X github.com/supabase/auth/internal/utilities.Version=`git describe --tags`" -buildvcs=false
+
+FLAGS=-ldflags "-X github.com/supabase/auth/internal/utilities.Version=`git describe --tags`" -buildvcs=false
+ifdef RELEASE_VERSION
+	FLAGS=-ldflags "-X github.com/supabase/auth/internal/utilities.Version=$(RELEASE_VERSION)" -buildvcs=false
+endif
+
 DEV_DOCKER_COMPOSE:=docker-compose-dev.yml
 
 help: ## Show this help.


### PR DESCRIPTION
Adds a new release process based on [release-please](https://github.com/googleapis/release-please).

As soon as this gets merged, releases will work as follows:

1. PR merges will be collected by release-please into a release PR. The team at Supabase decides when a release is ready to go out, usually weekly or bi-weekly.
2. Every PR merge (that uses `feat:` or `fix:` titles) will result in a release candidate release with tag `rc<version>`. Example: if the new release will be `2.140.0` then the RC release will be `rc2.140-rc.1`, and so on.
3. Once the release PR is merged, an official release will be published with the tag `v<version>`, or per the example `v2.140.0`.
4. Releases with a patch version of `0` get a special branch `release/v2.140.0` which can be used to patch that and only that major+minor version, using the same process as above.

For an illustration, check this repo where I used to test the script: https://github.com/hf/gotrue-release-please-test

