### PR TITLE
feat: transfer app_metadata from hook response to access token response when using custom access token hook

### DIFF
--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -215,9 +215,9 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 			require.NoError(ts.T(), err)
 			sharedSecret := ts.TestOTPKey.Secret()
 			factors, err := models.FindFactorsByUser(ts.API.db, ts.TestUser)
+			require.NoError(ts.T(), err)
 			f := factors[0]
 			f.Secret = sharedSecret
-			require.NoError(ts.T(), err)
 			require.NoError(ts.T(), ts.API.db.Update(f), "Error updating new test factor")
 
 			// Create session to be invalidated

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -209,7 +209,6 @@ func (ts *MFATestSuite) TestMFAVerifyFactor() {
 	for _, v := range cases {
 		ts.Run(v.desc, func() {
 			// Authenticate users and set secret
-
 			var buffer bytes.Buffer
 			r, err := models.GrantAuthenticatedUser(ts.API.db, ts.TestUser, models.GrantParams{})
 			require.NoError(ts.T(), err)

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -353,6 +353,11 @@ func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, u
 			return "", 0, err
 		}
 		goTrueClaims := jwt.MapClaims(output.Claims)
+		appMetadata, ok := goTrueClaims["AppMetadata"].(map[string]interface{})
+		if !ok {
+			return "", 0, internalServerError("Error loading AppMetadata")
+		}
+		user.AppMetaData = appMetadata
 
 		token = jwt.NewWithClaims(jwt.SigningMethodHS256, goTrueClaims)
 

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -355,7 +355,7 @@ func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, u
 		goTrueClaims := jwt.MapClaims(output.Claims)
 		appMetadata, ok := goTrueClaims["app_metadata"].(map[string]interface{})
 		if !ok {
-			return "", 0, internalServerError("Error loading App Metadata")
+			return "", 0, internalServerError("error reading app metadata from hook response")
 		}
 		user.AppMetaData = appMetadata
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Developers may wish to easily access the app metadata on the response from `/token` for easy use instead of decrypting the token with JWT Secret

Only claims listed on `app_metadata` will be copied over and returned as part of the user response