### PR TITLE
fix: customAuthHook update REST response

### DIFF
--- a/internal/api/token_test.go
+++ b/internal/api/token_test.go
@@ -769,7 +769,6 @@ func (ts *TokenTestSuite) TestCustomAccessTokenInResponseUser() {
 		desc            string
 		grantType      string
 		requestBody 	map[string]interface{}
-		expectedUser  map[string]interface{}
 	}
 	var hookFunctionSQL string = ` create or replace function custom_access_token_add_claim(input jsonb) 
 	returns jsonb 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The `AuthTokenResponse` REST response would be updated with data that is modified by the custom access auth hook.

## What is the current behavior?

`AuthTokenResponse` REST response is not updated with data in the custom access auth hook token. #1415

## What is the new behavior?

The `User_metadata` in `User` data of the REST response is in sync `user_metadata` in the access token provided

## Additional context

Add any other context or screenshots.
