### PR TITLE
fix: error should be an IsNotFoundError

### DIFF
--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -9,6 +9,8 @@ func IsNotFoundError(err error) bool {
 		return true
 	case ConfirmationTokenNotFoundError, *ConfirmationTokenNotFoundError:
 		return true
+	case ConfirmationOrRecoveryTokenNotFoundError, *ConfirmationOrRecoveryTokenNotFoundError:
+		return true
 	case RefreshTokenNotFoundError, *RefreshTokenNotFoundError:
 		return true
 	case IdentityNotFoundError, *IdentityNotFoundError:


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `ConfirmationOrRecoveryTokenNotFoundError` should be an `IsNotFoundError`