### PR TITLE
fix: improve MFA QR Code resilience so as to support providers like 1Password

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -124,7 +124,7 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 	}
 	var buf bytes.Buffer
 	svgData := svg.New(&buf)
-	qrCode, _ := qr.Encode(key.String(), qr.Q, qr.Auto)
+	qrCode, _ := qr.Encode(key.String(), qr.H, qr.Auto)
 	qs := goqrsvg.NewQrSVG(qrCode, DefaultQRSize)
 	qs.StartQrSVG(svgData)
 	if err = qs.WriteQrSVG(svgData); err != nil {

--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -124,7 +124,7 @@ func (a *API) EnrollFactor(w http.ResponseWriter, r *http.Request) error {
 	}
 	var buf bytes.Buffer
 	svgData := svg.New(&buf)
-	qrCode, _ := qr.Encode(key.String(), qr.M, qr.Auto)
+	qrCode, _ := qr.Encode(key.String(), qr.Q, qr.Auto)
 	qs := goqrsvg.NewQrSVG(qrCode, DefaultQRSize)
 	qs.StartQrSVG(svgData)
 	if err = qs.WriteQrSVG(svgData); err != nil {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reduced version of #1438. This increases the [error correction level](https://pkg.go.dev/github.com/boombuler/barcode@v1.0.1/qr#ErrorCorrectionLevel) which should make the QR Code easier to scan

Other aspects such as visibility of QR code and potentially size adjustments will be handled for later. Want to get the minimal possible change out that might fix the issue

Works with 1Password locally, will test against Supabase setup once merged
