### PR TITLE
fix: Resend SMS when duplicate SMS sign ups are made

### DIFF
--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -199,7 +199,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 		}
-		identity, terr := models.FindIdentityByIdAndProvider(tx, user.ID.String(), "email")
+		identity, terr := models.FindIdentityByIdAndProvider(tx, user.ID.String(), params.Provider)
 		if terr != nil {
 			if !models.IsNotFoundError(terr) {
 				return terr


### PR DESCRIPTION
## What kind of change does this PR introduce?

Resends the confirmation on duplicate Phone sign ups which haven't been confirmed.

Example scenario:

1. User Signs up with phone and password 
  a. User does not verify otp
2. User signs up with phone 
  a. Currently this returns an error instead of re-sending the SMS 