### PR TITLE
fix: update file name so migration to Drop IP Address is applied

### DIFF
--- a/migrations/20240115144230_remove_ip_address_from_saml_relay_state.sql
+++ b/migrations/20240115144230_remove_ip_address_from_saml_relay_state.sql
@@ -1,7 +1,0 @@
-do $$
-begin
-   if exists (select from information_schema.columns where table_schema = '{{ index .Options "Namespace" }}' and table_name = 'saml_relay_states' and column_name = 'from_ip_address') then
-      alter table {{ index .Options "Namespace" }}.saml_relay_states drop column from_ip_address;
-   end if;
-end
-$$;

--- a/migrations/20240115144230_remove_ip_address_from_saml_relay_state.up.sql
+++ b/migrations/20240115144230_remove_ip_address_from_saml_relay_state.up.sql
@@ -1,0 +1,7 @@
+do $$
+begin
+   if exists (select from information_schema.columns where table_schema = '{{ index .Options "Namespace" }}' and table_name = 'saml_relay_states' and column_name = 'from_ip_address') then
+      alter table {{ index .Options "Namespace" }}.saml_relay_states drop column from_ip_address;
+   end if;
+end
+$$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

We need to have the `.up.sql` postfix for auth to detect the migration