### PR TITLE
fix: only create or update the email / phone identity after it's been verified (again)

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -7,9 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/fatih/structs"
 	"github.com/gofrs/uuid"
-	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/api/sms_provider"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
@@ -193,29 +191,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 
-		var identities []models.Identity
 		if params.Email != "" && params.Email != user.GetEmail() {
-			identity, terr := models.FindIdentityByIdAndProvider(tx, user.ID.String(), "email")
-			if terr != nil {
-				if !models.IsNotFoundError(terr) {
-					return terr
-				}
-				// updating the user's email should create a new email identity since the user doesn't have one
-				identity, terr = a.createNewIdentity(tx, user, "email", structs.Map(provider.Claims{
-					Subject: user.ID.String(),
-					Email:   params.Email,
-				}))
-				if terr != nil {
-					return terr
-				}
-			} else {
-				if terr := identity.UpdateIdentityData(tx, map[string]interface{}{
-					"email": params.Email,
-				}); terr != nil {
-					return terr
-				}
-			}
-			identities = append(identities, *identity)
 			mailer := a.Mailer(ctx)
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlowFromChallenge(params.CodeChallenge)
@@ -238,29 +214,13 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if params.Phone != "" && params.Phone != user.GetPhone() {
-			identity, terr := models.FindIdentityByIdAndProvider(tx, user.ID.String(), "phone")
-			if terr != nil {
-				if !models.IsNotFoundError(terr) {
-					return terr
-				}
-				// updating the user's phone should create a new phone identity since the user doesn't have one
-				identity, terr = a.createNewIdentity(tx, user, "phone", structs.Map(provider.Claims{
-					Subject: user.ID.String(),
-					Phone:   params.Phone,
-				}))
-				if terr != nil {
-					return terr
-				}
-			} else {
-				if terr := identity.UpdateIdentityData(tx, map[string]interface{}{
-					"phone": params.Phone,
+			if config.Sms.Autoconfirm {
+				if _, terr := a.smsVerify(r, ctx, tx, user, &VerifyParams{
+					Type:  phoneChangeVerification,
+					Phone: params.Phone,
 				}); terr != nil {
 					return terr
 				}
-			}
-			identities = append(identities, *identity)
-			if config.Sms.Autoconfirm {
-				return user.UpdatePhone(tx, params.Phone)
 			} else {
 				smsProvider, terr := sms_provider.GetSmsProvider(*config)
 				if terr != nil {
@@ -271,7 +231,6 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				}
 			}
 		}
-		user.Identities = append(user.Identities, identities...)
 
 		if terr = models.NewAuditLogEntry(r, tx, user, models.UserModifiedAction, "", nil); terr != nil {
 			return internalServerError("Error recording audit log entry").WithInternalError(terr)


### PR DESCRIPTION
## What kind of change does this PR introduce?
* We only want to create / update the email / phone identity after it's been verified during the email change / phone change flow
* Previously, the email / phone identity was created / updated immediately after the user update endpoint is called. This results in the identity being created before it's been confirmed.

Like #1403, but adding again.