### PR TITLE
ci: allow revert in commits and PRs

### DIFF
--- a/.github/workflows/conventional-commits-lint.js
+++ b/.github/workflows/conventional-commits-lint.js
@@ -8,6 +8,7 @@ const RELEASE_AS_DIRECTIVE = /^\s*Release-As:/im;
 const BREAKING_CHANGE_DIRECTIVE = /^\s*BREAKING[ \t]+CHANGE:/im;
 
 const ALLOWED_CONVENTIONAL_COMMIT_PREFIXES = [
+  "revert",
   "feat",
   "fix",
   "ci",


### PR DESCRIPTION
Allows the use of the `revert` semantic commit.