### PR TITLE
feat: deprecate existing webhook implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,8 @@ Default Content (if template is unavailable):
 <p><a href="{{ .ConfirmationURL }}">Change Email</a></p>
 ```
 
+> ⚠️ As of 12th Feb 2024, Webhooks are deprecated and will be removed in the next release. We will be replacing the existing Webhooks implementation with a similar HTTP Hook system in the coming weeks.
+
 `WEBHOOK_URL` - `string`
 
 Url of the webhook receiver endpoint. This will be called when events like `validate`, `signup` or `login` occur.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -67,7 +67,7 @@ func (a *API) deprecationNotices(ctx context.Context) {
 		log.Warn("DEPRECATION NOTICE: GOTRUE_JWT_DEFAULT_GROUP_NAME not supported by Supabase's GoTrue, will be removed soon")
 	}
 	if config.Webhook.URL != "" {
-		log.Warn("DEPRECATION NOTICE: GOTRUE_WEBHOOK_URL not supported by Supabase's GoTrue, all GOTRUE_WEBHOOK related configuration will be removed soon")
+		log.Warn("DEPRECATION NOTICE: GOTRUE_WEBHOOK_URL not supported by Supabase's GoTrue, all GOTRUE_WEBHOOK related configuration will be removed after v2.139.2")
 	}
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -66,6 +66,9 @@ func (a *API) deprecationNotices(ctx context.Context) {
 	if config.JWT.DefaultGroupName != "" {
 		log.Warn("DEPRECATION NOTICE: GOTRUE_JWT_DEFAULT_GROUP_NAME not supported by Supabase's GoTrue, will be removed soon")
 	}
+	if config.Webhook.URL != "" {
+		log.Warn("DEPRECATION NOTICE: GOTRUE_WEBHOOK_URL not supported by Supabase's GoTrue, all GOTRUE_WEBHOOK related configuration will be removed soon")
+	}
 }
 
 // NewAPIWithVersion creates a new REST API using the specified version


### PR DESCRIPTION
## What kind of change does this PR introduce?

We deprecate the existing HTTP webhook implementation to make way for Auth HTTP Hooks. We put up a deprecation notice as a warning and fully deprecate the configuration in the next release

## What is the current behavior?

We have webhooks but it is unused on the Supabase Auth platform

## What is the new behavior?

We remove webhooks in this PR and add [Standard Webhooks compliant](https://www.standardwebhooks.com/) HTTP Hooks.

We should also add a deprecation notice on the release

## Additional context

