### PR TITLE
feat: use dummy instance id to improve performance on refresh token queries

### DIFF
--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -105,7 +105,7 @@ func RevokeTokenFamily(tx *storage.Connection, token *RefreshToken) error {
 
 func FindTokenBySessionID(tx *storage.Connection, sessionId *uuid.UUID) (*RefreshToken, error) {
 	refreshToken := &RefreshToken{}
-	err := tx.Q().Where("session_id = ?", sessionId).Order("created_at asc").First(refreshToken)
+	err := tx.Q().Where("instance_id = ? and session_id = ?", uuid.Nil, sessionId).Order("created_at asc").First(refreshToken)
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, RefreshTokenNotFoundError{}
@@ -168,5 +168,5 @@ func createRefreshToken(tx *storage.Connection, user *User, oldToken *RefreshTok
 // Deprecated. For backward compatibility, some access tokens may not have a sessionId. Use models.Logout instead.
 // LogoutAllRefreshTokens deletes all sessions for a user.
 func LogoutAllRefreshTokens(tx *storage.Connection, userId uuid.UUID) error {
-	return tx.RawQuery("DELETE FROM "+(&pop.Model{Value: RefreshToken{}}).TableName()+" WHERE user_id = ?", userId).Exec()
+	return tx.RawQuery("DELETE FROM "+(&pop.Model{Value: RefreshToken{}}).TableName()+" WHERE instance_id = ? and user_id = ?", uuid.Nil, userId).Exec()
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use the nil instance ID so that we can leverage the compound index on instance_id and user_id when performing search and deletion


Aims to address #1449 and #1398. 

We note that `LogoutAllRefreshTokens` was marked as deprecated and may be possible  to remove if all access tokens now have a `sessionId`. Additionally, `FindTokenBySessionID` can likely be replaced  by using `FindCurrentlyActiveRefreshToken`. 

We will revisit these in a week or two but they are out of scope for this PR.