### PR TITLE
chore(docs): retify word toekn to token

### DIFF
--- a/internal/api/external_figma_test.go
+++ b/internal/api/external_figma_test.go
@@ -116,7 +116,7 @@ func (ts *ExternalTestSuite) TestSignupExternalFigma_PKCE() {
 			require.NoError(ts.T(), err)
 			require.NotEmpty(ts.T(), authCode)
 
-			// Check for valid provider access token, mock does not return refresh toekn
+			// Check for valid provider access token, mock does not return refresh token
 			user, err := models.FindUserByEmailAndAudience(ts.API.db, "figma@example.com", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 			require.NotEmpty(ts.T(), user)

--- a/internal/api/external_fly_test.go
+++ b/internal/api/external_fly_test.go
@@ -116,7 +116,7 @@ func (ts *ExternalTestSuite) TestSignupExternalFly_PKCE() {
 			require.NoError(ts.T(), err)
 			require.NotEmpty(ts.T(), authCode)
 
-			// Check for valid provider access token, mock does not return refresh toekn
+			// Check for valid provider access token, mock does not return refresh token
 			user, err := models.FindUserByEmailAndAudience(ts.API.db, "fly@example.com", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 			require.NotEmpty(ts.T(), user)

--- a/internal/api/external_github_test.go
+++ b/internal/api/external_github_test.go
@@ -123,7 +123,7 @@ func (ts *ExternalTestSuite) TestSignupExternalGitHub_PKCE() {
 			require.NoError(ts.T(), err)
 			require.NotEmpty(ts.T(), authCode)
 
-			// Check for valid provider access token, mock does not return refresh toekn
+			// Check for valid provider access token, mock does not return refresh token
 			user, err := models.FindUserByEmailAndAudience(ts.API.db, "github@example.com", ts.Config.JWT.Aud)
 			require.NoError(ts.T(), err)
 			require.NotEmpty(ts.T(), user)


### PR DESCRIPTION
- change "toekn" annotation for "token"

## What kind of change does this PR introduce?

  docs: fix annotation #1487 

## What is the current behavior?

 Word "toekn"

## What is the new behavior?

 to "token"
