### PR TITLE
feat: refactor generate access token

### DIFF
--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -49,7 +49,7 @@ func (ts *AuditTestSuite) makeSuperAdmin(email string) string {
 	u.Role = "supabase_admin"
 
 	var token string
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.PasswordGrant)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, "", models.PasswordGrant, models.AAL1.String(), []models.AMREntry{})
 	require.NoError(ts.T(), err, "Error generating access token")
 
 	p := jwt.Parser{ValidMethods: []string{jwt.SigningMethodHS256.Name}}

--- a/internal/api/invite_test.go
+++ b/internal/api/invite_test.go
@@ -60,7 +60,7 @@ func (ts *InviteTestSuite) makeSuperAdmin(email string) string {
 	u.Role = "supabase_admin"
 
 	var token string
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.Invite)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, "", models.Invite, models.AAL1.String(), []models.AMREntry{})
 
 	require.NoError(ts.T(), err, "Error generating access token")
 

--- a/internal/api/logout_test.go
+++ b/internal/api/logout_test.go
@@ -43,7 +43,7 @@ func (ts *LogoutTestSuite) SetupTest() {
 
 	// generate access token to use for logout
 	var t string
-	t, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.PasswordGrant)
+	t, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, "", models.PasswordGrant, models.AAL1.String(), []models.AMREntry{})
 	require.NoError(ts.T(), err)
 	ts.token = t
 }

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -300,7 +300,7 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 		if terr != nil {
 			return terr
 		}
-		token, terr = a.updateMFASessionAndClaims(r, tx, user, models.TOTPSignIn, models.GrantParams{
+		token, terr = a.updateMFASessionAndClaims(ctx, r, tx, user, models.TOTPSignIn, models.GrantParams{
 			FactorID: &factor.ID,
 		})
 		if terr != nil {

--- a/internal/api/mfa_test.go
+++ b/internal/api/mfa_test.go
@@ -91,7 +91,7 @@ func (ts *MFATestSuite) SetupTest() {
 }
 
 func (ts *MFATestSuite) generateAAL1Token(user *models.User, sessionId *uuid.UUID) string {
-	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionId, models.TOTPSignIn)
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionId.String(), models.TOTPSignIn, models.AAL1.String(), []models.AMREntry{})
 	require.NoError(ts.T(), err, "Error generating access token")
 	return token
 }

--- a/internal/api/phone_test.go
+++ b/internal/api/phone_test.go
@@ -157,7 +157,7 @@ func (ts *PhoneTestSuite) TestMissingSmsProviderConfig() {
 	require.NoError(ts.T(), ts.API.db.Update(u), "Error updating new test user")
 
 	var token string
-	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.OTP)
+	token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, "", models.OTP, models.AAL1.String(), []models.AMREntry{})
 	require.NoError(ts.T(), err)
 
 	cases := []struct {

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -47,7 +47,11 @@ func (ts *UserTestSuite) SetupTest() {
 }
 
 func (ts *UserTestSuite) generateToken(user *models.User, sessionId *uuid.UUID) string {
-	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionId, models.PasswordGrant)
+	sessionIDAsString := ""
+	if sessionId != nil {
+		sessionIDAsString = sessionId.String()
+	}
+	token, _, err := ts.API.generateAccessToken(context.Background(), ts.API.db, user, sessionIDAsString, models.PasswordGrant, models.AAL1.String(), []models.AMREntry{})
 	require.NoError(ts.T(), err, "Error generating access token")
 	return token
 }

--- a/internal/api/verify_test.go
+++ b/internal/api/verify_test.go
@@ -179,7 +179,7 @@ func (ts *VerifyTestSuite) TestVerifySecureEmailChange() {
 
 		// Generate access token for request
 		var token string
-		token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, nil, models.MagicLink)
+		token, _, err = ts.API.generateAccessToken(context.Background(), ts.API.db, u, "", models.MagicLink, models.AAL1.String(), []models.AMREntry{})
 		require.NoError(ts.T(), err)
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Aims to refactor generate access token with a few goals:

1. Merge `updateMFASessionAndClaims` into `issueRefreshToken`. Former shouldn't be needed
2. Enforce the pre-condition that one can only call `generateAccessToken` when there is an active session
3. Move token issuing out of the transaction so that any HTTP Hook invoked doesn't block the transaction

Left as draft as there are a few more steps