### PR TITLE
ci: fix release version name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - id: meta
         uses: docker/metadata-action@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CHECK_FILES?=./...
 
 FLAGS=-ldflags "-X github.com/supabase/auth/internal/utilities.Version=`git describe --tags`" -buildvcs=false
 ifdef RELEASE_VERSION
-	FLAGS=-ldflags "-X github.com/supabase/auth/internal/utilities.Version=$(RELEASE_VERSION)" -buildvcs=false
+	FLAGS=-ldflags "-X github.com/supabase/auth/internal/utilities.Version=v$(RELEASE_VERSION)" -buildvcs=false
 endif
 
 DEV_DOCKER_COMPOSE:=docker-compose-dev.yml


### PR DESCRIPTION
## What kind of change does this PR introduce?
- the healthcheck endpoint uses the `RELEASE_VERSION` value set during the CI process
- it should have a `v` prefix in the version name