### PR TITLE
fix: improve perf in account linking

### DIFF
--- a/internal/models/linking.go
+++ b/internal/models/linking.go
@@ -72,7 +72,7 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 		}
 
 		// we overwrite the email with the existing user's email since the user
-		// could have an empty empty
+		// could have an empty email
 		candidateEmail.Email = user.GetEmail()
 		return AccountLinkingResult{
 			Decision:       AccountExists,
@@ -109,14 +109,14 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 	var similarIdentities []*Identity
 	var similarUsers []*User
 	// look for similar identities and users based on email
-	if terr := tx.Q().Eager().Where("email ilike any (?)", verifiedEmails).All(&similarIdentities); terr != nil {
+	if terr := tx.Q().Eager().Where("email = any (?)", verifiedEmails).All(&similarIdentities); terr != nil {
 		return AccountLinkingResult{}, terr
 	}
 
 	if !strings.HasPrefix(providerName, "sso:") {
 		// there can be multiple user accounts with the same email when is_sso_user is true
 		// so we just do not consider those similar user accounts
-		if terr := tx.Q().Eager().Where("email ilike any (?) and is_sso_user is false", verifiedEmails).All(&similarUsers); terr != nil {
+		if terr := tx.Q().Eager().Where("lower(email) = any (?) and is_sso_user = false", verifiedEmails).All(&similarUsers); terr != nil {
 			return AccountLinkingResult{}, terr
 		}
 	}

--- a/internal/models/linking.go
+++ b/internal/models/linking.go
@@ -116,7 +116,7 @@ func DetermineAccountLinking(tx *storage.Connection, config *conf.GlobalConfigur
 	if !strings.HasPrefix(providerName, "sso:") {
 		// there can be multiple user accounts with the same email when is_sso_user is true
 		// so we just do not consider those similar user accounts
-		if terr := tx.Q().Eager().Where("lower(email) = any (?) and is_sso_user = false", verifiedEmails).All(&similarUsers); terr != nil {
+		if terr := tx.Q().Eager().Where("email = any (?) and is_sso_user = false", verifiedEmails).All(&similarUsers); terr != nil {
 			return AccountLinkingResult{}, terr
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Currently, we use an `ilike` which doesn't use the index on `auth.identities.email`. Since the emails in the `verifiedEmails` slice only contains lowercased emails, and the `auth.identities.email` are also guaranteed to be lowercase, there is no need for a case-insensitive search
* The partial unique index (`users_email_partial_key`) in auth.users is defined on the condition that `is_sso_user = false`. However, the query uses `is_sso_user is false` which causes it to not use the index ever (along with `ilike`). It would be much faster to do `lower(email) = any (?)` rather than `email ilike any (?)`
* Fixes #1390