### PR TITLE
ci: only calculate release versions if release please detects a version commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - if: ${{ steps.release.outputs }}
+      - if: ${{ steps.release.outputs.release_created == 'true' || steps.release.outputs.prs_created == 'true' }}
         id: versions
         run: |
           set -ex


### PR DESCRIPTION
If release please doesn't detect a version commit, the release name calculation should not run. IDK why that line was left like that.