### PR TITLE
feat: prefix release with v

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern={{version}},value=${{ inputs.version }},enable=true
+            type=semver,pattern=v{{version}},value=${{ inputs.version }},enable=true
 
       - uses: docker/setup-qemu-action@v2
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, our release tag is the version 2.139.0 while AIO expects a v prefix (e.g. v2.139.0). We add an additional v to adjust for that