### PR TITLE
fix: unlink identity bugs

### DIFF
--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -60,11 +60,23 @@ func (a *API) DeleteIdentity(w http.ResponseWriter, r *http.Request) error {
 		if terr := tx.Destroy(identityToBeDeleted); terr != nil {
 			return internalServerError("Database error deleting identity").WithInternalError(terr)
 		}
-		if terr := user.UpdateUserEmailFromIdentities(tx); terr != nil {
-			if models.IsUniqueConstraintViolatedError(terr) {
-				return forbiddenError("Unable to unlink identity due to email conflict").WithInternalError(terr)
+
+		switch identityToBeDeleted.Provider {
+		case "phone":
+			user.PhoneConfirmedAt = nil
+			if terr := user.SetPhone(tx, ""); terr != nil {
+				return internalServerError("Database error updating user phone").WithInternalError(terr)
 			}
-			return internalServerError("Database error updating user email").WithInternalError(terr)
+			if terr := tx.UpdateOnly(user, "phone_confirmed_at"); terr != nil {
+				return internalServerError("Database error updating user phone").WithInternalError(terr)
+			}
+		default:
+			if terr := user.UpdateUserEmailFromIdentities(tx); terr != nil {
+				if models.IsUniqueConstraintViolatedError(terr) {
+					return forbiddenError("Unable to unlink identity due to email conflict").WithInternalError(terr)
+				}
+				return internalServerError("Database error updating user email").WithInternalError(terr)
+			}
 		}
 		if terr := user.UpdateAppMetaDataProviders(tx); terr != nil {
 			return internalServerError("Database error updating user providers").WithInternalError(terr)

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -262,6 +262,12 @@ func (u *User) UpdateUserEmailFromIdentities(tx *storage.Connection) error {
 	if terr := u.SetEmail(tx, primaryIdentity.GetEmail()); terr != nil {
 		return terr
 	}
+	if primaryIdentity.GetEmail() == "" {
+		u.EmailConfirmedAt = nil
+		if terr := tx.UpdateOnly(u, "email_confirmed_at"); terr != nil {
+			return terr
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* handle removing the user's phone number when the phone identity is unlinked
* handle resetting the user's email if the email identity is unlinked
* add tests 