### PR TITLE
fix: azure not providing email claim with custom tenant url

### DIFF
--- a/internal/api/provider/azure.go
+++ b/internal/api/provider/azure.go
@@ -50,7 +50,7 @@ func NewAzureProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 		return nil, err
 	}
 
-	oauthScopes := []string{"openid"}
+	oauthScopes := []string{"openid", "email"}
 
 	if scopes != "" {
 		oauthScopes = append(oauthScopes, strings.Split(scopes, ",")...)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `email` claim is not returned when using a custom tenant URL, eg. `https://login.microsoftonline.com/c2d53323-1e4f-4f73-ae1e-63ba1aff706b`

This would result in an error like `Error getting user email from external provider`.

Fixes #550, #292

## What is the new behavior?

The email is now returned and auth is successful.

## Additional context

After a whole bunch of debugging, turns out Azure just needed an explicit `email` to be included in the request.