### PR TITLE
fix: configurable NameID format for SAML provider

### DIFF
--- a/internal/models/sso.go
+++ b/internal/models/sso.go
@@ -115,6 +115,8 @@ type SAMLProvider struct {
 
 	AttributeMapping SAMLAttributeMapping `db:"attribute_mapping" json:"attribute_mapping,omitempty"`
 
+	NameIDFormat *string `db:"name_id_format" json:"name_id_format,omitempty"`
+
 	CreatedAt time.Time `db:"created_at" json:"-"`
 	UpdatedAt time.Time `db:"updated_at" json:"-"`
 }

--- a/migrations/20240314092811_add_saml_name_id_format.up.sql
+++ b/migrations/20240314092811_add_saml_name_id_format.up.sql
@@ -1,0 +1,3 @@
+do $$ begin
+alter table {{ index .Options "Namespace" }}.saml_providers add column if not exists name_id_format text null;
+end $$


### PR DESCRIPTION
#1481 but for 2.144.0.

Adds the ability to specify the [NameID format](https://pkg.go.dev/github.com/crewjam/saml#NameIDFormat) for a SAML SSO provider's authentication request, as some providers don't appear to support accepting the persistent format.