### PR TITLE
feat: drop sha hash tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,6 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=sha,enable=true
             type=semver,pattern={{version}},value=${{ inputs.version }},enable=true
 
       - uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
## What kind of change does this PR introduce?

We currently publish a version with  [`sha-<version`](https://hub.docker.com/r/supabase/gotrue/tags) 

This might not be intended: https://supabase.slack.com/archives/C022071RB2L/p1707820895946899?thread_ts=1707807464.786769&cid=C022071RB2L so we drop it for now