### PR TITLE
ci: add explicit release version in docker build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,14 @@ jobs:
       - uses: docker/setup-qemu-action@v2
         with:
           platforms: amd64,arm64
+
+      - run: |
+          set -ex
+
+          echo "Adding explicit release version to Dockerfile..."
+
+          sed -i 's/RELEASE_VERSION=unspecified/RELEASE_VERSION=${{ inputs.version }}/' Dockerfile
+
       - uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN make deps
 
 # Building stuff
 COPY . /go/src/github.com/supabase/auth
-RUN make build
+
+# Make sure you change the RELEASE_VERSION value before publishing an image.
+RUN RELEASE_VERSION=unspecified make build
 
 FROM alpine:3.17
 RUN adduser -D -u 1000 supabase


### PR DESCRIPTION
Publishing builds the image, but the Makefile uses `git describe --tags` for the version if the `RELEASE_VERSION` env var is not defined. And this is an issue because the `.git` directory is not included in the image (and it shouldn't be). Furthermore, the describe tags does not reflect the proper version name.