### PR TITLE
fix: update phone if autoconfirm is enabled

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -215,6 +215,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 		if params.Phone != "" && params.Phone != user.GetPhone() {
 			if config.Sms.Autoconfirm {
+				user.PhoneChange = params.Phone
 				if _, terr := a.smsVerify(r, ctx, tx, user, &VerifyParams{
 					Type:  phoneChangeVerification,
 					Phone: params.Phone,

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -197,6 +197,13 @@ func (ts *UserTestSuite) TestUserUpdatePhoneAutoconfirmEnabled() {
 			w := httptest.NewRecorder()
 			ts.API.handler.ServeHTTP(w, req)
 			require.Equal(ts.T(), c.expectedCode, w.Code)
+
+			if c.expectedCode == http.StatusOK {
+				// check that the user response returned contains the updated phone field
+				data := &models.User{}
+				require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+				require.Equal(ts.T(), data.GetPhone(), c.userData["phone"])
+			}
 		})
 	}
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -305,12 +305,6 @@ func (u *User) UpdatePassword(tx *storage.Connection, sessionID *uuid.UUID) erro
 	}
 }
 
-// UpdatePhone updates the user's phone
-func (u *User) UpdatePhone(tx *storage.Connection, phone string) error {
-	u.Phone = storage.NullString(phone)
-	return tx.UpdateOnly(u, "phone")
-}
-
 // Authenticate a user from a password
 func (u *User) Authenticate(ctx context.Context, password string) bool {
 	err := crypto.CompareHashAndPassword(ctx, u.EncryptedPassword, password)


### PR DESCRIPTION
## What kind of change does this PR introduce?
* In #1407, the update user endpoint was refactored to use `smsVerify` if `GOTRUE_SMS_AUTOCONFIRM`  is enabled. However, `smsVerify` doesn't update the user's phone number to the new one. This PR aims to fix that.