### PR TITLE
fix: populate password verification attempt hook

### DIFF
--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -605,9 +605,9 @@ func (ts *TokenTestSuite) TestPasswordVerificationHook() {
 			uri:  "pg-functions://postgres/auth/password_verification_hook",
 			hookFunctionSQL: `
                 create or replace function password_verification_hook(input jsonb)
-                returns json as $$
+                returns jsonb as $$
                 begin
-                    return json_build_object('decision', 'continue');
+                    return jsonb_build_object('decision', 'continue');
                 end; $$ language plpgsql;`,
 			expectedCode: http.StatusOK,
 		}, {
@@ -615,9 +615,9 @@ func (ts *TokenTestSuite) TestPasswordVerificationHook() {
 			uri:  "pg-functions://postgres/auth/password_verification_hook_reject",
 			hookFunctionSQL: `
                 create or replace function password_verification_hook_reject(input jsonb)
-                returns json as $$
+                returns jsonb as $$
                 begin
-                    return json_build_object('decision', 'reject');
+                    return jsonb_build_object('decision', 'reject', 'message', 'You shall not pass!');
                 end; $$ language plpgsql;`,
 			expectedCode: http.StatusForbidden,
 		},

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -517,8 +517,8 @@ func LoadGlobal(filename string) (*GlobalConfiguration, error) {
 		return nil, err
 	}
 
-	if config.Hook.CustomAccessToken.Enabled {
-		if err := config.Hook.CustomAccessToken.PopulateExtensibilityPoint(); err != nil {
+	if config.Hook.PasswordVerificationAttempt.Enabled {
+		if err := config.Hook.PasswordVerificationAttempt.PopulateExtensibilityPoint(); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

We currently don't populate the hook name for the password verification hook.