### PR TITLE
feat: alter tag to use raw

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=v${{ inputs.version }}
+            type=raw,value=v${{ inputs.version }},enable=true
 
       - uses: docker/setup-qemu-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern=v{{version}},value=${{ inputs.version }},enable=true
+            type=raw,value=v${{ inputs.version }}
 
       - uses: docker/setup-qemu-action@v2
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Mirror Supabase Storage and use the [raw tag](https://github.com/supabase/storage/blob/master/.github/workflows/release.yml#L59C13-L59C29)

Currently, v tag [still doesn't show up](https://hub.docker.com/r/supabase/gotrue/tags)