### PR TITLE
fix: refactor email sending functions

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -320,7 +320,7 @@ func (a *API) HealthCheck(w http.ResponseWriter, r *http.Request) error {
 }
 
 // Mailer returns NewMailer with the current tenant config
-func (a *API) Mailer(ctx context.Context) mailer.Mailer {
+func (a *API) Mailer() mailer.Mailer {
 	config := a.config
 	return mailer.NewMailer(config)
 }

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -384,7 +384,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 			if decision.CandidateEmail.Email != "" {
 				referrer := utilities.GetReferrer(r, config)
 				externalURL := getExternalHost(ctx)
-				if terr = a.sendConfirmation(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow); terr != nil {
+				if terr = a.sendConfirmation(tx, user, referrer, externalURL, models.ImplicitFlow); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						return nil, tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every minute")
 					}

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -382,7 +382,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 		} else {
 			emailConfirmationSent := false
 			if decision.CandidateEmail.Email != "" {
-				if terr = a.sendConfirmation(ctx, r, tx, user, models.ImplicitFlow); terr != nil {
+				if terr = a.sendConfirmation(r, tx, user, models.ImplicitFlow); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						return nil, tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every minute")
 					}

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -382,10 +382,9 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 		} else {
 			emailConfirmationSent := false
 			if decision.CandidateEmail.Email != "" {
-				mailer := a.Mailer(ctx)
 				referrer := utilities.GetReferrer(r, config)
 				externalURL := getExternalHost(ctx)
-				if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow); terr != nil {
+				if terr = a.sendConfirmation(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						return nil, tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every minute")
 					}

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -382,9 +382,7 @@ func (a *API) createAccountFromExternalIdentity(tx *storage.Connection, r *http.
 		} else {
 			emailConfirmationSent := false
 			if decision.CandidateEmail.Email != "" {
-				referrer := utilities.GetReferrer(r, config)
-				externalURL := getExternalHost(ctx)
-				if terr = a.sendConfirmation(tx, user, referrer, externalURL, models.ImplicitFlow); terr != nil {
+				if terr = a.sendConfirmation(ctx, r, tx, user, models.ImplicitFlow); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						return nil, tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every minute")
 					}

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -134,7 +134,7 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 		if !userData.Metadata.EmailVerified {
 			referrer := utilities.GetReferrer(r, a.config)
 			externalURL := getExternalHost(ctx)
-			if terr := a.sendConfirmation(tx, targetUser, a.config.SMTP.MaxFrequency, referrer, externalURL, a.config.Mailer.OtpLength, models.ImplicitFlow); terr != nil {
+			if terr := a.sendConfirmation(tx, targetUser, referrer, externalURL, models.ImplicitFlow); terr != nil {
 				if errors.Is(terr, MaxFrequencyLimitError) {
 					return nil, tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "For security purposes, you can only request this once every minute")
 				}

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -11,7 +11,6 @@ import (
 	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
-	"github.com/supabase/auth/internal/utilities"
 )
 
 func (a *API) DeleteIdentity(w http.ResponseWriter, r *http.Request) error {
@@ -132,9 +131,7 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 			return nil, terr
 		}
 		if !userData.Metadata.EmailVerified {
-			referrer := utilities.GetReferrer(r, a.config)
-			externalURL := getExternalHost(ctx)
-			if terr := a.sendConfirmation(tx, targetUser, referrer, externalURL, models.ImplicitFlow); terr != nil {
+			if terr := a.sendConfirmation(ctx, r, tx, targetUser, models.ImplicitFlow); terr != nil {
 				if errors.Is(terr, MaxFrequencyLimitError) {
 					return nil, tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "For security purposes, you can only request this once every minute")
 				}

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -132,10 +132,9 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 			return nil, terr
 		}
 		if !userData.Metadata.EmailVerified {
-			mailer := a.Mailer(ctx)
 			referrer := utilities.GetReferrer(r, a.config)
 			externalURL := getExternalHost(ctx)
-			if terr := sendConfirmation(tx, targetUser, mailer, a.config.SMTP.MaxFrequency, referrer, externalURL, a.config.Mailer.OtpLength, models.ImplicitFlow); terr != nil {
+			if terr := a.sendConfirmation(tx, targetUser, a.config.SMTP.MaxFrequency, referrer, externalURL, a.config.Mailer.OtpLength, models.ImplicitFlow); terr != nil {
 				if errors.Is(terr, MaxFrequencyLimitError) {
 					return nil, tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "For security purposes, you can only request this once every minute")
 				}

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -131,7 +131,7 @@ func (a *API) linkIdentityToUser(r *http.Request, ctx context.Context, tx *stora
 			return nil, terr
 		}
 		if !userData.Metadata.EmailVerified {
-			if terr := a.sendConfirmation(ctx, r, tx, targetUser, models.ImplicitFlow); terr != nil {
+			if terr := a.sendConfirmation(r, tx, targetUser, models.ImplicitFlow); terr != nil {
 				if errors.Is(terr, MaxFrequencyLimitError) {
 					return nil, tooManyRequestsError(ErrorCodeOverSMSSendRateLimit, "For security purposes, you can only request this once every minute")
 				}

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -83,7 +83,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 
 		referrer := utilities.GetReferrer(r, config)
 		externalURL := getExternalHost(ctx)
-		if err := a.sendInvite(tx, user, referrer, externalURL, config.Mailer.OtpLength); err != nil {
+		if err := a.sendInvite(tx, user, referrer, externalURL); err != nil {
 			return internalServerError("Error inviting user").WithInternalError(err)
 		}
 		return nil

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -81,10 +81,9 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 
-		mailer := a.Mailer(ctx)
 		referrer := utilities.GetReferrer(r, config)
 		externalURL := getExternalHost(ctx)
-		if err := sendInvite(tx, user, mailer, referrer, externalURL, config.Mailer.OtpLength); err != nil {
+		if err := a.sendInvite(tx, user, referrer, externalURL, config.Mailer.OtpLength); err != nil {
 			return internalServerError("Error inviting user").WithInternalError(err)
 		}
 		return nil

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -79,7 +79,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 
-		if err := a.sendInvite(ctx, r, tx, user); err != nil {
+		if err := a.sendInvite(r, tx, user); err != nil {
 			return internalServerError("Error inviting user").WithInternalError(err)
 		}
 		return nil

--- a/internal/api/invite.go
+++ b/internal/api/invite.go
@@ -7,7 +7,6 @@ import (
 	"github.com/supabase/auth/internal/api/provider"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
-	"github.com/supabase/auth/internal/utilities"
 )
 
 // InviteParams are the parameters the Signup endpoint accepts
@@ -20,7 +19,6 @@ type InviteParams struct {
 func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	db := a.db.WithContext(ctx)
-	config := a.config
 	adminUser := getAdminUser(ctx)
 	params := &InviteParams{}
 	if err := retrieveRequestParams(r, params); err != nil {
@@ -81,9 +79,7 @@ func (a *API) Invite(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 
-		referrer := utilities.GetReferrer(r, config)
-		externalURL := getExternalHost(ctx)
-		if err := a.sendInvite(tx, user, referrer, externalURL); err != nil {
+		if err := a.sendInvite(ctx, r, tx, user); err != nil {
 			return internalServerError("Error inviting user").WithInternalError(err)
 		}
 		return nil

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -141,7 +141,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		}
 		referrer := utilities.GetReferrer(r, config)
 		externalURL := getExternalHost(ctx)
-		return a.sendMagicLink(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType)
+		return a.sendMagicLink(tx, user, referrer, externalURL, flowType)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -139,10 +139,9 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 			return terr
 		}
-		mailer := a.Mailer(ctx)
 		referrer := utilities.GetReferrer(r, config)
 		externalURL := getExternalHost(ctx)
-		return a.sendMagicLink(tx, user, mailer, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType)
+		return a.sendMagicLink(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -138,7 +138,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 			return terr
 		}
-		return a.sendMagicLink(ctx, r, tx, user, flowType)
+		return a.sendMagicLink(r, tx, user, flowType)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/internal/api/magic_link.go
+++ b/internal/api/magic_link.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sethvargo/go-password/password"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
-	"github.com/supabase/auth/internal/utilities"
 )
 
 // MagicLinkParams holds the parameters for a magic link request
@@ -139,9 +138,7 @@ func (a *API) MagicLink(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 			return terr
 		}
-		referrer := utilities.GetReferrer(r, config)
-		externalURL := getExternalHost(ctx)
-		return a.sendMagicLink(tx, user, referrer, externalURL, flowType)
+		return a.sendMagicLink(ctx, r, tx, user, flowType)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -492,7 +492,7 @@ func validateEmail(email string) (string, error) {
 }
 
 func validateSentWithinFrequencyLimit(sentAt *time.Time, frequency time.Duration) error {
-	if sentAt != nil && !sentAt.Add(frequency).Before(time.Now()) {
+	if sentAt != nil && sentAt.Add(frequency).After(time.Now()) {
 		return MaxFrequencyLimitError
 	}
 	return nil

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -281,7 +281,7 @@ func (a *API) sendConfirmation(ctx context.Context, r *http.Request, tx *storage
 	token := crypto.GenerateTokenHash(u.GetEmail(), otp)
 	u.ConfirmationToken = addFlowPrefixToToken(token, flowType)
 	now := time.Now()
-	if err := mailer.ConfirmationMail(u, otp, referrerURL, externalURL); err != nil {
+	if err := mailer.ConfirmationMail(ctx, r, u, otp, referrerURL, externalURL); err != nil {
 		u.ConfirmationToken = oldToken
 		return errors.Wrap(err, "Error sending confirmation email")
 	}
@@ -309,7 +309,7 @@ func (a *API) sendInvite(ctx context.Context, r *http.Request, tx *storage.Conne
 	}
 	u.ConfirmationToken = crypto.GenerateTokenHash(u.GetEmail(), otp)
 	now := time.Now()
-	if err := mailer.InviteMail(u, otp, referrerURL, externalURL); err != nil {
+	if err := mailer.InviteMail(ctx, r, u, otp, referrerURL, externalURL); err != nil {
 		u.ConfirmationToken = oldToken
 		return errors.Wrap(err, "Error sending invite email")
 	}
@@ -344,7 +344,7 @@ func (a *API) sendPasswordRecovery(ctx context.Context, r *http.Request, tx *sto
 	token := crypto.GenerateTokenHash(u.GetEmail(), otp)
 	u.RecoveryToken = addFlowPrefixToToken(token, flowType)
 	now := time.Now()
-	if err := mailer.RecoveryMail(u, otp, referrerURL, externalURL); err != nil {
+	if err := mailer.RecoveryMail(ctx, r, u, otp, referrerURL, externalURL); err != nil {
 		u.RecoveryToken = oldToken
 		return errors.Wrap(err, "Error sending recovery email")
 	}
@@ -357,7 +357,7 @@ func (a *API) sendPasswordRecovery(ctx context.Context, r *http.Request, tx *sto
 	return nil
 }
 
-func (a *API) sendReauthenticationOtp(tx *storage.Connection, u *models.User) error {
+func (a *API) sendReauthenticationOtp(ctx context.Context, r *http.Request, tx *storage.Connection, u *models.User) error {
 	config := a.config
 	maxFrequency := config.SMTP.MaxFrequency
 	otpLength := config.Mailer.OtpLength
@@ -376,7 +376,7 @@ func (a *API) sendReauthenticationOtp(tx *storage.Connection, u *models.User) er
 	}
 	u.ReauthenticationToken = crypto.GenerateTokenHash(u.GetEmail(), otp)
 	now := time.Now()
-	if err := mailer.ReauthenticateMail(u, otp); err != nil {
+	if err := mailer.ReauthenticateMail(ctx, r, u, otp); err != nil {
 		u.ReauthenticationToken = oldToken
 		return errors.Wrap(err, "Error sending reauthentication email")
 	}
@@ -413,7 +413,7 @@ func (a *API) sendMagicLink(ctx context.Context, r *http.Request, tx *storage.Co
 	u.RecoveryToken = addFlowPrefixToToken(token, flowType)
 
 	now := time.Now()
-	if err := mailer.MagicLinkMail(u, otp, referrerURL, externalURL); err != nil {
+	if err := mailer.MagicLinkMail(ctx, r, u, otp, referrerURL, externalURL); err != nil {
 		u.RecoveryToken = oldToken
 		return errors.Wrap(err, "Error sending magic link email")
 	}
@@ -460,7 +460,7 @@ func (a *API) sendEmailChange(ctx context.Context, r *http.Request, tx *storage.
 
 	u.EmailChangeConfirmStatus = zeroConfirmation
 	now := time.Now()
-	if err := mailer.EmailChangeMail(u, otpNew, otpCurrent, referrerURL, externalURL); err != nil {
+	if err := mailer.EmailChangeMail(ctx, r, u, otpNew, otpCurrent, referrerURL, externalURL); err != nil {
 		return err
 	}
 

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -42,7 +42,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 		if email != "" {
-			return a.sendReauthenticationOtp(tx, user)
+			return a.sendReauthenticationOtp(ctx, r, tx, user)
 		} else if phone != "" {
 			smsProvider, terr := sms_provider.GetSmsProvider(*config)
 			if terr != nil {

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -42,8 +42,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 		if email != "" {
-			mailer := a.Mailer(ctx)
-			return a.sendReauthenticationOtp(tx, user, mailer, config.SMTP.MaxFrequency, config.Mailer.OtpLength)
+			return a.sendReauthenticationOtp(tx, user, config.SMTP.MaxFrequency, config.Mailer.OtpLength)
 		} else if phone != "" {
 			smsProvider, terr := sms_provider.GetSmsProvider(*config)
 			if terr != nil {

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -42,7 +42,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 		if email != "" {
-			return a.sendReauthenticationOtp(ctx, r, tx, user)
+			return a.sendReauthenticationOtp(r, tx, user)
 		} else if phone != "" {
 			smsProvider, terr := sms_provider.GetSmsProvider(*config)
 			if terr != nil {

--- a/internal/api/reauthenticate.go
+++ b/internal/api/reauthenticate.go
@@ -42,7 +42,7 @@ func (a *API) Reauthenticate(w http.ResponseWriter, r *http.Request) error {
 			return terr
 		}
 		if email != "" {
-			return a.sendReauthenticationOtp(tx, user, config.SMTP.MaxFrequency, config.Mailer.OtpLength)
+			return a.sendReauthenticationOtp(tx, user)
 		} else if phone != "" {
 			smsProvider, terr := sms_provider.GetSmsProvider(*config)
 			if terr != nil {

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
-	"github.com/supabase/auth/internal/utilities"
 )
 
 // RecoverParams holds the parameters for a password recovery request
@@ -34,7 +33,6 @@ func (p *RecoverParams) Validate() error {
 func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	db := a.db.WithContext(ctx)
-	config := a.config
 	params := &RecoverParams{}
 	if err := retrieveRequestParams(r, params); err != nil {
 		return err
@@ -66,9 +64,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 			return terr
 		}
-		referrer := utilities.GetReferrer(r, config)
-		externalURL := getExternalHost(ctx)
-		return a.sendPasswordRecovery(tx, user, referrer, externalURL, flowType)
+		return a.sendPasswordRecovery(ctx, r, tx, user, flowType)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -66,10 +66,9 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 			return terr
 		}
-		mailer := a.Mailer(ctx)
 		referrer := utilities.GetReferrer(r, config)
 		externalURL := getExternalHost(ctx)
-		return a.sendPasswordRecovery(tx, user, mailer, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType)
+		return a.sendPasswordRecovery(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -68,7 +68,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		}
 		referrer := utilities.GetReferrer(r, config)
 		externalURL := getExternalHost(ctx)
-		return a.sendPasswordRecovery(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType)
+		return a.sendPasswordRecovery(tx, user, referrer, externalURL, flowType)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/internal/api/recover.go
+++ b/internal/api/recover.go
@@ -64,7 +64,7 @@ func (a *API) Recover(w http.ResponseWriter, r *http.Request) error {
 		if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 			return terr
 		}
-		return a.sendPasswordRecovery(ctx, r, tx, user, flowType)
+		return a.sendPasswordRecovery(r, tx, user, flowType)
 	})
 	if err != nil {
 		if errors.Is(err, MaxFrequencyLimitError) {

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -124,7 +124,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 			// PKCE not implemented yet
-			return a.sendConfirmation(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow)
+			return a.sendConfirmation(tx, user, referrer, externalURL, models.ImplicitFlow)
 		case smsVerification:
 			if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 				return terr
@@ -139,7 +139,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			}
 			messageID = mID
 		case emailChangeVerification:
-			return a.sendEmailChange(tx, config, user, user.EmailChange, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow)
+			return a.sendEmailChange(tx, user, user.EmailChange, referrer, externalURL, models.ImplicitFlow)
 		case phoneChangeVerification:
 			smsProvider, terr := sms_provider.GetSmsProvider(*config)
 			if terr != nil {

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -115,7 +115,6 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	messageID := ""
-	mailer := a.Mailer(ctx)
 	referrer := utilities.GetReferrer(r, config)
 	externalURL := getExternalHost(ctx)
 	err = db.Transaction(func(tx *storage.Connection) error {
@@ -125,7 +124,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 			// PKCE not implemented yet
-			return sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow)
+			return a.sendConfirmation(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow)
 		case smsVerification:
 			if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 				return terr
@@ -140,7 +139,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			}
 			messageID = mID
 		case emailChangeVerification:
-			return a.sendEmailChange(tx, config, user, mailer, user.EmailChange, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow)
+			return a.sendEmailChange(tx, config, user, user.EmailChange, referrer, externalURL, config.Mailer.OtpLength, models.ImplicitFlow)
 		case phoneChangeVerification:
 			smsProvider, terr := sms_provider.GetSmsProvider(*config)
 			if terr != nil {

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -121,7 +121,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 			// PKCE not implemented yet
-			return a.sendConfirmation(ctx, r, tx, user, models.ImplicitFlow)
+			return a.sendConfirmation(r, tx, user, models.ImplicitFlow)
 		case smsVerification:
 			if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 				return terr
@@ -136,7 +136,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			}
 			messageID = mID
 		case emailChangeVerification:
-			return a.sendEmailChange(ctx, r, tx, user, user.EmailChange, models.ImplicitFlow)
+			return a.sendEmailChange(r, tx, user, user.EmailChange, models.ImplicitFlow)
 		case phoneChangeVerification:
 			smsProvider, terr := sms_provider.GetSmsProvider(*config)
 			if terr != nil {

--- a/internal/api/resend.go
+++ b/internal/api/resend.go
@@ -9,7 +9,6 @@ import (
 	"github.com/supabase/auth/internal/conf"
 	"github.com/supabase/auth/internal/models"
 	"github.com/supabase/auth/internal/storage"
-	"github.com/supabase/auth/internal/utilities"
 )
 
 // ResendConfirmationParams holds the parameters for a resend request
@@ -115,8 +114,6 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	messageID := ""
-	referrer := utilities.GetReferrer(r, config)
-	externalURL := getExternalHost(ctx)
 	err = db.Transaction(func(tx *storage.Connection) error {
 		switch params.Type {
 		case signupVerification:
@@ -124,7 +121,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 				return terr
 			}
 			// PKCE not implemented yet
-			return a.sendConfirmation(tx, user, referrer, externalURL, models.ImplicitFlow)
+			return a.sendConfirmation(ctx, r, tx, user, models.ImplicitFlow)
 		case smsVerification:
 			if terr := models.NewAuditLogEntry(r, tx, user, models.UserRecoveryRequestedAction, "", nil); terr != nil {
 				return terr
@@ -139,7 +136,7 @@ func (a *API) Resend(w http.ResponseWriter, r *http.Request) error {
 			}
 			messageID = mID
 		case emailChangeVerification:
-			return a.sendEmailChange(tx, user, user.EmailChange, referrer, externalURL, models.ImplicitFlow)
+			return a.sendEmailChange(ctx, r, tx, user, user.EmailChange, models.ImplicitFlow)
 		case phoneChangeVerification:
 			smsProvider, terr := sms_provider.GetSmsProvider(*config)
 			if terr != nil {

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -234,7 +234,6 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					return internalServerError("Database error updating user").WithInternalError(terr)
 				}
 			} else {
-				mailer := a.Mailer(ctx)
 				referrer := utilities.GetReferrer(r, config)
 				if terr = models.NewAuditLogEntry(r, tx, user, models.UserConfirmationRequestedAction, "", map[string]interface{}{
 					"provider": params.Provider,
@@ -248,7 +247,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					}
 				}
 				externalURL := getExternalHost(ctx)
-				if terr = sendConfirmation(tx, user, mailer, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType); terr != nil {
+				if terr = a.sendConfirmation(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						now := time.Now()
 						left := user.ConfirmationSentAt.Add(config.SMTP.MaxFrequency).Sub(now) / time.Second

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -244,7 +244,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 						return terr
 					}
 				}
-				if terr = a.sendConfirmation(ctx, r, tx, user, flowType); terr != nil {
+				if terr = a.sendConfirmation(r, tx, user, flowType); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						now := time.Now()
 						left := user.ConfirmationSentAt.Add(config.SMTP.MaxFrequency).Sub(now) / time.Second

--- a/internal/api/signup.go
+++ b/internal/api/signup.go
@@ -247,7 +247,7 @@ func (a *API) Signup(w http.ResponseWriter, r *http.Request) error {
 					}
 				}
 				externalURL := getExternalHost(ctx)
-				if terr = a.sendConfirmation(tx, user, config.SMTP.MaxFrequency, referrer, externalURL, config.Mailer.OtpLength, flowType); terr != nil {
+				if terr = a.sendConfirmation(tx, user, referrer, externalURL, flowType); terr != nil {
 					if errors.Is(terr, MaxFrequencyLimitError) {
 						now := time.Now()
 						left := user.ConfirmationSentAt.Add(config.SMTP.MaxFrequency).Sub(now) / time.Second

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -201,7 +201,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 				}
 
 			}
-			if terr = a.sendEmailChange(ctx, r, tx, user, params.Email, flowType); terr != nil {
+			if terr = a.sendEmailChange(r, tx, user, params.Email, flowType); terr != nil {
 				if errors.Is(terr, MaxFrequencyLimitError) {
 					return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every 60 seconds")
 				}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -194,7 +194,6 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if params.Email != "" && params.Email != user.GetEmail() {
-			mailer := a.Mailer(ctx)
 			referrer := utilities.GetReferrer(r, config)
 			flowType := getFlowFromChallenge(params.CodeChallenge)
 			if isPKCEFlow(flowType) {
@@ -205,7 +204,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 			}
 			externalURL := getExternalHost(ctx)
-			if terr = a.sendEmailChange(tx, config, user, mailer, params.Email, referrer, externalURL, config.Mailer.OtpLength, flowType); terr != nil {
+			if terr = a.sendEmailChange(tx, config, user, params.Email, referrer, externalURL, config.Mailer.OtpLength, flowType); terr != nil {
 				if errors.Is(terr, MaxFrequencyLimitError) {
 					return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every 60 seconds")
 				}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -204,7 +204,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 
 			}
 			externalURL := getExternalHost(ctx)
-			if terr = a.sendEmailChange(tx, config, user, params.Email, referrer, externalURL, config.Mailer.OtpLength, flowType); terr != nil {
+			if terr = a.sendEmailChange(tx, user, params.Email, referrer, externalURL, flowType); terr != nil {
 				if errors.Is(terr, MaxFrequencyLimitError) {
 					return tooManyRequestsError(ErrorCodeOverEmailSendRateLimit, "For security purposes, you can only request this once every 60 seconds")
 				}

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -1,7 +1,6 @@
 package mailer
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -17,12 +16,12 @@ import (
 // Mailer defines the interface a mailer must implement.
 type Mailer interface {
 	Send(user *models.User, subject, body string, data map[string]interface{}) error
-	InviteMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
-	ConfirmationMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
-	RecoveryMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
-	MagicLinkMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
-	EmailChangeMail(ctx context.Context, r *http.Request, user *models.User, otpNew, otpCurrent, referrerURL string, externalURL *url.URL) error
-	ReauthenticateMail(ctx context.Context, r *http.Request, user *models.User, otp string) error
+	InviteMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
+	ConfirmationMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
+	RecoveryMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
+	MagicLinkMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
+	EmailChangeMail(r *http.Request, user *models.User, otpNew, otpCurrent, referrerURL string, externalURL *url.URL) error
+	ReauthenticateMail(r *http.Request, user *models.User, otp string) error
 	ValidateEmail(email string) error
 	GetEmailActionLink(user *models.User, actionType, referrerURL string, externalURL *url.URL) (string, error)
 }

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -1,7 +1,9 @@
 package mailer
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/gofrs/uuid"
@@ -15,12 +17,12 @@ import (
 // Mailer defines the interface a mailer must implement.
 type Mailer interface {
 	Send(user *models.User, subject, body string, data map[string]interface{}) error
-	InviteMail(user *models.User, otp, referrerURL string, externalURL *url.URL) error
-	ConfirmationMail(user *models.User, otp, referrerURL string, externalURL *url.URL) error
-	RecoveryMail(user *models.User, otp, referrerURL string, externalURL *url.URL) error
-	MagicLinkMail(user *models.User, otp, referrerURL string, externalURL *url.URL) error
-	EmailChangeMail(user *models.User, otpNew, otpCurrent, referrerURL string, externalURL *url.URL) error
-	ReauthenticateMail(user *models.User, otp string) error
+	InviteMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
+	ConfirmationMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
+	RecoveryMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
+	MagicLinkMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error
+	EmailChangeMail(ctx context.Context, r *http.Request, user *models.User, otpNew, otpCurrent, referrerURL string, externalURL *url.URL) error
+	ReauthenticateMail(ctx context.Context, r *http.Request, user *models.User, otp string) error
 	ValidateEmail(email string) error
 	GetEmailActionLink(user *models.User, actionType, referrerURL string, externalURL *url.URL) (string, error)
 }

--- a/internal/mailer/template.go
+++ b/internal/mailer/template.go
@@ -1,7 +1,9 @@
 package mailer
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -75,7 +77,7 @@ func (m TemplateMailer) ValidateEmail(email string) error {
 }
 
 // InviteMail sends a invite mail to a new user
-func (m *TemplateMailer) InviteMail(user *models.User, otp, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) InviteMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
 	path, err := getPath(m.Config.Mailer.URLPaths.Invite, &EmailParams{
 		Token:      user.ConfirmationToken,
 		Type:       "invite",
@@ -106,7 +108,7 @@ func (m *TemplateMailer) InviteMail(user *models.User, otp, referrerURL string, 
 }
 
 // ConfirmationMail sends a signup confirmation mail to a new user
-func (m *TemplateMailer) ConfirmationMail(user *models.User, otp, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) ConfirmationMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
 	path, err := getPath(m.Config.Mailer.URLPaths.Confirmation, &EmailParams{
 		Token:      user.ConfirmationToken,
 		Type:       "signup",
@@ -136,7 +138,7 @@ func (m *TemplateMailer) ConfirmationMail(user *models.User, otp, referrerURL st
 }
 
 // ReauthenticateMail sends a reauthentication mail to an authenticated user
-func (m *TemplateMailer) ReauthenticateMail(user *models.User, otp string) error {
+func (m *TemplateMailer) ReauthenticateMail(ctx context.Context, r *http.Request, user *models.User, otp string) error {
 	data := map[string]interface{}{
 		"SiteURL": m.Config.SiteURL,
 		"Email":   user.Email,
@@ -154,7 +156,7 @@ func (m *TemplateMailer) ReauthenticateMail(user *models.User, otp string) error
 }
 
 // EmailChangeMail sends an email change confirmation mail to a user
-func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) EmailChangeMail(ctx context.Context, r *http.Request, user *models.User, otpNew, otpCurrent, referrerURL string, externalURL *url.URL) error {
 	type Email struct {
 		Address   string
 		Otp       string
@@ -229,7 +231,7 @@ func (m *TemplateMailer) EmailChangeMail(user *models.User, otpNew, otpCurrent, 
 }
 
 // RecoveryMail sends a password recovery mail
-func (m *TemplateMailer) RecoveryMail(user *models.User, otp, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) RecoveryMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
 	path, err := getPath(m.Config.Mailer.URLPaths.Recovery, &EmailParams{
 		Token:      user.RecoveryToken,
 		Type:       "recovery",
@@ -258,7 +260,7 @@ func (m *TemplateMailer) RecoveryMail(user *models.User, otp, referrerURL string
 }
 
 // MagicLinkMail sends a login link mail
-func (m *TemplateMailer) MagicLinkMail(user *models.User, otp, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) MagicLinkMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
 	path, err := getPath(m.Config.Mailer.URLPaths.Recovery, &EmailParams{
 		Token:      user.RecoveryToken,
 		Type:       "magiclink",

--- a/internal/mailer/template.go
+++ b/internal/mailer/template.go
@@ -1,7 +1,6 @@
 package mailer
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -77,7 +76,7 @@ func (m TemplateMailer) ValidateEmail(email string) error {
 }
 
 // InviteMail sends a invite mail to a new user
-func (m *TemplateMailer) InviteMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) InviteMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
 	path, err := getPath(m.Config.Mailer.URLPaths.Invite, &EmailParams{
 		Token:      user.ConfirmationToken,
 		Type:       "invite",
@@ -108,7 +107,7 @@ func (m *TemplateMailer) InviteMail(ctx context.Context, r *http.Request, user *
 }
 
 // ConfirmationMail sends a signup confirmation mail to a new user
-func (m *TemplateMailer) ConfirmationMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) ConfirmationMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
 	path, err := getPath(m.Config.Mailer.URLPaths.Confirmation, &EmailParams{
 		Token:      user.ConfirmationToken,
 		Type:       "signup",
@@ -138,7 +137,7 @@ func (m *TemplateMailer) ConfirmationMail(ctx context.Context, r *http.Request, 
 }
 
 // ReauthenticateMail sends a reauthentication mail to an authenticated user
-func (m *TemplateMailer) ReauthenticateMail(ctx context.Context, r *http.Request, user *models.User, otp string) error {
+func (m *TemplateMailer) ReauthenticateMail(r *http.Request, user *models.User, otp string) error {
 	data := map[string]interface{}{
 		"SiteURL": m.Config.SiteURL,
 		"Email":   user.Email,
@@ -156,7 +155,7 @@ func (m *TemplateMailer) ReauthenticateMail(ctx context.Context, r *http.Request
 }
 
 // EmailChangeMail sends an email change confirmation mail to a user
-func (m *TemplateMailer) EmailChangeMail(ctx context.Context, r *http.Request, user *models.User, otpNew, otpCurrent, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) EmailChangeMail(r *http.Request, user *models.User, otpNew, otpCurrent, referrerURL string, externalURL *url.URL) error {
 	type Email struct {
 		Address   string
 		Otp       string
@@ -231,7 +230,7 @@ func (m *TemplateMailer) EmailChangeMail(ctx context.Context, r *http.Request, u
 }
 
 // RecoveryMail sends a password recovery mail
-func (m *TemplateMailer) RecoveryMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) RecoveryMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
 	path, err := getPath(m.Config.Mailer.URLPaths.Recovery, &EmailParams{
 		Token:      user.RecoveryToken,
 		Type:       "recovery",
@@ -260,7 +259,7 @@ func (m *TemplateMailer) RecoveryMail(ctx context.Context, r *http.Request, user
 }
 
 // MagicLinkMail sends a login link mail
-func (m *TemplateMailer) MagicLinkMail(ctx context.Context, r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
+func (m *TemplateMailer) MagicLinkMail(r *http.Request, user *models.User, otp, referrerURL string, externalURL *url.URL) error {
 	path, err := getPath(m.Config.Mailer.URLPaths.Recovery, &EmailParams{
 		Token:      user.RecoveryToken,
 		Type:       "magiclink",


### PR DESCRIPTION
## What kind of change does this PR introduce?

The overall goal of this to expose a unified interface for emails. So that we can potentially implement the Hook as a Custom Mailer. This is to ensure that the impact on the existing code flow is minimal and that we can turn off the Hook easily if needed.  

After this change, we can do something similar to:

```
mailer. := a.Mailer()
if a.config.Hook.Enabled {
    mailer =   a.CustomMailer
} 
```

 and have all Hook logic live  in the custom Mailer



Specific changes are:

- Removes context from mailer as it is currently unused
- pushes down mailer into respective email sending methods
- Adds remaining send methods as API methods
- Fetch OTP Length and MaxFrequency from config
- Add convenience function for checking if an email was sent within frequency limit
- push down `externalURL` and `referrer` into send function

