### PR TITLE
feat: clean up test setup in MFA tests

### DIFF
--- a/internal/models/sessions_test.go
+++ b/internal/models/sessions_test.go
@@ -74,14 +74,14 @@ func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
 	firstClaimAddedTime := time.Now()
 	session = ts.AddClaimAndReloadSession(session, TOTPSignIn)
 
-	aal, amr, err := session.CalculateAALAndAMR(u)
+	_, _, err = session.CalculateAALAndAMR(u)
 	require.NoError(ts.T(), err)
 
 	session = ts.AddClaimAndReloadSession(session, TOTPSignIn)
 
 	session = ts.AddClaimAndReloadSession(session, SSOSAML)
 
-	aal, amr, err = session.CalculateAALAndAMR(u)
+	aal, amr, err := session.CalculateAALAndAMR(u)
 	require.NoError(ts.T(), err)
 
 	require.Equal(ts.T(), AAL2.String(), aal)

--- a/internal/models/sessions_test.go
+++ b/internal/models/sessions_test.go
@@ -53,44 +53,51 @@ func (ts *SessionsTestSuite) TestFindBySessionIDWithForUpdate() {
 	require.Equal(ts.T(), session.ID, found.ID)
 }
 
+func (ts *SessionsTestSuite) AddClaimAndReloadSession(session *Session, claim AuthenticationMethod) *Session {
+	err := AddClaimToSession(ts.db, session.ID, claim)
+	require.NoError(ts.T(), err)
+	session, err = FindSessionByID(ts.db, session.ID, false)
+	require.NoError(ts.T(), err)
+	return session
+}
+
 func (ts *SessionsTestSuite) TestCalculateAALAndAMR() {
-	totalDistinctClaims := 2
+	totalDistinctClaims := 3
 	u, err := FindUserByEmailAndAudience(ts.db, "test@example.com", ts.Config.JWT.Aud)
 	require.NoError(ts.T(), err)
 	session, err := NewSession(u.ID, nil)
 	require.NoError(ts.T(), err)
 	require.NoError(ts.T(), ts.db.Create(session))
 
-	err = AddClaimToSession(ts.db, session.ID, PasswordGrant)
-	require.NoError(ts.T(), err)
+	session = ts.AddClaimAndReloadSession(session, PasswordGrant)
 
 	firstClaimAddedTime := time.Now()
-	err = AddClaimToSession(ts.db, session.ID, TOTPSignIn)
-	require.NoError(ts.T(), err)
-	session, err = FindSessionByID(ts.db, session.ID, false)
-	require.NoError(ts.T(), err)
+	session = ts.AddClaimAndReloadSession(session, TOTPSignIn)
 
 	aal, amr, err := session.CalculateAALAndAMR(u)
 	require.NoError(ts.T(), err)
-	require.Equal(ts.T(), AAL2.String(), aal)
-	require.Equal(ts.T(), totalDistinctClaims, len(amr))
 
-	err = AddClaimToSession(ts.db, session.ID, TOTPSignIn)
-	require.NoError(ts.T(), err)
+	session = ts.AddClaimAndReloadSession(session, TOTPSignIn)
 
-	session, err = FindSessionByID(ts.db, session.ID, false)
-	require.NoError(ts.T(), err)
+	session = ts.AddClaimAndReloadSession(session, SSOSAML)
 
 	aal, amr, err = session.CalculateAALAndAMR(u)
 	require.NoError(ts.T(), err)
 
 	require.Equal(ts.T(), AAL2.String(), aal)
 	require.Equal(ts.T(), totalDistinctClaims, len(amr))
+
 	found := false
 	for _, claim := range session.AMRClaims {
 		if claim.GetAuthenticationMethod() == TOTPSignIn.String() {
 			require.True(ts.T(), firstClaimAddedTime.Before(claim.UpdatedAt))
 			found = true
+		}
+	}
+
+	for _, claim := range amr {
+		if claim.Method == SSOSAML.String() {
+			require.NotNil(ts.T(), claim.Provider)
 		}
 	}
 	require.True(ts.T(), found)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove redundant test setup, particularly around `TestSecondarySession`. 
- Changes `generateToken` into `generateAAL1Token`
- Abstracts adding the claim and reloading a session into a single method. Was probably a mistake to add [AMREntry](https://github.com/supabase/gotrue/blob/e9f38e76d8a7b93c5c2bb0de918a9b156155f018/internal/models/sessions.go#L38). Should sync to use [AMRClaim](https://github.com/supabase/gotrue/blob/e9f38e76d8a7b93c5c2bb0de918a9b156155f018/internal/models/amr.go) at some point
- Add additional check that a provider fields must exist if there's an SSO Claim on the last entry