### PR TITLE
ci: use `RELEASE_VERSION` instead of `RELEASE_NAME` in publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,8 +133,8 @@ jobs:
   publish:
     needs:
       - release_please
-    if: ${{ success() && needs.release_please.outputs.RELEASE_NAME }}
+    if: ${{ success() && needs.release_please.outputs.RELEASE_VERSION }}
     uses: ./.github/workflows/publish.yml
     secrets: inherit
     with:
-      version: ${{ needs.release_please.outputs.RELEASE_NAME }}
+      version: ${{ needs.release_please.outputs.RELEASE_VERSION }}


### PR DESCRIPTION
Maybe it doesn't want `rc`-prefixed versions?
