### PR TITLE
fix: prevent user email side-channel leak on verify

### DIFF
--- a/internal/api/verify.go
+++ b/internal/api/verify.go
@@ -625,7 +625,7 @@ func (a *API) verifyUserAndToken(conn *storage.Connection, params *VerifyParams,
 
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			return nil, notFoundError(err.Error()).WithInternalError(err)
+			return nil, expiredTokenError("Token has expired or is invalid").WithInternalError(err)
 		}
 		return nil, internalServerError("Database error finding user").WithInternalError(err)
 	}


### PR DESCRIPTION
There is a side-channel leak whether an email exists in the system when using the `verify` endpoint. It returns `User not found` (when it doesn't) vs `Token has expired or is invalid` (when it exists).