### PR TITLE
feat: update publish.yml checkout repository so there is access to Dockerfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
       - id: meta
         uses: docker/metadata-action@v4
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the `Dockerfile` can't be read as the [repository might not be cloned](https://github.com/supabase/gotrue/actions/runs/7869435581/job/21468831486#step:4:42)

This PR downloads the repository to allow access to the `Dockerfile`