### PR TITLE
ci: fix publish step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      MAIN_RELEASE_VERSION: ${{ steps.versions.outputs.MAIN_RELEASE_VERSION }}
+      RELEASE_VERSION: ${{ steps.versions.outputs.RELEASE_VERSION }}
+      RELEASE_CANDIDATE: ${{ steps.versions.outputs.RELEASE_CANDIDATE }}
+      RELEASE_NAME: ${{ steps.versions.outputs.RELEASE_NAME }}
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release


### PR DESCRIPTION
The outputs of the job were not registered.