### PR TITLE
feat: HTTP Hook - Add custom envconfig decoding for HTTP Hook Secrets

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -28,7 +28,7 @@ var postgresNamesRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]{0,62}$`)
 // So this 4 * Math.ceil(24/3) = 32 and 4 * Math.ceil(64/3) = 88 for symmetric secrets
 // Since Ed25519 key is 32 bytes so we have 4 * Math.ceil(32/3) = 44
 var symmetricSecretFormat = regexp.MustCompile(`^v1,whsec_[A-Za-z0-9+/=]{32,88}`)
-var asymmetricSecretFormat = regexp.MustCompile(`^v1a,whpk_[A-Za-z0-9+/=]{44,};whsk_[A-Za-z0-9+/=]{44,}$`)
+var asymmetricSecretFormat = regexp.MustCompile(`^v1a,whpk_[A-Za-z0-9+/=]{44,}:whsk_[A-Za-z0-9+/=]{44,}$`)
 
 // Time is used to represent timestamps in the configuration, as envconfig has
 // trouble parsing empty strings, due to time.Time.UnmarshalText().
@@ -452,11 +452,25 @@ type HookConfiguration struct {
 	CustomSMSProvider           ExtensibilityPointConfiguration `json:"custom_sms_provider" split_words:"true"`
 }
 
+type HTTPHookSecrets []string
+
+func (h *HTTPHookSecrets) Decode(value string) error {
+	parts := strings.Split(value, "|")
+	for _, part := range parts {
+		if part != "" {
+			*h = append(*h, part)
+		}
+	}
+
+	return nil
+}
+
 type ExtensibilityPointConfiguration struct {
-	URI             string   `json:"uri"`
-	Enabled         bool     `json:"enabled"`
-	HookName        string   `json:"hook_name"`
-	HTTPHookSecrets []string `json:"secrets"`
+	URI      string `json:"uri"`
+	Enabled  bool   `json:"enabled"`
+	HookName string `json:"hook_name"`
+	// We use | as a separator for keys and : as a separator for keys within a keypair. For instance: v1,whsec_test|v1a,whpk_myother:v1a,whsk_testkey|v1,whsec_secret3
+	HTTPHookSecrets []string `json:"secrets" envconfig:"secrets"`
 }
 
 func (h *HookConfiguration) Validate() error {


### PR DESCRIPTION
## What kind of change does this PR introduce?

We represent HTTP Hooks as a `|` separated list, similar to what we do with required password characters. Asymmetric keys are separated by `:` like: `v1a,whpk_mypublickey|whsk_mysecretkey:v1,whsec_mysymettrickey`

We opt for `:` and `|` as they are not part of the base64 alphabet which we use to store secrets.