### PR TITLE
fix: use email change email in identity

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -520,14 +520,14 @@ func (a *API) emailChangeVerify(r *http.Request, ctx context.Context, conn *stor
 			// confirming the email change should create a new email identity if the user doesn't have one
 			if _, terr = a.createNewIdentity(tx, user, "email", structs.Map(provider.Claims{
 				Subject:       user.ID.String(),
-				Email:         params.Email,
+				Email:         user.EmailChange,
 				EmailVerified: true,
 			})); terr != nil {
 				return terr
 			}
 		} else {
 			if terr := identity.UpdateIdentityData(tx, map[string]interface{}{
-				"email":          params.Email,
+				"email":          user.EmailChange,
 				"email_verified": true,
 			}); terr != nil {
 				return terr


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes a bug in https://github.com/supabase/gotrue/pull/1409 where the new email is not being used in the email identity created