### PR TITLE
fix: unmarshal is_private_email correctly

### DIFF
--- a/internal/api/provider/oidc.go
+++ b/internal/api/provider/oidc.go
@@ -90,8 +90,9 @@ func parseGoogleIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, 
 
 	if claims.Email != "" {
 		data.Emails = append(data.Emails, Email{
-			Email:    claims.Email,
-			Verified: claims.IsEmailVerified(),
+			Email: claims.Email,
+			// Verified: claims.IsEmailVerified(),
+			Verified: false,
 			Primary:  true,
 		})
 	}
@@ -122,8 +123,8 @@ type AppleIDTokenClaims struct {
 
 	Email string `json:"email"`
 
-	AuthTime       *float64 `json:"auth_time"`
-	IsPrivateEmail *bool    `json:"is_private_email,string"`
+	AuthTime       *float64        `json:"auth_time"`
+	IsPrivateEmail *IsPrivateEmail `json:"is_private_email"`
 }
 
 func parseAppleIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, error) {

--- a/internal/api/provider/oidc.go
+++ b/internal/api/provider/oidc.go
@@ -90,9 +90,8 @@ func parseGoogleIDToken(token *oidc.IDToken) (*oidc.IDToken, *UserProvidedData, 
 
 	if claims.Email != "" {
 		data.Emails = append(data.Emails, Email{
-			Email: claims.Email,
-			// Verified: claims.IsEmailVerified(),
-			Verified: false,
+			Email:    claims.Email,
+			Verified: claims.IsEmailVerified(),
 			Primary:  true,
 		})
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Apple returns either a boolean or string value in `is_private_email` which is why we need to implement our own custom unmarshaler to deal with it (https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple)

