### PR TITLE
feat: pass transaction to `invokeHook`, fixing pool exhaustion

### DIFF
--- a/internal/api/mfa.go
+++ b/internal/api/mfa.go
@@ -258,7 +258,7 @@ func (a *API) VerifyFactor(w http.ResponseWriter, r *http.Request) error {
 
 		output := hooks.MFAVerificationAttemptOutput{}
 
-		err := a.invokeHook(ctx, &input, &output)
+		err := a.invokeHook(ctx, nil, &input, &output)
 		if err != nil {
 			return err
 		}

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -170,7 +170,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 			Valid:  isValidPassword,
 		}
 		output := hooks.PasswordVerificationAttemptOutput{}
-		err := a.invokeHook(ctx, &input, &output)
+		err := a.invokeHook(ctx, nil, &input, &output)
 		if err != nil {
 			return err
 		}
@@ -350,7 +350,7 @@ func (a *API) generateAccessToken(ctx context.Context, tx *storage.Connection, u
 
 		output := hooks.CustomAccessTokenOutput{}
 
-		err := a.invokeHook(ctx, &input, &output)
+		err := a.invokeHook(ctx, tx, &input, &output)
 		if err != nil {
 			return "", 0, err
 		}


### PR DESCRIPTION
When invoking a hook, if the invocation is done within an already open transaction, `invokeHook` should not try to open a new transaction. This can easily cause connection pool exhaustion and deadlock.