### PR TITLE
feat: refactor PKCE FlowState to reduce duplicate code

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -84,7 +84,6 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 		if err != nil {
 			return "", err
 		}
-
 		if err := a.db.Create(flowState); err != nil {
 			return "", err
 		}

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -80,11 +80,10 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 
 	flowStateID := ""
 	if isPKCEFlow(flowType) {
-		codeChallengeMethodType, err := models.ParseCodeChallengeMethod(codeChallengeMethod)
+		flowState, err := generateFlowState(providerType, models.OAuth, codeChallengeMethod, codeChallenge, nil)
 		if err != nil {
 			return "", err
 		}
-		flowState := models.NewFlowState(providerType, codeChallenge, codeChallengeMethodType, models.OAuth, nil)
 
 		if err := a.db.Create(flowState); err != nil {
 			return "", err

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -79,15 +79,13 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 	flowType := getFlowFromChallenge(codeChallenge)
 
 	flowStateID := ""
-	if flowType == models.PKCEFlow {
+	if isPKCEFlow(flowType) {
 		codeChallengeMethodType, err := models.ParseCodeChallengeMethod(codeChallengeMethod)
 		if err != nil {
 			return "", err
 		}
-		flowState, err := models.NewFlowState(providerType, codeChallenge, codeChallengeMethodType, models.OAuth)
-		if err != nil {
-			return "", err
-		}
+		flowState := models.NewFlowState(providerType, codeChallenge, codeChallengeMethodType, models.OAuth, nil)
+
 		if err := a.db.Create(flowState); err != nil {
 			return "", err
 		}

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -128,7 +128,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	var flowState *models.FlowState
 
 	if isPKCEFlow(flowType) {
-		flowState, err = generateFlowState(flowType, models.MagicLink, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+		flowState, err = generateFlowState(models.MagicLink, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -128,7 +128,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 	var flowState *models.FlowState
 
 	if isPKCEFlow(flowType) {
-		flowState, err = generateFlowState(models.MagicLink, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+		flowState, err = generateFlowState(models.MagicLink.String(), models.MagicLink, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -3,6 +3,7 @@ package api
 import (
 	"regexp"
 
+	"github.com/gofrs/uuid"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
 )
@@ -76,4 +77,14 @@ func getFlowFromChallenge(codeChallenge string) models.FlowType {
 	} else {
 		return models.ImplicitFlow
 	}
+}
+
+func generateFlowState(flowType models.FlowType, authenticationMethod models.AuthenticationMethod, codeChallengeMethodParam string, codeChallenge string, userID *uuid.UUID) (*models.FlowState, error) {
+	codeChallengeMethod, err := models.ParseCodeChallengeMethod(codeChallengeMethodParam)
+	if err != nil {
+		return nil, err
+	}
+	flowState := models.NewFlowState(authenticationMethod.String(), codeChallenge, codeChallengeMethod, authenticationMethod, userID)
+	return flowState, nil
+
 }

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -80,12 +80,12 @@ func getFlowFromChallenge(codeChallenge string) models.FlowType {
 }
 
 // Should only be used with Auth Code of PKCE Flows
-func generateFlowState(authenticationMethod models.AuthenticationMethod, codeChallengeMethodParam string, codeChallenge string, userID *uuid.UUID) (*models.FlowState, error) {
+func generateFlowState(providerType string, authenticationMethod models.AuthenticationMethod, codeChallengeMethodParam string, codeChallenge string, userID *uuid.UUID) (*models.FlowState, error) {
 	codeChallengeMethod, err := models.ParseCodeChallengeMethod(codeChallengeMethodParam)
 	if err != nil {
 		return nil, err
 	}
-	flowState := models.NewFlowState(authenticationMethod.String(), codeChallenge, codeChallengeMethod, authenticationMethod, userID)
+	flowState := models.NewFlowState(providerType, codeChallenge, codeChallengeMethod, authenticationMethod, userID)
 	return flowState, nil
 
 }

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -79,7 +79,8 @@ func getFlowFromChallenge(codeChallenge string) models.FlowType {
 	}
 }
 
-func generateFlowState(flowType models.FlowType, authenticationMethod models.AuthenticationMethod, codeChallengeMethodParam string, codeChallenge string, userID *uuid.UUID) (*models.FlowState, error) {
+// Should only be used with Auth Code of PKCE Flows
+func generateFlowState(authenticationMethod models.AuthenticationMethod, codeChallengeMethodParam string, codeChallenge string, userID *uuid.UUID) (*models.FlowState, error) {
 	codeChallengeMethod, err := models.ParseCodeChallengeMethod(codeChallengeMethodParam)
 	if err != nil {
 		return nil, err

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -58,7 +58,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	}
 	var flowState *models.FlowState
 	if isPKCEFlow(flowType) {
-		flowState, err = generateFlowState(models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID))
+		flowState, err = generateFlowState(models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID))
 		if err != nil {
 			return err
 		}

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -58,7 +58,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	}
 	var flowState *models.FlowState
 	if isPKCEFlow(flowType) {
-		flowState, err = generateFlowState(flowType, models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID))
+		flowState, err = generateFlowState(models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID))
 		if err != nil {
 			return err
 		}

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -75,7 +75,6 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 		}
-
 		externalURL := getExternalHost(ctx)
 		return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType)
 	})

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -231,7 +231,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 				if isPKCEFlow(flowType) {
-					flowState, terr := generateFlowState(params.Provider, models.EmailSignup, params.CodeChallenge, params.CodeChallengeMethod, &user.ID)
+					flowState, terr := generateFlowState(params.Provider, models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 					if err != nil {
 						return terr
 					}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -232,7 +232,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				}
 				if isPKCEFlow(flowType) {
 					flowState, terr := generateFlowState(params.Provider, models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
-					if err != nil {
+					if terr != nil {
 						return terr
 					}
 					if terr := tx.Create(flowState); terr != nil {

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -237,8 +237,9 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				}); terr != nil {
 					return terr
 				}
-				if ok := isPKCEFlow(flowType); ok {
-					if terr := models.NewFlowStateWithUserID(tx, params.Provider, params.CodeChallenge, codeChallengeMethod, models.EmailSignup, &user.ID); terr != nil {
+				if isPKCEFlow(flowType) {
+					flowState := models.NewFlowState(params.Provider, params.CodeChallenge, codeChallengeMethod, models.EmailSignup, &user.ID)
+					if terr := tx.Create(flowState); terr != nil {
 						return terr
 					}
 				}

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -61,7 +61,7 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	var flowStateID *uuid.UUID
 	flowStateID = nil
 	if isPKCEFlow(flowType) {
-		flowState, err := generateFlowState(flowType, models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
+		flowState, err := generateFlowState(models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -61,7 +61,7 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	var flowStateID *uuid.UUID
 	flowStateID = nil
 	if isPKCEFlow(flowType) {
-		flowState, err := generateFlowState(models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
+		flowState, err := generateFlowState(models.SSOSAML.String(), models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -60,12 +60,8 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	flowType := getFlowFromChallenge(params.CodeChallenge)
 	var flowStateID *uuid.UUID
 	flowStateID = nil
-	if flowType == models.PKCEFlow {
-		codeChallengeMethodType, err := models.ParseCodeChallengeMethod(codeChallengeMethod)
-		if err != nil {
-			return err
-		}
-		flowState, err := models.NewFlowState(models.SSOSAML.String(), codeChallenge, codeChallengeMethodType, models.SSOSAML)
+	if isPKCEFlow(flowType) {
+		flowState, err := generateFlowState(flowType, models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -306,8 +306,7 @@ func (ts *TokenTestSuite) TestTokenPKCEGrantFailure() {
 	invalidVerifier := codeVerifier + "123"
 	codeChallenge := sha256.Sum256([]byte(codeVerifier))
 	challenge := base64.RawURLEncoding.EncodeToString(codeChallenge[:])
-	flowState, err := models.NewFlowState("github", challenge, models.SHA256, models.OAuth)
-	require.NoError(ts.T(), err)
+	flowState := models.NewFlowState("github", challenge, models.SHA256, models.OAuth, nil)
 	flowState.AuthCode = authCode
 	require.NoError(ts.T(), ts.API.db.Create(flowState))
 	cases := []struct {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -197,11 +197,12 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlowFromChallenge(params.CodeChallenge)
 			if isPKCEFlow(flowType) {
-				codeChallengeMethod, terr := models.ParseCodeChallengeMethod(params.CodeChallengeMethod)
-				if terr != nil {
-					return terr
+				flowState, err := generateFlowState(flowType, models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+				if err != nil {
+					return err
 				}
-				if terr := models.NewFlowStateWithUserID(tx, models.EmailChange.String(), params.CodeChallenge, codeChallengeMethod, models.EmailChange, &user.ID); terr != nil {
+
+				if terr := tx.Create(flowState); terr != nil {
 					return terr
 				}
 			}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -197,7 +197,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlowFromChallenge(params.CodeChallenge)
 			if isPKCEFlow(flowType) {
-				flowState, err := generateFlowState(models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+				flowState, err := generateFlowState(models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 				if err != nil {
 					return err
 				}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -197,9 +197,9 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlowFromChallenge(params.CodeChallenge)
 			if isPKCEFlow(flowType) {
-				flowState, err := generateFlowState(models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
-				if err != nil {
-					return err
+				flowState, terr := generateFlowState(models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+				if terr != nil {
+					return terr
 				}
 
 				if terr := tx.Create(flowState); terr != nil {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -197,7 +197,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlowFromChallenge(params.CodeChallenge)
 			if isPKCEFlow(flowType) {
-				flowState, err := generateFlowState(flowType, models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+				flowState, err := generateFlowState(models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 				if err != nil {
 					return err
 				}

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -661,8 +661,8 @@ func (ts *VerifyTestSuite) TestVerifyPKCEOTP() {
 			var buffer bytes.Buffer
 			require.NoError(ts.T(), json.NewEncoder(&buffer).Encode(c.payload))
 			codeChallenge := "codechallengecodechallengcodechallengcodechallengcodechallenge" + c.payload.Type
-			err := models.NewFlowStateWithUserID(ts.API.db, c.authenticationMethod.String(), codeChallenge, models.SHA256, c.authenticationMethod, &u.ID)
-			require.NoError(ts.T(), err)
+			flowState := models.NewFlowState(c.authenticationMethod.String(), codeChallenge, models.SHA256, c.authenticationMethod, &u.ID)
+			require.NoError(ts.T(), ts.API.db.Create(flowState))
 
 			requestUrl := fmt.Sprintf("http://localhost/verify?type=%v&token=%v", c.payload.Type, c.payload.Token)
 			req := httptest.NewRequest(http.MethodGet, requestUrl, &buffer)

--- a/internal/models/flow_state.go
+++ b/internal/models/flow_state.go
@@ -81,21 +81,7 @@ func (FlowState) TableName() string {
 	return tableName
 }
 
-func NewFlowState(providerType, codeChallenge string, codeChallengeMethod CodeChallengeMethod, authenticationMethod AuthenticationMethod) (*FlowState, error) {
-	id := uuid.Must(uuid.NewV4())
-	authCode := uuid.Must(uuid.NewV4())
-	flowState := &FlowState{
-		ID:                   id,
-		ProviderType:         providerType,
-		CodeChallenge:        codeChallenge,
-		CodeChallengeMethod:  codeChallengeMethod.String(),
-		AuthCode:             authCode.String(),
-		AuthenticationMethod: authenticationMethod.String(),
-	}
-	return flowState, nil
-}
-
-func NewFlowStateWithUserID(tx *storage.Connection, providerType, codeChallenge string, codeChallengeMethod CodeChallengeMethod, authenticationMethod AuthenticationMethod, userID *uuid.UUID) error {
+func NewFlowState(providerType, codeChallenge string, codeChallengeMethod CodeChallengeMethod, authenticationMethod AuthenticationMethod, userID *uuid.UUID) *FlowState {
 	id := uuid.Must(uuid.NewV4())
 	authCode := uuid.Must(uuid.NewV4())
 	flowState := &FlowState{
@@ -107,7 +93,7 @@ func NewFlowStateWithUserID(tx *storage.Connection, providerType, codeChallenge 
 		AuthenticationMethod: authenticationMethod.String(),
 		UserID:               userID,
 	}
-	return tx.Create(flowState)
+	return flowState
 }
 
 func FindFlowStateByAuthCode(tx *storage.Connection, authCode string) (*FlowState, error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Removes `NewFlowStateWithUserID` - it is sufficient to have one method to create a flow state
- Compresses some of the PKCE checks into a single function
