### PR TITLE
fix: move creation of flow state into function

### DIFF
--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -80,11 +80,8 @@ func (a *API) GetExternalProviderRedirectURL(w http.ResponseWriter, r *http.Requ
 
 	flowStateID := ""
 	if isPKCEFlow(flowType) {
-		flowState, err := generateFlowState(providerType, models.OAuth, codeChallengeMethod, codeChallenge, nil)
+		flowState, err := generateFlowState(a.db, providerType, models.OAuth, codeChallengeMethod, codeChallenge, nil)
 		if err != nil {
-			return "", err
-		}
-		if err := a.db.Create(flowState); err != nil {
 			return "", err
 		}
 		flowStateID = flowState.ID.String()

--- a/internal/api/pkce.go
+++ b/internal/api/pkce.go
@@ -80,12 +80,15 @@ func getFlowFromChallenge(codeChallenge string) models.FlowType {
 }
 
 // Should only be used with Auth Code of PKCE Flows
-func generateFlowState(providerType string, authenticationMethod models.AuthenticationMethod, codeChallengeMethodParam string, codeChallenge string, userID *uuid.UUID) (*models.FlowState, error) {
+func generateFlowState(tx *storage.Connection, providerType string, authenticationMethod models.AuthenticationMethod, codeChallengeMethodParam string, codeChallenge string, userID *uuid.UUID) (*models.FlowState, error) {
 	codeChallengeMethod, err := models.ParseCodeChallengeMethod(codeChallengeMethodParam)
 	if err != nil {
 		return nil, err
 	}
 	flowState := models.NewFlowState(providerType, codeChallenge, codeChallengeMethod, authenticationMethod, userID)
+	if err := tx.Create(flowState); err != nil {
+		return nil, err
+	}
 	return flowState, nil
 
 }

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -57,7 +57,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		return internalServerError("Unable to process request").WithInternalError(err)
 	}
 	if isPKCEFlow(flowType) {
-		if _, err := generateFlowState(a.db, models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID)); err != nil {
+		if _, err := generateFlowState(db, models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID)); err != nil {
 			return err
 		}
 	}

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -56,10 +56,8 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		}
 		return internalServerError("Unable to process request").WithInternalError(err)
 	}
-	var flowState *models.FlowState
 	if isPKCEFlow(flowType) {
-		flowState, err = generateFlowState(models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID))
-		if err != nil {
+		if _, err := generateFlowState(a.db, models.Recovery.String(), models.Recovery, params.CodeChallengeMethod, params.CodeChallenge, &(user.ID)); err != nil {
 			return err
 		}
 	}
@@ -70,11 +68,6 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		}
 		mailer := a.Mailer(ctx)
 		referrer := utilities.GetReferrer(r, config)
-		if flowState != nil {
-			if terr := tx.Create(flowState); terr != nil {
-				return terr
-			}
-		}
 		externalURL := getExternalHost(ctx)
 		return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType)
 	})

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -231,7 +231,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 				if isPKCEFlow(flowType) {
-					_, terr := generateFlowState(a.db, params.Provider, models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+					_, terr := generateFlowState(tx, params.Provider, models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 					if terr != nil {
 						return terr
 					}

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -231,11 +231,8 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					return terr
 				}
 				if isPKCEFlow(flowType) {
-					flowState, terr := generateFlowState(params.Provider, models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+					_, terr := generateFlowState(a.db, params.Provider, models.EmailSignup, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 					if terr != nil {
-						return terr
-					}
-					if terr := tx.Create(flowState); terr != nil {
 						return terr
 					}
 				}

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -61,11 +61,8 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	var flowStateID *uuid.UUID
 	flowStateID = nil
 	if isPKCEFlow(flowType) {
-		flowState, err := generateFlowState(models.SSOSAML.String(), models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
+		flowState, err := generateFlowState(a.db, models.SSOSAML.String(), models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
 		if err != nil {
-			return err
-		}
-		if err := a.db.Create(flowState); err != nil {
 			return err
 		}
 		flowStateID = &flowState.ID

--- a/internal/api/sso.go
+++ b/internal/api/sso.go
@@ -61,7 +61,7 @@ func (a *API) SingleSignOn(w http.ResponseWriter, r *http.Request) error {
 	var flowStateID *uuid.UUID
 	flowStateID = nil
 	if isPKCEFlow(flowType) {
-		flowState, err := generateFlowState(a.db, models.SSOSAML.String(), models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
+		flowState, err := generateFlowState(db, models.SSOSAML.String(), models.SSOSAML, codeChallengeMethod, codeChallenge, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -197,14 +197,11 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlowFromChallenge(params.CodeChallenge)
 			if isPKCEFlow(flowType) {
-				flowState, terr := generateFlowState(models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+				_, terr := generateFlowState(a.db, models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 				if terr != nil {
 					return terr
 				}
 
-				if terr := tx.Create(flowState); terr != nil {
-					return terr
-				}
 			}
 			externalURL := getExternalHost(ctx)
 			if terr = a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, externalURL, config.Mailer.OtpLength, flowType); terr != nil {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -197,7 +197,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlowFromChallenge(params.CodeChallenge)
 			if isPKCEFlow(flowType) {
-				_, terr := generateFlowState(a.db, models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
+				_, terr := generateFlowState(tx, models.EmailChange.String(), models.EmailChange, params.CodeChallengeMethod, params.CodeChallenge, &user.ID)
 				if terr != nil {
 					return terr
 				}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Follow up to #1446  Moves the creation of the flow state into `generateFlowState`