### PR TITLE
fix: add http support for https hooks on localhost

### DIFF
--- a/internal/api/hooks.go
+++ b/internal/api/hooks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/supabase/auth/internal/storage"
 )
 
-func (a *API) runHook(ctx context.Context, tx *storage.Connection, name string, input, output any) ([]byte, error) {
+func (a *API) runPostgresHook(ctx context.Context, tx *storage.Connection, name string, input, output any) ([]byte, error) {
 	db := a.db.WithContext(ctx)
 
 	request, err := json.Marshal(input)
@@ -68,7 +68,7 @@ func (a *API) invokeHook(ctx context.Context, tx *storage.Connection, input, out
 			panic("output should be *hooks.MFAVerificationAttemptOutput")
 		}
 
-		if _, err := a.runHook(ctx, tx, config.Hook.MFAVerificationAttempt.HookName, input, output); err != nil {
+		if _, err := a.runPostgresHook(ctx, tx, config.Hook.MFAVerificationAttempt.HookName, input, output); err != nil {
 			return internalServerError("Error invoking MFA verification hook.").WithInternalError(err)
 		}
 
@@ -94,7 +94,7 @@ func (a *API) invokeHook(ctx context.Context, tx *storage.Connection, input, out
 			panic("output should be *hooks.PasswordVerificationAttemptOutput")
 		}
 
-		if _, err := a.runHook(ctx, tx, config.Hook.PasswordVerificationAttempt.HookName, input, output); err != nil {
+		if _, err := a.runPostgresHook(ctx, tx, config.Hook.PasswordVerificationAttempt.HookName, input, output); err != nil {
 			return internalServerError("Error invoking password verification hook.").WithInternalError(err)
 		}
 
@@ -120,7 +120,7 @@ func (a *API) invokeHook(ctx context.Context, tx *storage.Connection, input, out
 			panic("output should be *hooks.CustomAccessTokenOutput")
 		}
 
-		if _, err := a.runHook(ctx, tx, config.Hook.CustomAccessToken.HookName, input, output); err != nil {
+		if _, err := a.runPostgresHook(ctx, tx, config.Hook.CustomAccessToken.HookName, input, output); err != nil {
 			return internalServerError("Error invoking access token hook.").WithInternalError(err)
 		}
 

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -501,6 +501,12 @@ func (e *ExtensibilityPointConfiguration) ValidateExtensibilityPoint() error {
 	switch strings.ToLower(u.Scheme) {
 	case "pg-functions":
 		return validatePostgresPath(u)
+	case "http":
+		hostname := u.Hostname()
+		if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1" {
+			return validateHTTPSHookSecrets(e.HTTPHookSecrets)
+		}
+		return fmt.Errorf("only localhost, 127.0.0.1, and ::1 are supported with http")
 	case "https":
 		return validateHTTPSHookSecrets(e.HTTPHookSecrets)
 	default:

--- a/internal/conf/configuration_test.go
+++ b/internal/conf/configuration_test.go
@@ -161,8 +161,10 @@ func TestValidateExtensibilityPointURI(t *testing.T) {
 		{desc: "Valid Postgres URI", uri: "pg-functions://postgres/auth/verification_hook_reject", expectError: false},
 		{desc: "Another Valid URI", uri: "pg-functions://postgres/user_management/add_user", expectError: false},
 		{desc: "Another Valid URI", uri: "pg-functions://postgres/MySpeCial/FUNCTION_THAT_YELLS_AT_YOU", expectError: false},
+		{desc: "Valid HTTP URI", uri: "http://localhost/functions/v1/custom-sms-sender", expectError: false},
 
 		// Negative test cases
+		{desc: "Invalid HTTP URI", uri: "http://asdfgggg.website.co/functions/v1/custom-sms-sender", expectError: true},
 		{desc: "Invalid HTTPS URI (HTTP)", uri: "http://asdfgggqqwwerty.supabase.co/functions/v1/custom-sms-sender", expectError: true},
 		{desc: "Invalid Schema Name", uri: "pg-functions://postgres/123auth/verification_hook_reject", expectError: true},
 		{desc: "Invalid Function Name", uri: "pg-functions://postgres/auth/123verification_hook_reject", expectError: true},


### PR DESCRIPTION
## What kind of change does this PR introduce?
Splits out config changes from #1474 
- rename runHook to runPostgresHook
- Allow http with https hooks only on localhost